### PR TITLE
fix: restart helper and daemon services on update

### DIFF
--- a/crates/veld-core/src/setup.rs
+++ b/crates/veld-core/src/setup.rs
@@ -369,6 +369,16 @@ pub async fn install_daemon() -> Result<StepResult, anyhow::Error> {
 "#,
                 veld_daemon_bin.display()
             );
+            // Unload first if already loaded (required for upgrades).
+            if plist_path.exists() {
+                let _ = Command::new("launchctl")
+                    .args(["unload", "-w"])
+                    .arg(&plist_path)
+                    .stdin(std::process::Stdio::null())
+                    .status()
+                    .await;
+            }
+
             std::fs::write(&plist_path, plist)
                 .context("failed to write daemon LaunchAgent plist")?;
 
@@ -402,6 +412,8 @@ pub async fn install_daemon() -> Result<StepResult, anyhow::Error> {
             std::fs::write(&unit_path, unit).context("failed to write daemon systemd unit")?;
 
             run_cmd("systemctl", &["--user", "daemon-reload"]).await?;
+            // restart to pick up new binary on upgrades.
+            let _ = run_cmd("systemctl", &["--user", "restart", "veld-daemon"]).await;
             run_cmd("systemctl", &["--user", "enable", "--now", "veld-daemon"]).await?;
         }
         other => anyhow::bail!("unsupported OS: {other}"),
@@ -502,6 +514,18 @@ async fn install_helper_macos(bin: &Path) -> Result<(), anyhow::Error> {
 "#,
         bin.display()
     );
+
+    // Unload first if already loaded (required for upgrades — `load` on an
+    // already-loaded plist is a no-op, so the old binary keeps running).
+    if plist_path.exists() {
+        let _ = Command::new("launchctl")
+            .args(["unload", "-w"])
+            .arg(plist_path)
+            .stdin(std::process::Stdio::null())
+            .status()
+            .await;
+    }
+
     std::fs::write(plist_path, plist).context("failed to write helper LaunchDaemon plist")?;
 
     let result = tokio::time::timeout(
@@ -534,6 +558,8 @@ async fn install_helper_linux(bin: &Path) -> Result<(), anyhow::Error> {
     std::fs::write(unit_path, unit).context("failed to write helper systemd unit")?;
 
     run_cmd("systemctl", &["daemon-reload"]).await?;
+    // restart (not just enable) to pick up new binary on upgrades.
+    let _ = run_cmd("systemctl", &["restart", "veld-helper"]).await;
     run_cmd("systemctl", &["enable", "--now", "veld-helper"]).await?;
     Ok(())
 }

--- a/install.sh
+++ b/install.sh
@@ -173,6 +173,34 @@ for bin in veld-helper veld-daemon; do
   fi
 done
 
+# --- Restart running services (picks up new binaries) ---
+
+if [ "$OS" = "macos" ]; then
+  HELPER_PLIST="/Library/LaunchDaemons/dev.veld.helper.plist"
+  if [ -f "$HELPER_PLIST" ]; then
+    echo "Restarting veld-helper service..."
+    $NEED_SUDO launchctl unload -w "$HELPER_PLIST" 2>/dev/null || true
+    $NEED_SUDO launchctl load -w "$HELPER_PLIST" 2>/dev/null || true
+  fi
+
+  DAEMON_PLIST="$HOME/Library/LaunchAgents/dev.veld.daemon.plist"
+  if [ -f "$DAEMON_PLIST" ]; then
+    echo "Restarting veld-daemon service..."
+    launchctl unload -w "$DAEMON_PLIST" 2>/dev/null || true
+    launchctl load -w "$DAEMON_PLIST" 2>/dev/null || true
+  fi
+else
+  # Linux: restart systemd services if they exist.
+  if systemctl is-active --quiet veld-helper 2>/dev/null; then
+    echo "Restarting veld-helper service..."
+    $NEED_SUDO systemctl restart veld-helper 2>/dev/null || true
+  fi
+  if systemctl --user is-active --quiet veld-daemon 2>/dev/null; then
+    echo "Restarting veld-daemon service..."
+    systemctl --user restart veld-daemon 2>/dev/null || true
+  fi
+fi
+
 # --- macOS: remove quarantine attribute ---
 
 if [ "$OS" = "macos" ]; then


### PR DESCRIPTION
## Summary
- Fix version mismatch after updating veld (e.g. `veld 1.4.0` but `veld-helper 1.3.3`)
- `launchctl load -w` on an already-loaded plist is a no-op, so the old binary keeps running
- Setup functions now `unload` before `load` to force service restart with new binary
- Install script explicitly restarts running services after copying new binaries
- Same fix applied for Linux (systemd restart)

## Test plan
- [ ] CI passes
- [ ] After `curl | bash` update: `veld version` shows matching versions for all binaries
- [ ] `veld setup` on existing install restarts helper with new binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)