### PR TITLE
fix: install script JSON parsing for tag_name

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,7 +43,7 @@ if [ -n "${VELD_VERSION:-}" ]; then
   TAG="v${VERSION}"
 else
   echo "Fetching latest release..."
-  TAG="$(curl -fsSL -H "Accept: application/json" "https://api.github.com/repos/${REPO}/releases/latest" | grep -o '"tag_name":"[^"]*"' | cut -d'"' -f4)"
+  TAG="$(curl -fsSL -H "Accept: application/json" "https://api.github.com/repos/${REPO}/releases/latest" | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)"
   VERSION="${TAG#v}"
 fi
 


### PR DESCRIPTION
## Summary
- The GitHub API returns `"tag_name": "v1.1.0"` with spaces around the colon
- The grep pattern expected no spaces, causing the install script to fail at version detection
- Fixed grep pattern to handle optional spaces: `"tag_name": *"[^"]*"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)