### PR TITLE
fix: populate full variable context in on_stop hooks

### DIFF
--- a/crates/veld-core/src/orchestrator.rs
+++ b/crates/veld-core/src/orchestrator.rs
@@ -591,8 +591,10 @@ impl Orchestrator {
                     let _ = self.helper_client.remove_route(&route_id).await;
                 }
 
-                // Run on_stop hook if defined.
-                self.run_on_stop_hook(node_state).await;
+                // Run on_stop hook if defined (skip nodes that never ran).
+                if node_state.status != NodeStatus::Pending {
+                    self.run_on_stop_hook(run_name, node_state).await;
+                }
 
                 node_state.status = NodeStatus::Stopped;
                 node_state.pid = None;
@@ -613,7 +615,7 @@ impl Orchestrator {
     }
 
     /// Run the `on_stop` hook for a node if one is defined in the config.
-    async fn run_on_stop_hook(&self, node_state: &NodeState) {
+    async fn run_on_stop_hook(&self, run_name: &str, node_state: &NodeState) {
         let variant_cfg = match self
             .config
             .nodes
@@ -635,11 +637,26 @@ impl Orchestrator {
             "running on_stop hook"
         );
 
-        // Build a variable context with the node's outputs so the hook
-        // can reference values produced during start (e.g. container names).
+        // Build variable context matching what was available at start time.
         let mut ctx = VariableContext::new();
+        ctx.set_builtin("run", run_name.to_owned());
         ctx.set_builtin("root", self.project_root.to_string_lossy().into_owned());
         ctx.set_builtin("project", self.config.name.clone());
+        ctx.set_builtin(
+            "worktree",
+            url::slugify(
+                self.project_root
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("default"),
+            ),
+        );
+        ctx.set_builtin(
+            "branch",
+            url::slugify(&detect_git_branch(&self.project_root)),
+        );
+        ctx.set_builtin("username", whoami_username());
+
         for (k, v) in &node_state.outputs {
             ctx.set_builtin(k, v.clone());
             ctx.set_node_output(&format!("nodes.{}.{k}", node_state.node_name), v.clone());
@@ -661,7 +678,17 @@ impl Orchestrator {
         };
 
         // Build env from the variant config.
-        let env = build_env(variant_cfg.env.as_ref(), &ctx).unwrap_or_default();
+        let env = match build_env(variant_cfg.env.as_ref(), &ctx) {
+            Ok(env) => env,
+            Err(e) => {
+                tracing::warn!(
+                    node = node_state.node_name,
+                    error = %e,
+                    "failed to resolve on_stop env variables, using empty env"
+                );
+                HashMap::new()
+            }
+        };
 
         match process::run_bash(&resolved_cmd, &self.project_root, &env).await {
             Ok(result) => {

--- a/crates/veld/src/commands/nodes.rs
+++ b/crates/veld/src/commands/nodes.rs
@@ -28,7 +28,11 @@ pub async fn run(json: bool) -> i32 {
             .collect();
         println!("{}", serde_json::to_string_pretty(&nodes).unwrap());
     } else if visible_nodes.is_empty() {
-        output::print_info("No nodes defined.");
+        if config.nodes.is_empty() {
+            output::print_info("No nodes defined.");
+        } else {
+            output::print_info("All nodes are hidden.");
+        }
     } else {
         let mut rows: Vec<Vec<String>> = Vec::new();
         let mut sorted: Vec<(&String, &veld_core::config::NodeConfig)> = visible_nodes;


### PR DESCRIPTION
## Summary

Fixes a bug introduced in #23 where `on_stop` hooks were missing critical builtin variables:

- **Bug fix**: Add `${veld.run}`, `${veld.branch}`, `${veld.worktree}`, `${veld.username}` to the on_stop variable context. Without these, the documented example `docker rm -f veld-db-${veld.run}` would silently fail (variable resolution error caught and swallowed).
- **Skip Pending nodes**: Don't run on_stop for nodes that never started (Pending status)
- **Better error logging**: Log warning when env resolution fails in on_stop instead of silently using empty env
- **UX**: Distinguish "No nodes defined" vs "All nodes are hidden" in `veld nodes` output

## Test plan

- [ ] `on_stop` command with `${veld.run}` resolves correctly
- [ ] `on_stop` command with `${veld.branch}`, `${veld.worktree}`, `${veld.username}` resolves correctly
- [ ] Nodes in Pending status don't trigger on_stop
- [ ] `veld nodes` with all hidden nodes says "All nodes are hidden"
- [ ] `cargo clippy --all-targets` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)