### PR TITLE
fix: helper socket permissions for non-root CLI access

### DIFF
--- a/crates/veld-helper/src/main.rs
+++ b/crates/veld-helper/src/main.rs
@@ -71,6 +71,20 @@ async fn main() -> Result<()> {
     let listener = UnixListener::bind(&socket_path)
         .with_context(|| format!("failed to bind socket at {}", socket_path.display()))?;
 
+    // Allow non-root users to connect to the socket. The helper runs as root
+    // but the CLI and daemon run as the regular user.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o777))
+            .with_context(|| {
+                format!(
+                    "failed to set socket permissions on {}",
+                    socket_path.display()
+                )
+            })?;
+    }
+
     info!(
         "veld-helper {VERSION} listening on {}",
         socket_path.display()


### PR DESCRIPTION
## Summary
- The helper daemon runs as root and binds `/var/run/veld-helper.sock`
- Default socket permissions are `root:daemon rwxr-xr-x` (755)
- Unix socket `connect()` requires **write** permission, so non-root users get "Permission denied"
- This causes `check_setup()` to report `veld-helper` as missing, making all commands fail with "setup not done"
- Fix: `chmod 0777` on the socket after binding

## Test plan
- [ ] Run `veld setup` (restarts helper with new binary)
- [ ] Run `veld status` as regular user — should no longer say setup required
- [ ] CI integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)