### PR TITLE
fix: build job needs contents:read for checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,8 @@ jobs:
 
   build:
     name: Build (${{ matrix.suffix }})
-    permissions: {}
+    permissions:
+      contents: read
     needs: release
     if: needs.release.outputs.new_release_published == 'true'
     strategy:


### PR DESCRIPTION
## Summary
- Build job had `permissions: {}` which prevented `actions/checkout` from reading the repo
- Grant `contents: read` so it can checkout the tag ref

Also deleted the dangling `v1.1.0` tag — merging this will trigger a fresh release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)