### PR TITLE
fix: don't wipe Caddy routes when starting additional runs

### DIFF
--- a/crates/veld-helper/src/caddy.rs
+++ b/crates/veld-helper/src/caddy.rs
@@ -35,11 +35,7 @@ impl CaddyManager {
 
         if let Some(pid) = state.child_pid {
             if is_process_alive(pid) {
-                info!(pid, "caddy is already running, ensuring base config");
-                drop(state);
-                self.reload()
-                    .await
-                    .context("failed to reload caddy config")?;
+                info!(pid, "caddy is already running");
                 return Ok(());
             }
             // Stale PID.
@@ -47,13 +43,11 @@ impl CaddyManager {
         }
 
         // Check if Caddy is already running externally (e.g. from a previous
-        // helper instance). If the admin API responds, just reload the config.
+        // helper instance). If the admin API responds, nothing to do — routes
+        // are added individually via add_route(), not via base config reload.
         drop(state);
         if self.is_running().await {
-            info!("caddy admin API already reachable, loading base config");
-            self.reload()
-                .await
-                .context("failed to reload caddy config")?;
+            info!("caddy admin API already reachable, skipping startup");
             return Ok(());
         }
 


### PR DESCRIPTION
## Summary
- Stop calling `reload()` (which posts empty base config) when Caddy is already running
- `caddy_start()` now returns immediately if Caddy is reachable, preserving existing routes
- Routes are added individually via `add_route()` and don't need the base config reload

## Context
When starting a second run, `caddy_start()` detected Caddy was already running and called `reload()`, which posted a base config with `"routes": []` — wiping all routes from the first run. Only the last started run had working URLs.

## Test plan
- [ ] Start run A → URLs work
- [ ] Start run B → both A and B URLs work
- [ ] Stop run A → B URLs still work
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)