### PR TITLE
fix: re-sign binaries on macOS to avoid Gatekeeper SIGKILL

### DIFF
--- a/crates/veld/src/commands/version.rs
+++ b/crates/veld/src/commands/version.rs
@@ -6,26 +6,59 @@ use std::process::Command;
 pub fn print_version() {
     let cli_version = env!("CARGO_PKG_VERSION");
 
-    let helper_version =
-        find_and_query_version("veld-helper").unwrap_or_else(|| cli_version.to_string());
-    let daemon_version =
-        find_and_query_version("veld-daemon").unwrap_or_else(|| cli_version.to_string());
+    let helper_version = find_and_query_version("veld-helper");
+    let daemon_version = find_and_query_version("veld-daemon");
 
     println!("{}", output::bold("Veld"));
     println!("  veld           {cli_version}");
-    println!("  veld-daemon    {daemon_version}");
-    println!("  veld-helper    {helper_version}");
+    println!(
+        "  veld-daemon    {}",
+        format_version(&daemon_version, cli_version)
+    );
+    println!(
+        "  veld-helper    {}",
+        format_version(&helper_version, cli_version)
+    );
+}
+
+/// Format a version result for display.
+fn format_version(result: &VersionResult, cli_version: &str) -> String {
+    match result {
+        VersionResult::Ok(v) => v.clone(),
+        VersionResult::NotFound => format!("{cli_version} (assumed — binary not found)"),
+        VersionResult::ExecFailed(path) => {
+            format!("{cli_version} (assumed — could not execute {path})")
+        }
+    }
+}
+
+enum VersionResult {
+    /// Successfully queried the version.
+    Ok(String),
+    /// Binary not found at any candidate path.
+    NotFound,
+    /// Binary exists but `--version` failed (e.g. macOS killed it).
+    ExecFailed(String),
 }
 
 /// Find a binary by checking known paths and query its version.
-fn find_and_query_version(binary_name: &str) -> Option<String> {
+///
+/// If a binary exists at a candidate path but `--version` fails (e.g. macOS
+/// Gatekeeper kills it), stop searching — don't fall through to potentially
+/// stale copies at other locations.
+fn find_and_query_version(binary_name: &str) -> VersionResult {
     let candidates = binary_candidates(binary_name);
     for path in &candidates {
-        if let Some(v) = query_binary_version(path) {
-            return Some(v);
+        if !Path::new(path).exists() {
+            continue;
+        }
+        // Binary exists at this path. Try to query its version.
+        match query_binary_version(path) {
+            Some(v) => return VersionResult::Ok(v),
+            None => return VersionResult::ExecFailed(path.clone()),
         }
     }
-    None
+    VersionResult::NotFound
 }
 
 /// Build list of candidate paths for a binary.
@@ -77,13 +110,13 @@ pub fn check_version_mismatch() -> Result<(), String> {
     let cli_version = env!("CARGO_PKG_VERSION");
     let mut mismatches: Vec<String> = Vec::new();
 
-    if let Some(v) = find_and_query_version("veld-helper") {
+    if let VersionResult::Ok(v) = find_and_query_version("veld-helper") {
         if v != cli_version {
             mismatches.push(format!("veld-helper is v{v} (expected v{cli_version})"));
         }
     }
 
-    if let Some(v) = find_and_query_version("veld-daemon") {
+    if let VersionResult::Ok(v) = find_and_query_version("veld-daemon") {
         if v != cli_version {
             mismatches.push(format!("veld-daemon is v{v} (expected v{cli_version})"));
         }

--- a/install.sh
+++ b/install.sh
@@ -203,16 +203,38 @@ else
   fi
 fi
 
-# --- macOS: remove quarantine attribute ---
+# --- macOS: clear extended attributes and re-sign binaries ---
+#
+# Downloaded binaries carry com.apple.quarantine and com.apple.provenance
+# attributes. On macOS Sequoia (15+), provenance alone can cause Gatekeeper
+# to SIGKILL unsigned/adhoc-signed binaries. Clearing all xattrs and
+# re-signing locally makes macOS treat them as trusted.
 
 if [ "$OS" = "macos" ]; then
-  echo "Removing macOS quarantine attribute..."
-  $NEED_SUDO xattr -dr com.apple.quarantine "${INSTALL_DIR}/veld" 2>/dev/null || true
+  echo "Clearing macOS extended attributes and re-signing binaries..."
+  $NEED_SUDO xattr -cr "${INSTALL_DIR}/veld" 2>/dev/null || true
+  $NEED_SUDO codesign --force --sign - "${INSTALL_DIR}/veld" 2>/dev/null || true
   for bin in veld-helper veld-daemon; do
     if [ -f "${LIB_DIR}/${bin}" ]; then
-      $NEED_SUDO xattr -dr com.apple.quarantine "${LIB_DIR}/${bin}" 2>/dev/null || true
+      $NEED_SUDO xattr -cr "${LIB_DIR}/${bin}" 2>/dev/null || true
+      $NEED_SUDO codesign --force --sign - "${LIB_DIR}/${bin}" 2>/dev/null || true
     fi
   done
+fi
+
+# --- Clean up stale binaries from alternate install location ---
+#
+# Previous installs may have placed binaries in ~/.local/lib/veld/ (fallback
+# when /usr/local was not writable). If we just installed to a different
+# location, remove the stale copies so `veld version` doesn't pick them up.
+
+if [ "$LIB_DIR" != "$HOME/.local/lib/veld" ] && [ -d "$HOME/.local/lib/veld" ]; then
+  echo "Removing stale binaries from $HOME/.local/lib/veld/..."
+  for bin in veld-helper veld-daemon; do
+    rm -f "$HOME/.local/lib/veld/$bin" 2>/dev/null || true
+  done
+  # Remove the directory if empty.
+  rmdir "$HOME/.local/lib/veld" 2>/dev/null || true
 fi
 
 # --- Auto-run veld setup in interactive mode ---


### PR DESCRIPTION
## Summary
- Clear all extended attributes (`xattr -cr`) and re-sign binaries locally (`codesign --force --sign -`) after installation on macOS
- Clean up stale binaries from `~/.local/lib/veld/` when installing to `/usr/local/lib/veld/`
- Harden `veld version` to stop searching after finding a binary that exists but can't execute, preventing fallback to stale copies

## Context
On macOS Sequoia (15+), downloaded binaries carry `com.apple.provenance` which causes Gatekeeper to SIGKILL adhoc-signed binaries even after quarantine is removed. The old install script only removed `com.apple.quarantine`. This caused `veld-helper --version` to fail, and `veld version` would fall through to stale old binaries at `~/.local/lib/veld/`, showing incorrect versions.

## Test plan
- [ ] `install.sh` on macOS: all binaries execute without SIGKILL
- [ ] `veld version` shows correct matching versions
- [ ] Old binaries at `~/.local/lib/veld/` are cleaned up
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)