### PR TITLE
feat: CLI UX overhaul — stop cleanup, purge removal, URL template cascade

### DIFF
--- a/crates/veld-core/src/config.rs
+++ b/crates/veld-core/src/config.rs
@@ -70,6 +70,10 @@ pub struct NodeConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_variant: Option<String>,
 
+    /// Optional URL template override for all variants of this node.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url_template: Option<String>,
+
     pub variants: HashMap<String, VariantConfig>,
 }
 
@@ -113,6 +117,10 @@ pub struct VariantConfig {
     /// Idempotency verify command (bash steps only).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub verify: Option<String>,
+
+    /// Optional URL template override for this specific variant.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url_template: Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/veld-core/src/orchestrator.rs
+++ b/crates/veld-core/src/orchestrator.rs
@@ -68,6 +68,15 @@ pub enum OrchestratorError {
 // ---------------------------------------------------------------------------
 
 /// The main orchestration engine.
+/// Result of a stop operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StopResult {
+    /// The run was actively stopped (processes killed, routes removed).
+    Stopped,
+    /// The run was already stopped; state was cleaned up.
+    AlreadyStopped,
+}
+
 pub struct Orchestrator {
     pub config: VeldConfig,
     pub config_path: PathBuf,
@@ -334,9 +343,16 @@ impl Orchestrator {
         ))
         .await;
 
-        // Build URL.
+        // Build URL using the most specific template (variant > node > project).
+        let node_cfg = &self.config.nodes[&sel.node];
+        let effective_template = url::resolve_url_template(
+            &self.config.url_template,
+            node_cfg.url_template.as_deref(),
+            variant_cfg.url_template.as_deref(),
+        );
         let url_values = url::build_url_template_values(
             &sel.node,
+            &sel.variant,
             &run.name,
             &self.config.name,
             branch,
@@ -344,7 +360,7 @@ impl Orchestrator {
             username,
             hostname,
         );
-        let node_url = url::evaluate_url_template(&self.config.url_template, &url_values)?;
+        let node_url = url::evaluate_url_template(effective_template, &url_values)?;
         let https_url = format!("https://{node_url}");
         node_state.url = Some(https_url.clone());
 
@@ -527,12 +543,21 @@ impl Orchestrator {
     // Stop
     // -----------------------------------------------------------------------
 
-    /// Stop a run in reverse dependency order.
-    pub async fn stop(&mut self, run_name: &str) -> Result<(), OrchestratorError> {
+    /// Stop a run in reverse dependency order. Returns whether the run was
+    /// actually stopped or was already stopped.
+    pub async fn stop(&mut self, run_name: &str) -> Result<StopResult, OrchestratorError> {
         let mut project_state = ProjectState::load(&self.project_root)?;
         let run = project_state
             .get_run_mut(run_name)
             .ok_or_else(|| crate::state::StateError::RunNotFound(run_name.to_owned()))?;
+
+        if run.status == RunStatus::Stopped {
+            // Already stopped — clean up state and return.
+            project_state.runs.remove(run_name);
+            project_state.save(&self.project_root)?;
+            self.remove_from_registry(run_name);
+            return Ok(StopResult::AlreadyStopped);
+        }
 
         run.status = RunStatus::Stopping;
 
@@ -574,24 +599,28 @@ impl Orchestrator {
             self.children.remove(key);
         }
 
-        run.status = RunStatus::Stopped;
-        run.stopped_at = Some(chrono::Utc::now());
-
+        // Remove the run from project state entirely (no lingering stopped state).
+        project_state.runs.remove(run_name);
         project_state.save(&self.project_root)?;
 
-        // Update global registry so `veld list` reflects the stopped state.
+        // Remove from global registry.
+        self.remove_from_registry(run_name);
+
+        Ok(StopResult::Stopped)
+    }
+
+    /// Remove a run from the global registry.
+    fn remove_from_registry(&self, run_name: &str) {
         if let Ok(mut registry) = GlobalRegistry::load() {
             let key = self.project_root.to_string_lossy().into_owned();
             if let Some(entry) = registry.projects.get_mut(&key) {
-                if let Some(run_info) = entry.runs.get_mut(run_name) {
-                    run_info.status = RunStatus::Stopped;
-                    run_info.urls.clear();
+                entry.runs.remove(run_name);
+                if entry.runs.is_empty() {
+                    registry.projects.remove(&key);
                 }
                 let _ = registry.save();
             }
         }
-
-        Ok(())
     }
 
     // -----------------------------------------------------------------------

--- a/crates/veld-core/src/url.rs
+++ b/crates/veld-core/src/url.rs
@@ -46,6 +46,26 @@ pub fn slugify(input: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
+// URL template resolution (cascade: variant > node > project > built-in)
+// ---------------------------------------------------------------------------
+
+/// Resolve the effective URL template for a given node+variant, using the
+/// most specific override: variant > node > project.
+pub fn resolve_url_template<'a>(
+    project_template: &'a str,
+    node_template: Option<&'a str>,
+    variant_template: Option<&'a str>,
+) -> &'a str {
+    if let Some(t) = variant_template {
+        return t;
+    }
+    if let Some(t) = node_template {
+        return t;
+    }
+    project_template
+}
+
+// ---------------------------------------------------------------------------
 // URL template evaluation
 // ---------------------------------------------------------------------------
 
@@ -60,8 +80,10 @@ pub fn evaluate_url_template(
 }
 
 /// Build the template variables map for a given node in a run.
+#[allow(clippy::too_many_arguments)]
 pub fn build_url_template_values(
     service: &str,
+    variant: &str,
     run_name: &str,
     project: &str,
     branch: &str,
@@ -71,6 +93,7 @@ pub fn build_url_template_values(
 ) -> HashMap<String, String> {
     let mut values = HashMap::new();
     values.insert("service".to_owned(), slugify(service));
+    values.insert("variant".to_owned(), slugify(variant));
     values.insert("run".to_owned(), slugify(run_name));
     values.insert("project".to_owned(), slugify(project));
     values.insert("branch".to_owned(), slugify(branch));

--- a/crates/veld/src/commands/mod.rs
+++ b/crates/veld/src/commands/mod.rs
@@ -43,7 +43,13 @@ pub fn resolve_run_name(
         .collect();
 
     match active_runs.len() {
-        1 => return Some(active_runs[0].clone()),
+        1 => {
+            let resolved = active_runs[0].clone();
+            if !json {
+                output::print_info(&format!("Using run '{}' (only active run).", resolved));
+            }
+            return Some(resolved);
+        }
         n if n > 1 => {
             let mut names: Vec<&str> = active_runs.iter().map(|s| s.as_str()).collect();
             names.sort();
@@ -61,7 +67,11 @@ pub fn resolve_run_name(
 
     // No active runs. For read-only commands, fall back to any run.
     if include_stopped && project_state.runs.len() == 1 {
-        return Some(project_state.runs.keys().next().unwrap().clone());
+        let resolved = project_state.runs.keys().next().unwrap().clone();
+        if !json {
+            output::print_info(&format!("Using run '{}' (only run).", resolved));
+        }
+        return Some(resolved);
     }
 
     if include_stopped && project_state.runs.len() > 1 {

--- a/crates/veld/src/commands/restart.rs
+++ b/crates/veld/src/commands/restart.rs
@@ -30,40 +30,29 @@ pub async fn run(name: Option<String>, debug: bool) -> i32 {
     };
     let run_name = run_name.as_str();
 
+    // Save the selections BEFORE stopping (stop removes the run from state).
+    let selections: Vec<graph::NodeSelection> = match project_state.get_run(run_name) {
+        Some(run_state) => run_state
+            .nodes
+            .values()
+            .map(|ns| graph::NodeSelection {
+                node: ns.node_name.clone(),
+                variant: ns.variant.clone(),
+            })
+            .collect(),
+        None => {
+            output::print_error(&format!("Run '{run_name}' not found."), false);
+            return 1;
+        }
+    };
+
     output::print_info(&format!("Restarting environment '{run_name}'..."));
 
-    // First stop the existing run.
+    // Stop the existing run (this removes it from state).
     if let Err(e) = orchestrator.stop(run_name).await {
         output::print_error(&format!("Failed to stop '{run_name}': {e}"), false);
         return 1;
     }
-
-    // Re-read state to get the selections that were used.
-    let project_state = match ProjectState::load(&orchestrator.project_root) {
-        Ok(s) => s,
-        Err(e) => {
-            output::print_error(&format!("Failed to load state: {e}"), false);
-            return 1;
-        }
-    };
-
-    let run_state = match project_state.get_run(run_name) {
-        Some(r) => r,
-        None => {
-            output::print_error(&format!("Run '{run_name}' not found after stop."), false);
-            return 1;
-        }
-    };
-
-    // Reconstruct selections from the node states.
-    let selections: Vec<veld_core::graph::NodeSelection> = run_state
-        .nodes
-        .values()
-        .map(|ns| graph::NodeSelection {
-            node: ns.node_name.clone(),
-            variant: ns.variant.clone(),
-        })
-        .collect();
 
     // Start again with a fresh orchestrator.
     let mut orchestrator = Orchestrator::new(config_path, config);

--- a/crates/veld/src/commands/runs.rs
+++ b/crates/veld/src/commands/runs.rs
@@ -1,10 +1,10 @@
 use veld_core::config;
-use veld_core::state::{GlobalRegistry, ProjectState, RunStatus};
+use veld_core::state::ProjectState;
 
 use crate::output;
 
-/// `veld runs [--all] [--name <n>] [--json]`
-pub async fn list(all: bool, name: Option<&str>, json: bool) -> i32 {
+/// `veld runs [--name <n>] [--json]`
+pub async fn list(name: Option<&str>, json: bool) -> i32 {
     if !super::require_setup(json).await {
         return 1;
     }
@@ -27,11 +27,6 @@ pub async fn list(all: bool, name: Option<&str>, json: bool) -> i32 {
     // Filter by name if given.
     if let Some(filter_name) = name {
         runs.retain(|(n, _)| *n == filter_name);
-    }
-
-    // Unless --all, only show active (non-stopped) runs.
-    if !all {
-        runs.retain(|(_, r)| r.status != RunStatus::Stopped);
     }
 
     runs.sort_by_key(|(n, _)| (*n).clone());
@@ -69,62 +64,5 @@ pub async fn list(all: bool, name: Option<&str>, json: bool) -> i32 {
         output::print_table(&["NAME", "STATE", "STARTED", "NODES"], &rows);
     }
 
-    0
-}
-
-/// `veld runs purge --name <n>`
-pub async fn purge(name: &str) -> i32 {
-    if !super::require_setup(false).await {
-        return 1;
-    }
-
-    let Some((config_path, _cfg)) = super::load_config(false) else {
-        return 1;
-    };
-    let project_root = config::project_root(&config_path);
-
-    let mut project_state = match ProjectState::load(&project_root) {
-        Ok(s) => s,
-        Err(e) => {
-            output::print_error(&format!("Failed to load state: {e}"), false);
-            return 1;
-        }
-    };
-
-    if project_state.runs.remove(name).is_none() {
-        output::print_error(&format!("Run '{name}' not found."), false);
-        return 1;
-    }
-
-    // Remove log directory.
-    let log_dir = veld_core::logging::log_dir(&project_root, name);
-    if log_dir.exists() {
-        if let Err(e) = std::fs::remove_dir_all(&log_dir) {
-            output::print_error(
-                &format!("Failed to remove logs at {}: {e}", log_dir.display()),
-                false,
-            );
-        }
-    }
-
-    if let Err(e) = project_state.save(&project_root) {
-        output::print_error(&format!("Failed to save state: {e}"), false);
-        return 1;
-    }
-
-    // Also remove from the global registry so `veld list` stays in sync.
-    if let Ok(mut registry) = GlobalRegistry::load() {
-        let key = project_root.to_string_lossy().into_owned();
-        if let Some(entry) = registry.projects.get_mut(&key) {
-            entry.runs.remove(name);
-            // If no runs left, remove the entire project entry.
-            if entry.runs.is_empty() {
-                registry.projects.remove(&key);
-            }
-            let _ = registry.save();
-        }
-    }
-
-    output::print_success(&format!("Purged run '{name}'."));
     0
 }

--- a/crates/veld/src/commands/start.rs
+++ b/crates/veld/src/commands/start.rs
@@ -136,7 +136,7 @@ pub async fn run(
         Err(e) => {
             output::print_error(&format!("Startup failed: {e}"), false);
             // Best-effort teardown.
-            let _ = orchestrator.stop(run_name).await;
+            let _stop_result = orchestrator.stop(run_name).await;
             1
         }
     }

--- a/crates/veld/src/commands/stop.rs
+++ b/crates/veld/src/commands/stop.rs
@@ -1,4 +1,4 @@
-use veld_core::orchestrator::Orchestrator;
+use veld_core::orchestrator::{Orchestrator, StopResult};
 
 use crate::output;
 
@@ -24,11 +24,15 @@ pub async fn run(name: Option<String>, all: bool) -> i32 {
 
     if all {
         let run_names: Vec<String> = project_state.runs.keys().cloned().collect();
+        if run_names.is_empty() {
+            output::print_info("No runs to stop.");
+            return 0;
+        }
         let mut stopped = 0;
 
         for rn in &run_names {
             match orchestrator.stop(rn).await {
-                Ok(()) => stopped += 1,
+                Ok(_) => stopped += 1,
                 Err(e) => {
                     output::print_error(&format!("Failed to stop '{rn}': {e}"), false);
                 }
@@ -45,8 +49,12 @@ pub async fn run(name: Option<String>, all: bool) -> i32 {
         let run_name = run_name.as_str();
 
         match orchestrator.stop(run_name).await {
-            Ok(()) => {
+            Ok(StopResult::Stopped) => {
                 output::print_success(&format!("Environment '{run_name}' stopped."));
+                0
+            }
+            Ok(StopResult::AlreadyStopped) => {
+                output::print_info(&format!("Environment '{run_name}' is already stopped."));
                 0
             }
             Err(e) => {

--- a/crates/veld/src/main.rs
+++ b/crates/veld/src/main.rs
@@ -62,15 +62,8 @@ enum Command {
         debug: bool,
     },
 
-    /// Manage environment runs.
+    /// List environment runs.
     Runs {
-        #[command(subcommand)]
-        action: Option<RunsAction>,
-
-        /// Show all runs (including stopped).
-        #[arg(long)]
-        all: bool,
-
         /// Filter by run name.
         #[arg(long)]
         name: Option<String>,
@@ -180,16 +173,6 @@ enum Command {
     Version,
 }
 
-#[derive(Subcommand)]
-enum RunsAction {
-    /// Purge a stopped run's state and logs.
-    Purge {
-        /// Name of the run to purge.
-        #[arg(long)]
-        name: String,
-    },
-}
-
 fn init_tracing(debug: bool) {
     use tracing_subscriber::EnvFilter;
 
@@ -247,15 +230,7 @@ async fn main() {
 
         Command::Restart { name, debug } => commands::restart::run(name, debug).await,
 
-        Command::Runs {
-            action,
-            all,
-            name,
-            json,
-        } => match action {
-            Some(RunsAction::Purge { name }) => commands::runs::purge(&name).await,
-            None => commands::runs::list(all, name.as_deref(), json).await,
-        },
+        Command::Runs { name, json } => commands::runs::list(name.as_deref(), json).await,
 
         Command::Status { name, json } => commands::status::run(name, json).await,
 

--- a/schema/v1/veld.schema.json
+++ b/schema/v1/veld.schema.json
@@ -22,7 +22,7 @@
     },
     "url_template": {
       "type": "string",
-      "description": "URL template for services. Supports placeholders: {service}, {run}, {project}, {port}.",
+      "description": "URL template for services. Supports placeholders: {service}, {variant}, {run}, {project}, {branch}, {worktree}, {username}, {hostname}. Supports fallback operator: {branch ?? run}.",
       "default": "{service}.{run}.{project}.localhost",
       "examples": [
         "{service}.{run}.{project}.localhost",
@@ -61,6 +61,10 @@
         "default_variant": {
           "type": "string",
           "description": "The variant to use when none is specified. If omitted and the node has exactly one variant, that variant is used automatically."
+        },
+        "url_template": {
+          "type": "string",
+          "description": "URL template override for all variants of this node. Overrides the project-level url_template."
         },
         "variants": {
           "type": "object",
@@ -138,6 +142,10 @@
         "verify": {
           "type": "string",
           "description": "Idempotency verification command. Only applies to \"bash\" type variants. If this command exits 0, the step is considered already complete and is skipped."
+        },
+        "url_template": {
+          "type": "string",
+          "description": "URL template override for this specific variant. Overrides both node-level and project-level url_template."
         }
       },
       "allOf": [


### PR DESCRIPTION
## Summary

- **Remove `purge` command** — `veld stop` now fully removes run state from both ProjectState and GlobalRegistry (matching `docker compose down` semantics)
- **Better stop feedback** — stopping an already-stopped run says "already stopped" (exit 0) instead of "stopped successfully"
- **Auto-resolve prints selection** — when `--name` is omitted and a single run is found, the CLI prints which run was auto-selected
- **URL template cascade** — URL templates can now be overridden at node and variant level (variant > node > project > built-in default)
- **`{variant}` template variable** — new placeholder available in URL templates
- **Schema updated** — `url_template` field added to NodeConfig and VariantConfig in JSON schema
- **Restart rewritten** — captures node selections before calling stop, since stop now removes state

## Test plan

- [ ] `veld stop` on a running env removes it from both `.veld/state.json` and global registry
- [ ] `veld stop` on an already-stopped env prints "already stopped", exits 0
- [ ] `veld status` (no `--name`) on a single-run project prints which run was selected
- [ ] `veld restart` works correctly (saves selections, stops, re-starts)
- [ ] URL template with `{variant}` resolves correctly
- [ ] Node-level and variant-level `url_template` overrides take precedence
- [ ] `veld --help` no longer shows `purge` subcommand
- [ ] `cargo clippy --all-targets` passes clean
- [ ] `cargo fmt --all -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)