### PR TITLE
fix: server processes die in detached mode due to broken pipes

### DIFF
--- a/crates/veld-core/src/orchestrator.rs
+++ b/crates/veld-core/src/orchestrator.rs
@@ -89,6 +89,9 @@ pub struct Orchestrator {
     debug: bool,
     /// Debug log writer (created on demand when debug is true).
     debug_writer: Option<LogWriter>,
+    /// Foreground mode — pipes stdout/stderr through timestamping tasks.
+    /// When false (detached), redirects directly to file so processes survive CLI exit.
+    foreground: bool,
 }
 
 impl Orchestrator {
@@ -104,7 +107,13 @@ impl Orchestrator {
             children: HashMap::new(),
             debug: false,
             debug_writer: None,
+            foreground: false,
         }
+    }
+
+    /// Enable foreground mode (timestamped pipe for server output).
+    pub fn set_foreground(&mut self, foreground: bool) {
+        self.foreground = foreground;
     }
 
     /// Enable debug mode for orchestration trace logging.
@@ -408,8 +417,14 @@ impl Orchestrator {
         // the OS level so the process survives after the CLI exits.
         let log_path = logging::log_file(&self.project_root, &run.name, &sel.node, &sel.variant);
 
-        let child =
-            process::start_server(&resolved_cmd, &self.project_root, &env, &log_path).await?;
+        let child = process::start_server(
+            &resolved_cmd,
+            &self.project_root,
+            &env,
+            &log_path,
+            self.foreground,
+        )
+        .await?;
         let pid = child.id().unwrap_or(0);
         node_state.pid = Some(pid);
 

--- a/crates/veld-core/src/process.rs
+++ b/crates/veld-core/src/process.rs
@@ -42,20 +42,38 @@ pub struct BashOutput {
 
 /// Spawn a long-running server process. Returns the `Child` handle.
 ///
-/// stdout and stderr are piped through a background task that prepends
-/// ISO 8601 timestamps to each line before appending to the log file.
-/// The process survives after the CLI exits (kill_on_drop is false).
+/// When `foreground` is true, stdout/stderr are piped through background
+/// tasks that prepend ISO 8601 timestamps to each line. The process will
+/// die when the CLI exits (pipes close).
+///
+/// When `foreground` is false (detached mode), stdout/stderr are redirected
+/// directly to the log file so the process survives after the CLI exits.
 pub async fn start_server(
     command: &str,
     working_dir: &Path,
     env: &HashMap<String, String>,
     log_file: &Path,
+    foreground: bool,
 ) -> Result<Child, ProcessError> {
     // Ensure log directory exists.
     if let Some(parent) = log_file.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
 
+    if foreground {
+        start_server_foreground(command, working_dir, env, log_file).await
+    } else {
+        start_server_detached(command, working_dir, env, log_file).await
+    }
+}
+
+/// Foreground mode: pipe stdout/stderr through timestamping tasks.
+async fn start_server_foreground(
+    command: &str,
+    working_dir: &Path,
+    env: &HashMap<String, String>,
+    log_file: &Path,
+) -> Result<Child, ProcessError> {
     let mut child = Command::new("sh")
         .arg("-c")
         .arg(command)
@@ -64,17 +82,16 @@ pub async fn start_server(
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .kill_on_drop(false) // We manage lifecycle explicitly.
+        .kill_on_drop(false)
         .spawn()
         .map_err(ProcessError::SpawnFailed)?;
 
     tracing::info!(
         pid = child.id().unwrap_or(0),
         command = command,
-        "started server process"
+        "started server process (foreground)"
     );
 
-    // Spawn background tasks to timestamp and write stdout/stderr to the log file.
     let log_path = log_file.to_path_buf();
 
     if let Some(stdout) = child.stdout.take() {
@@ -94,6 +111,42 @@ pub async fn start_server(
     Ok(child)
 }
 
+/// Detached mode: redirect stdout/stderr directly to the log file.
+/// The process survives after the CLI exits.
+async fn start_server_detached(
+    command: &str,
+    working_dir: &Path,
+    env: &HashMap<String, String>,
+    log_file: &Path,
+) -> Result<Child, ProcessError> {
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_file)
+        .map_err(ProcessError::SpawnFailed)?;
+    let stderr_file = file.try_clone().map_err(ProcessError::SpawnFailed)?;
+
+    let child = Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .current_dir(working_dir)
+        .envs(env)
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(file))
+        .stderr(Stdio::from(stderr_file))
+        .kill_on_drop(false)
+        .spawn()
+        .map_err(ProcessError::SpawnFailed)?;
+
+    tracing::info!(
+        pid = child.id().unwrap_or(0),
+        command = command,
+        "started server process (detached)"
+    );
+
+    Ok(child)
+}
+
 /// Read lines from an async reader, prepend timestamps, and append to the log file.
 async fn timestamp_pipe<R: tokio::io::AsyncRead + Unpin>(reader: R, log_path: &Path) {
     let mut lines = BufReader::new(reader).lines();
@@ -102,7 +155,6 @@ async fn timestamp_pipe<R: tokio::io::AsyncRead + Unpin>(reader: R, log_path: &P
             Ok(Some(line)) => {
                 let timestamp = chrono::Utc::now().to_rfc3339();
                 let formatted = format!("[{timestamp}] {line}\n");
-                // Open in append mode for each write to avoid holding the file lock.
                 if let Ok(mut file) = tokio::fs::OpenOptions::new()
                     .create(true)
                     .append(true)

--- a/crates/veld/src/commands/start.rs
+++ b/crates/veld/src/commands/start.rs
@@ -82,8 +82,10 @@ pub async fn run(
     let run_name_str = run_name.as_str();
 
     // Build the orchestrator.
+    let foreground = !detach && is_tty();
     let mut orchestrator = Orchestrator::new(config_path.clone(), config);
     orchestrator.set_debug(_debug);
+    orchestrator.set_foreground(foreground);
 
     println!(
         "{} Starting environment '{}'...",
@@ -139,8 +141,6 @@ pub async fn run(
             }
 
             // Foreground mode: tail logs and stop on Ctrl+C.
-            // Default to foreground when TTY, unless --detach is set.
-            let foreground = !detach && is_tty();
             if foreground {
                 println!();
                 output::print_info("Streaming logs (Ctrl+C to stop)...");


### PR DESCRIPTION
## Summary

PR #26 changed `start_server` to pipe stdout/stderr through tokio background tasks for timestamping. This broke detached mode: when the CLI exits, the tokio runtime shuts down, the pipe-reading tasks are dropped, the pipe write ends close, and the server processes receive SIGPIPE and die.

**Fix:** Two code paths in `start_server`:
- **Foreground mode** (`-f` / TTY): pipe through timestamping tasks (logs get ISO 8601 timestamps, process dies with CLI — intended)
- **Detached mode** (`-d` / non-TTY): redirect stdout/stderr directly to the log file via OS-level file descriptors (no timestamps, but process survives CLI exit)

The `Orchestrator` now tracks `foreground` mode and passes it through to `process::start_server`.

## Test plan

- [ ] `veld start -d` — processes survive after CLI exits, `veld status` shows healthy
- [ ] `veld start` (foreground/TTY) — logs stream with timestamps, Ctrl+C stops everything
- [ ] `veld stop` works after detached start
- [ ] `cargo clippy --all-targets` passes
- [ ] `cargo fmt --all -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)