### PR TITLE
feat: auto-escalate to sudo in veld setup/uninstall

### DIFF
--- a/crates/veld/src/commands/setup.rs
+++ b/crates/veld/src/commands/setup.rs
@@ -2,6 +2,34 @@ use crate::output;
 
 /// `veld setup` -- run the first-time setup sequence.
 pub async fn run() -> i32 {
+    // Setup requires root for writing LaunchDaemons, binding /var/run socket,
+    // etc. If we're not root, re-exec with sudo so the user gets a password
+    // prompt automatically.
+    if !is_root_user() {
+        eprintln!(
+            "{} Setup requires administrator privileges.",
+            output::bold("Note:")
+        );
+        let exe = match std::env::current_exe() {
+            Ok(e) => e,
+            Err(e) => {
+                eprintln!("Cannot determine executable path: {e}");
+                return 1;
+            }
+        };
+        let status = std::process::Command::new("sudo")
+            .arg(&exe)
+            .arg("setup")
+            .status();
+        return match status {
+            Ok(s) => s.code().unwrap_or(1),
+            Err(e) => {
+                eprintln!("Failed to run sudo: {e}");
+                1
+            }
+        };
+    }
+
     println!("{}", output::bold("Veld Setup"));
     println!();
 
@@ -74,4 +102,17 @@ fn print_step_ok(detail: &str) {
 
 fn print_step_fail(detail: &str) {
     eprintln!(" {} {}", output::cross(), output::red(detail));
+}
+
+/// Check if the current process is running as root.
+pub fn is_root_user() -> bool {
+    std::env::var("EUID")
+        .or_else(|_| {
+            std::process::Command::new("id")
+                .arg("-u")
+                .output()
+                .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        })
+        .map(|id| id == "0")
+        .unwrap_or(false)
 }

--- a/crates/veld/src/commands/uninstall.rs
+++ b/crates/veld/src/commands/uninstall.rs
@@ -3,6 +3,32 @@ use std::io::{self, BufRead, Write};
 
 /// `veld uninstall` -- remove Veld and clean up.
 pub async fn run() -> i32 {
+    // Uninstall needs root for removing LaunchDaemons, system files, etc.
+    if !super::setup::is_root_user() {
+        eprintln!(
+            "{} Uninstall requires administrator privileges.",
+            output::bold("Note:")
+        );
+        let exe = match std::env::current_exe() {
+            Ok(e) => e,
+            Err(e) => {
+                eprintln!("Cannot determine executable path: {e}");
+                return 1;
+            }
+        };
+        let status = std::process::Command::new("sudo")
+            .arg(&exe)
+            .arg("uninstall")
+            .status();
+        return match status {
+            Ok(s) => s.code().unwrap_or(1),
+            Err(e) => {
+                eprintln!("Failed to run sudo: {e}");
+                1
+            }
+        };
+    }
+
     if output::is_tty() {
         eprintln!(
             "{} This will remove Veld, its daemons, certificates and cached state.",

--- a/install.sh
+++ b/install.sh
@@ -157,6 +157,7 @@ if [ "$OS" = "macos" ]; then
 fi
 
 # --- Auto-run veld setup in interactive mode ---
+# veld setup self-escalates to sudo when needed, so no need to wrap in sudo here.
 
 if [ -t 1 ]; then
   echo ""


### PR DESCRIPTION
## Summary
- `veld setup` and `veld uninstall` now detect when they're not running as root and automatically re-exec with `sudo`, prompting the user for their password
- No more confusing "socket not reachable" errors when forgetting `sudo`
- Install script benefits automatically since `veld setup` handles its own privilege escalation

## Test plan
- [ ] Run `veld setup` without sudo — should prompt for password, then succeed
- [ ] Run `sudo veld setup` — should work as before (no double sudo)
- [ ] CI integration tests pass (already run as root, so re-exec is skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)