### PR TITLE
feat: hidden nodes and on_stop teardown hooks

### DIFF
--- a/crates/veld-core/src/config.rs
+++ b/crates/veld-core/src/config.rs
@@ -74,6 +74,11 @@ pub struct NodeConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url_template: Option<String>,
 
+    /// When true, this node is hidden from `veld nodes` output.
+    /// Hidden nodes still participate in the dependency graph normally.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hidden: Option<bool>,
+
     pub variants: HashMap<String, VariantConfig>,
 }
 
@@ -121,6 +126,11 @@ pub struct VariantConfig {
     /// Optional URL template override for this specific variant.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url_template: Option<String>,
+
+    /// Teardown command to run when the environment is stopped.
+    /// Executed in reverse dependency order during `veld stop`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_stop: Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/veld-core/src/orchestrator.rs
+++ b/crates/veld-core/src/orchestrator.rs
@@ -591,6 +591,9 @@ impl Orchestrator {
                     let _ = self.helper_client.remove_route(&route_id).await;
                 }
 
+                // Run on_stop hook if defined.
+                self.run_on_stop_hook(node_state).await;
+
                 node_state.status = NodeStatus::Stopped;
                 node_state.pid = None;
             }
@@ -607,6 +610,77 @@ impl Orchestrator {
         self.remove_from_registry(run_name);
 
         Ok(StopResult::Stopped)
+    }
+
+    /// Run the `on_stop` hook for a node if one is defined in the config.
+    async fn run_on_stop_hook(&self, node_state: &NodeState) {
+        let variant_cfg = match self
+            .config
+            .nodes
+            .get(&node_state.node_name)
+            .and_then(|n| n.variants.get(&node_state.variant))
+        {
+            Some(cfg) => cfg,
+            None => return,
+        };
+
+        let on_stop_cmd = match variant_cfg.on_stop.as_deref() {
+            Some(cmd) => cmd,
+            None => return,
+        };
+
+        tracing::info!(
+            node = node_state.node_name,
+            variant = node_state.variant,
+            "running on_stop hook"
+        );
+
+        // Build a variable context with the node's outputs so the hook
+        // can reference values produced during start (e.g. container names).
+        let mut ctx = VariableContext::new();
+        ctx.set_builtin("root", self.project_root.to_string_lossy().into_owned());
+        ctx.set_builtin("project", self.config.name.clone());
+        for (k, v) in &node_state.outputs {
+            ctx.set_builtin(k, v.clone());
+            ctx.set_node_output(&format!("nodes.{}.{k}", node_state.node_name), v.clone());
+        }
+        if let Some(port) = node_state.port {
+            ctx.set_builtin("port", port.to_string());
+        }
+
+        let resolved_cmd = match crate::variables::interpolate(on_stop_cmd, &ctx) {
+            Ok(cmd) => cmd,
+            Err(e) => {
+                tracing::warn!(
+                    node = node_state.node_name,
+                    error = %e,
+                    "failed to resolve on_stop command variables"
+                );
+                return;
+            }
+        };
+
+        // Build env from the variant config.
+        let env = build_env(variant_cfg.env.as_ref(), &ctx).unwrap_or_default();
+
+        match process::run_bash(&resolved_cmd, &self.project_root, &env).await {
+            Ok(result) => {
+                if result.exit_code != 0 {
+                    tracing::warn!(
+                        node = node_state.node_name,
+                        exit_code = result.exit_code,
+                        "on_stop hook exited with non-zero code"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    node = node_state.node_name,
+                    error = %e,
+                    "on_stop hook failed to execute"
+                );
+            }
+        }
     }
 
     /// Remove a run from the global registry.

--- a/crates/veld/src/commands/nodes.rs
+++ b/crates/veld/src/commands/nodes.rs
@@ -6,10 +6,16 @@ pub async fn run(json: bool) -> i32 {
         return 1;
     };
 
+    // Filter out hidden nodes.
+    let visible_nodes: Vec<(&String, &veld_core::config::NodeConfig)> = config
+        .nodes
+        .iter()
+        .filter(|(_, node_cfg)| !node_cfg.hidden.unwrap_or(false))
+        .collect();
+
     if json {
         // Build structured output.
-        let nodes: Vec<serde_json::Value> = config
-            .nodes
+        let nodes: Vec<serde_json::Value> = visible_nodes
             .iter()
             .map(|(name, node_cfg)| {
                 let variants: Vec<&String> = node_cfg.variants.keys().collect();
@@ -21,14 +27,13 @@ pub async fn run(json: bool) -> i32 {
             })
             .collect();
         println!("{}", serde_json::to_string_pretty(&nodes).unwrap());
-    } else if config.nodes.is_empty() {
+    } else if visible_nodes.is_empty() {
         output::print_info("No nodes defined.");
     } else {
         let mut rows: Vec<Vec<String>> = Vec::new();
-        let mut names: Vec<&String> = config.nodes.keys().collect();
-        names.sort();
-        for name in names {
-            let node_cfg = &config.nodes[name];
+        let mut sorted: Vec<(&String, &veld_core::config::NodeConfig)> = visible_nodes;
+        sorted.sort_by_key(|(name, _)| name.to_owned());
+        for (name, node_cfg) in sorted {
             let mut variants: Vec<&String> = node_cfg.variants.keys().collect();
             variants.sort();
             rows.push(vec![

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,6 +103,22 @@ Specifies which variant to use when none is explicitly selected. Optional -- if 
 
 If a node has multiple variants and no `default_variant` is set, the user must explicitly specify which variant to use.
 
+### `hidden`
+
+When set to `true`, the node is excluded from `veld nodes` output. Hidden nodes still participate fully in the dependency graph — they are started, stopped, and have their `on_stop` hooks executed like any other node. This is useful for internal setup tasks (certificate generation, database seeding, etc.) that end users don't need to see.
+
+```json
+"generate-certs": {
+  "hidden": true,
+  "variants": {
+    "default": {
+      "type": "bash",
+      "command": "./scripts/generate-certs.sh"
+    }
+  }
+}
+```
+
 ### `url_template` (node-level)
 
 Overrides the project-level `url_template` for all variants of this node. See [URL Template Cascade](#url-template-cascade) for resolution order.
@@ -137,6 +153,7 @@ A variant defines how a node behaves in a given context. The same node might be 
 | `outputs`           | array or object  | No       | All            | Output declarations (format varies by type)           |
 | `sensitive_outputs`  | array of strings | No       | All            | Output keys to mask and encrypt                       |
 | `url_template`      | string           | No       | `start_server` | URL template override for this variant                |
+| `on_stop`           | string           | No       | All            | Teardown command run when the environment is stopped  |
 | `verify`            | string           | No       | `bash` only    | Idempotency verification command                      |
 
 ### `type`
@@ -361,6 +378,39 @@ The verify command receives the previous run's output variables as environment v
   "script": "./scripts/clone-db.sh",
   "verify": "./scripts/verify-db.sh",
   "outputs": ["DATABASE_URL"]
+}
+```
+
+### `on_stop`
+
+A teardown command that runs when `veld stop` is called. Executed in reverse dependency order, after the process is killed (for `start_server` nodes) but before state is cleaned up.
+
+This is especially useful for `bash` nodes that provision external resources during start — databases, Docker containers, temporary credentials — that need explicit cleanup.
+
+```json
+{
+  "type": "bash",
+  "command": "docker run -d --name veld-db-${veld.run} -p ${veld.port}:5432 postgres:16",
+  "on_stop": "docker rm -f veld-db-${veld.run}",
+  "outputs": ["DATABASE_URL"]
+}
+```
+
+The `on_stop` command receives the same variable context that was available during start:
+- All `${veld.*}` built-in variables (`${veld.root}`, `${veld.project}`, `${veld.port}`, etc.)
+- All outputs produced by this node (e.g. `${veld.exit_code}`, custom outputs)
+- Environment variables from the variant's `env` block
+
+If the `on_stop` command fails (non-zero exit code or execution error), Veld logs a warning but continues tearing down the remaining nodes. A failing teardown hook never blocks the stop operation.
+
+`on_stop` works with both `bash` and `start_server` variants:
+
+```json
+{
+  "type": "start_server",
+  "command": "docker run --rm --name veld-redis-${veld.run} -p ${veld.port}:6379 redis:7",
+  "on_stop": "docker stop veld-redis-${veld.run}",
+  "health_check": { "type": "port" }
 }
 ```
 
@@ -590,12 +640,14 @@ Below is a realistic `veld.json` for a monorepo with a database, backend API, fr
           "type": "bash",
           "script": "./scripts/clone-db.sh",
           "verify": "./scripts/verify-db.sh",
+          "on_stop": "./scripts/drop-db.sh",
           "outputs": ["DATABASE_URL"],
           "sensitive_outputs": ["DATABASE_URL"]
         },
         "docker": {
           "type": "start_server",
-          "command": "docker run --rm --name veld-db-${veld.run} -e POSTGRES_PASSWORD=veld -p ${veld.port}:5432 postgres:16",
+          "command": "docker run -d --name veld-db-${veld.run} -e POSTGRES_PASSWORD=veld -p ${veld.port}:5432 postgres:16",
+          "on_stop": "docker rm -f veld-db-${veld.run}",
           "health_check": {
             "type": "port",
             "timeout_seconds": 30
@@ -603,6 +655,17 @@ Below is a realistic `veld.json` for a monorepo with a database, backend API, fr
           "outputs": {
             "DATABASE_URL": "postgresql://postgres:veld@localhost:${veld.port}/app"
           }
+        }
+      }
+    },
+
+    "generate-certs": {
+      "hidden": true,
+      "variants": {
+        "default": {
+          "type": "bash",
+          "command": "./scripts/generate-dev-certs.sh",
+          "verify": "test -f ./certs/dev.pem"
         }
       }
     },

--- a/schema/v1/veld.schema.json
+++ b/schema/v1/veld.schema.json
@@ -66,6 +66,11 @@
           "type": "string",
           "description": "URL template override for all variants of this node. Overrides the project-level url_template."
         },
+        "hidden": {
+          "type": "boolean",
+          "description": "When true, this node is hidden from `veld nodes` output. Hidden nodes still participate in the dependency graph and run normally.",
+          "default": false
+        },
         "variants": {
           "type": "object",
           "description": "Available variants for this node. Each key is a variant name.",
@@ -146,6 +151,10 @@
         "url_template": {
           "type": "string",
           "description": "URL template override for this specific variant. Overrides both node-level and project-level url_template."
+        },
+        "on_stop": {
+          "type": "string",
+          "description": "Teardown command to run when the environment is stopped. Executed in reverse dependency order. Supports Veld variable substitution."
         }
       },
       "allOf": [


### PR DESCRIPTION
## Summary

- **Hidden nodes** — new `hidden: true` field on NodeConfig. Hidden nodes are excluded from `veld nodes` output but still participate fully in the dependency graph (started, stopped, teardown hooks run). Useful for internal setup tasks like cert generation or database seeding.
- **`on_stop` teardown hooks** — new `on_stop` field on VariantConfig. A shell command that runs during `veld stop` in reverse dependency order, after the process is killed but before state is cleaned up. The hook receives the full variable context (outputs, env, port, root) so it can clean up external resources (Docker containers, temp databases, tokens, etc.). Failing hooks log a warning but never block the stop.
- JSON schema and docs updated with both features, including examples and complete example showcase

## Test plan

- [ ] `veld nodes` hides nodes with `hidden: true`
- [ ] `veld nodes --json` hides nodes with `hidden: true`
- [ ] Hidden nodes still start and stop normally as dependencies
- [ ] `veld stop` runs `on_stop` hooks in reverse dependency order
- [ ] `on_stop` command can reference `${veld.run}`, `${veld.port}`, and node outputs
- [ ] Failing `on_stop` hook logs warning but doesn't block stop
- [ ] Node without `on_stop` is unaffected (no-op)
- [ ] `cargo clippy --all-targets` passes clean
- [ ] `cargo fmt --all -- --check` passes
- [ ] JSON schema validates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)