### PR TITLE
fix: server processes die when CLI exits (502 errors)

### DIFF
--- a/crates/veld-core/src/orchestrator.rs
+++ b/crates/veld-core/src/orchestrator.rs
@@ -388,35 +388,14 @@ impl Orchestrator {
             }
         }
 
-        // Start the process.
+        // Start the process. stdout/stderr are redirected to the log file at
+        // the OS level so the process survives after the CLI exits.
         let log_path = logging::log_file(&self.project_root, &run.name, &sel.node, &sel.variant);
-        let log_writer = LogWriter::new(log_path).await?;
 
-        let mut child = process::start_server(&resolved_cmd, &self.project_root, &env).await?;
+        let child =
+            process::start_server(&resolved_cmd, &self.project_root, &env, &log_path).await?;
         let pid = child.id().unwrap_or(0);
         node_state.pid = Some(pid);
-
-        // Pipe child stdout/stderr to the log file in background tasks.
-        if let Some(stdout) = child.stdout.take() {
-            let writer = log_writer.clone();
-            tokio::spawn(async move {
-                use tokio::io::{AsyncBufReadExt, BufReader};
-                let mut lines = BufReader::new(stdout).lines();
-                while let Ok(Some(line)) = lines.next_line().await {
-                    let _ = writer.write_line(&line).await;
-                }
-            });
-        }
-        if let Some(stderr) = child.stderr.take() {
-            let writer = log_writer.clone();
-            tokio::spawn(async move {
-                use tokio::io::{AsyncBufReadExt, BufReader};
-                let mut lines = BufReader::new(stderr).lines();
-                while let Ok(Some(line)) = lines.next_line().await {
-                    let _ = writer.write_line(&format!("[stderr] {line}")).await;
-                }
-            });
-        }
 
         self.children
             .insert(RunState::node_key(&sel.node, &sel.variant), child);

--- a/crates/veld-core/src/process.rs
+++ b/crates/veld-core/src/process.rs
@@ -42,19 +42,35 @@ pub struct BashOutput {
 
 /// Spawn a long-running server process. Returns the `Child` handle.
 ///
+/// stdout and stderr are redirected to the provided log file so that
+/// the process survives after the CLI exits (no broken-pipe SIGPIPE).
 /// The caller is responsible for monitoring and killing.
 pub async fn start_server(
     command: &str,
     working_dir: &Path,
     env: &HashMap<String, String>,
+    log_file: &Path,
 ) -> Result<Child, ProcessError> {
+    // Ensure log directory exists.
+    if let Some(parent) = log_file.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_file)
+        .map_err(ProcessError::SpawnFailed)?;
+    let stderr_file = file.try_clone().map_err(ProcessError::SpawnFailed)?;
+
     let child = Command::new("sh")
         .arg("-c")
         .arg(command)
         .current_dir(working_dir)
         .envs(env)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(file))
+        .stderr(Stdio::from(stderr_file))
         .kill_on_drop(false) // We manage lifecycle explicitly.
         .spawn()
         .map_err(ProcessError::SpawnFailed)?;


### PR DESCRIPTION
## Summary
- Server processes were spawned with piped stdout/stderr
- When `veld start` exited, the pipe fds closed, causing SIGPIPE on the next write
- Processes died immediately after CLI exit, resulting in Caddy returning 502
- Fix: redirect stdout/stderr to the log file at the OS level (`Stdio::from(File)`)
- Processes now survive independently of the CLI lifecycle

## Root cause
`tokio::process::Command` with `Stdio::piped()` creates OS pipes owned by the parent. Even with `kill_on_drop(false)`, when the parent exits and the pipe fds close, any write by the child triggers SIGPIPE → process death.

## Test plan
- [ ] `veld start` then wait 10 seconds, `curl` the URLs → should work
- [ ] `veld logs` still shows output (now raw, without timestamps)
- [ ] CI integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)