### PR TITLE
fix: sync GlobalRegistry when stopping/purging runs

### DIFF
--- a/crates/veld-core/src/orchestrator.rs
+++ b/crates/veld-core/src/orchestrator.rs
@@ -579,6 +579,18 @@ impl Orchestrator {
 
         project_state.save(&self.project_root)?;
 
+        // Update global registry so `veld list` reflects the stopped state.
+        if let Ok(mut registry) = GlobalRegistry::load() {
+            let key = self.project_root.to_string_lossy().into_owned();
+            if let Some(entry) = registry.projects.get_mut(&key) {
+                if let Some(run_info) = entry.runs.get_mut(run_name) {
+                    run_info.status = RunStatus::Stopped;
+                    run_info.urls.clear();
+                }
+                let _ = registry.save();
+            }
+        }
+
         Ok(())
     }
 

--- a/crates/veld-daemon/src/gc.rs
+++ b/crates/veld-daemon/src/gc.rs
@@ -113,6 +113,7 @@ pub async fn run_gc() -> anyhow::Result<GcSummary> {
 
                             if let Some(info) = reg_entry.runs.get_mut(run_name) {
                                 info.status = RunStatus::Stopped;
+                                info.urls.clear();
                                 registry_changed = true;
                             }
 

--- a/crates/veld/src/commands/list.rs
+++ b/crates/veld/src/commands/list.rs
@@ -16,7 +16,7 @@ pub async fn run(urls: bool, json: bool) -> i32 {
         match serde_json::to_string_pretty(&registry) {
             Ok(s) => println!("{s}"),
             Err(e) => {
-                output::print_error(&format!("JSON serialization failed: {e}"), true);
+                output::print_error(&format!("JSON serialization failed: {e}"), json);
                 return 1;
             }
         }

--- a/crates/veld/src/commands/runs.rs
+++ b/crates/veld/src/commands/runs.rs
@@ -1,5 +1,5 @@
 use veld_core::config;
-use veld_core::state::{ProjectState, RunStatus};
+use veld_core::state::{GlobalRegistry, ProjectState, RunStatus};
 
 use crate::output;
 
@@ -110,6 +110,19 @@ pub async fn purge(name: &str) -> i32 {
     if let Err(e) = project_state.save(&project_root) {
         output::print_error(&format!("Failed to save state: {e}"), false);
         return 1;
+    }
+
+    // Also remove from the global registry so `veld list` stays in sync.
+    if let Ok(mut registry) = GlobalRegistry::load() {
+        let key = project_root.to_string_lossy().into_owned();
+        if let Some(entry) = registry.projects.get_mut(&key) {
+            entry.runs.remove(name);
+            // If no runs left, remove the entire project entry.
+            if entry.runs.is_empty() {
+                registry.projects.remove(&key);
+            }
+            let _ = registry.save();
+        }
     }
 
     output::print_success(&format!("Purged run '{name}'."));

--- a/crates/veld/src/commands/status.rs
+++ b/crates/veld/src/commands/status.rs
@@ -40,7 +40,7 @@ pub async fn run(name: Option<String>, json: bool) -> i32 {
         match serde_json::to_string_pretty(&run_state) {
             Ok(s) => println!("{s}"),
             Err(e) => {
-                output::print_error(&format!("JSON serialization failed: {e}"), true);
+                output::print_error(&format!("JSON serialization failed: {e}"), json);
                 return 1;
             }
         }


### PR DESCRIPTION
## Summary
- `orchestrator.stop()`: update GlobalRegistry status to Stopped and clear URLs
- `runs purge`: remove run from GlobalRegistry, not just ProjectState
- daemon `gc`: clear URLs when marking orphan runs as stopped in registry
- Fix hardcoded `true` → `json` in serialization error paths (`status.rs`, `list.rs`)

## Context
Stopping or purging a run only updated ProjectState (`.veld/state.json`) but left the GlobalRegistry (`registry.json`) showing "running". This caused `veld list` to display stale ghost runs that couldn't be stopped or removed.

## Test plan
- [ ] `veld start` → `veld list` shows running → `veld stop` → `veld list` shows stopped
- [ ] `veld runs purge --name X` → `veld list` no longer shows the run
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)