### PR TITLE
feat: implement veld update — check GitHub releases and auto-update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 slug = "0.1"
 dirs = "6"
 nix = { version = "0.29", features = ["signal", "process", "net"] }
-reqwest = { version = "0.12", features = ["rustls-tls"], default-features = false }
+reqwest = { version = "0.12", features = ["rustls-tls", "json"], default-features = false }
 sha2 = "0.10"
 base64 = "0.22"

--- a/crates/veld-core/src/setup.rs
+++ b/crates/veld-core/src/setup.rs
@@ -629,16 +629,102 @@ async fn install_helper_linux(bin: &Path) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-/// Check for available updates. Returns `Some(version)` if an update exists.
+const GITHUB_REPO: &str = "prosperity-solutions/veld";
+
+/// Check for available updates. Returns `Some(version)` if a newer version
+/// exists on GitHub releases, or `None` if we're already up to date.
 pub async fn check_update() -> Result<Option<String>, anyhow::Error> {
-    // Stub: no update mechanism in v0.1.
-    Ok(None)
+    let current = env!("CARGO_PKG_VERSION");
+
+    let client = reqwest::Client::builder()
+        .user_agent(format!("veld/{current}"))
+        .timeout(Duration::from_secs(10))
+        .build()
+        .context("failed to build HTTP client")?;
+
+    let url = format!("https://api.github.com/repos/{GITHUB_REPO}/releases/latest");
+    let resp = client
+        .get(&url)
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+        .context("failed to fetch latest release from GitHub")?;
+
+    if !resp.status().is_success() {
+        anyhow::bail!(
+            "GitHub API returned status {} when checking for updates",
+            resp.status()
+        );
+    }
+
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .context("failed to parse GitHub release response")?;
+
+    let tag = body["tag_name"]
+        .as_str()
+        .context("GitHub release missing tag_name")?;
+
+    let latest = tag.strip_prefix('v').unwrap_or(tag);
+
+    if is_newer(latest, current) {
+        Ok(Some(latest.to_owned()))
+    } else {
+        Ok(None)
+    }
 }
 
-/// Download and install the given version.
-pub async fn perform_update(_version: &str) -> Result<(), anyhow::Error> {
-    // Stub: no update mechanism in v0.1.
-    tracing::info!("No update available");
+/// Compare two semver-like version strings. Returns true if `latest` is
+/// newer than `current`.
+fn is_newer(latest: &str, current: &str) -> bool {
+    let parse = |v: &str| -> (u64, u64, u64) {
+        let mut parts = v.split('.');
+        let major = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+        let minor = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+        let patch = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+        (major, minor, patch)
+    };
+    parse(latest) > parse(current)
+}
+
+/// Download and run the install script to update to the given version.
+pub async fn perform_update(version: &str) -> Result<(), anyhow::Error> {
+    let install_url = format!("https://raw.githubusercontent.com/{GITHUB_REPO}/main/install.sh");
+
+    let client = reqwest::Client::builder()
+        .user_agent(format!("veld/{}", env!("CARGO_PKG_VERSION")))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .context("failed to build HTTP client")?;
+
+    let script = client
+        .get(&install_url)
+        .send()
+        .await
+        .context("failed to download install script")?
+        .text()
+        .await
+        .context("failed to read install script")?;
+
+    // Run the install script with the target version pinned, in
+    // non-interactive mode (skip the `veld setup` prompt at the end).
+    let status = Command::new("bash")
+        .arg("-c")
+        .arg(&script)
+        .env("VELD_VERSION", version)
+        .env("VELD_NON_INTERACTIVE", "1")
+        .status()
+        .await
+        .context("failed to execute install script")?;
+
+    if !status.success() {
+        anyhow::bail!(
+            "install script exited with code {}",
+            status.code().unwrap_or(-1)
+        );
+    }
+
     Ok(())
 }
 

--- a/crates/veld/src/commands/update.rs
+++ b/crates/veld/src/commands/update.rs
@@ -2,16 +2,21 @@ use crate::output;
 
 /// `veld update` -- update Veld to the latest version.
 pub async fn run() -> i32 {
+    let current = env!("CARGO_PKG_VERSION");
+    output::print_info(&format!("Current version: {current}"));
     output::print_info("Checking for updates...");
 
     match veld_core::setup::check_update().await {
         Ok(Some(new_version)) => {
-            output::print_info(&format!("New version available: {new_version}"));
-            output::print_info("Downloading update...");
+            output::print_info(&format!("New version available: {current} → {new_version}"));
+            output::print_info("Installing update...");
 
             match veld_core::setup::perform_update(&new_version).await {
                 Ok(()) => {
                     output::print_success(&format!("Updated to {new_version}."));
+                    output::print_info("Running setup to restart services...");
+                    // Re-run setup to restart daemons with the new binaries.
+                    let _ = commands_setup_run().await;
                     0
                 }
                 Err(e) => {
@@ -21,12 +26,24 @@ pub async fn run() -> i32 {
             }
         }
         Ok(None) => {
-            output::print_success("Already on the latest version.");
+            output::print_success(&format!("Already on the latest version ({current})."));
             0
         }
         Err(e) => {
             output::print_error(&format!("Update check failed: {e}"), false);
             1
+        }
+    }
+}
+
+/// Run `veld setup` to restart helper/daemon with updated binaries.
+async fn commands_setup_run() -> i32 {
+    match veld_core::setup::require_setup().await {
+        Ok(_) => 0,
+        Err(_) => {
+            // Setup not complete — tell user to run it manually.
+            output::print_info("Run `veld setup` to complete configuration.");
+            0
         }
     }
 }

--- a/install.sh
+++ b/install.sh
@@ -240,14 +240,14 @@ fi
 # --- Auto-run veld setup in interactive mode ---
 # veld setup self-escalates to sudo when needed, so no need to wrap in sudo here.
 
-if [ -t 1 ]; then
+if [ -z "${VELD_NON_INTERACTIVE:-}" ] && [ -t 1 ]; then
   echo ""
   echo "Running veld setup..."
   "${INSTALL_DIR}/veld" setup || echo "Warning: veld setup failed. You can re-run it manually: veld setup"
 else
   echo ""
-  echo "Non-interactive mode detected — skipping 'veld setup'."
-  echo "Run it manually after install:"
+  echo "Skipping 'veld setup' (non-interactive mode)."
+  echo "Run it manually if needed:"
   echo "  veld setup"
 fi
 


### PR DESCRIPTION
## Summary

`veld update` was a stub that always reported "up to date". Now it actually works:

- **Version check**: Queries `api.github.com/repos/.../releases/latest`, extracts `tag_name`, compares semver against current `CARGO_PKG_VERSION`
- **Update mechanism**: Downloads `install.sh` from the repo and runs it with `VELD_VERSION` pinned to the target release. The install script handles platform detection, checksum verification, binary signing, service restart, and stale binary cleanup.
- **Post-update**: Runs `veld setup` to restart helper/daemon with the new binaries
- **Non-interactive**: Added `VELD_NON_INTERACTIVE` env var to `install.sh` to skip interactive setup when called programmatically
- Added `json` feature to workspace `reqwest` dependency

## Test plan

- [ ] `veld update` on latest version prints "Already on the latest version (x.y.z)"
- [ ] `veld update` on an older version detects the newer release and shows version transition
- [ ] Install script respects `VELD_NON_INTERACTIVE=1` (skips setup prompt)
- [ ] `cargo clippy --all-targets` passes clean
- [ ] `cargo fmt --all -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)