### PR TITLE
fix: robust start/stop/status — stale runs and dead processes

### DIFF
--- a/crates/veld-core/src/orchestrator.rs
+++ b/crates/veld-core/src/orchestrator.rs
@@ -145,6 +145,11 @@ impl Orchestrator {
         selections: &[NodeSelection],
         run_name: &str,
     ) -> Result<RunState, OrchestratorError> {
+        // Clean up any stale run with the same name (kills processes, removes
+        // DNS/Caddy routes, clears state). This handles the case where a
+        // previous run was not properly cleaned up or the user reuses a name.
+        self.cleanup_stale_run(run_name).await;
+
         let resolved = graph::resolve_selections(selections, &self.config)?;
         let plan = graph::build_execution_plan(&resolved, &self.config)?;
 
@@ -627,6 +632,45 @@ impl Orchestrator {
         self.remove_from_registry(run_name);
 
         Ok(StopResult::Stopped)
+    }
+
+    /// Clean up a stale run with the given name if it exists in state.
+    /// Kills any live processes, removes DNS/Caddy routes, and clears state.
+    /// Errors are logged but never propagated — this is best-effort cleanup.
+    async fn cleanup_stale_run(&mut self, run_name: &str) {
+        let project_state = match ProjectState::load(&self.project_root) {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+
+        let run = match project_state.get_run(run_name) {
+            Some(r) => r,
+            None => return,
+        };
+
+        tracing::info!(run_name, "cleaning up stale run before starting");
+
+        // Kill any processes that are still alive.
+        for ns in run.nodes.values() {
+            if let Some(pid) = ns.pid {
+                if process::is_alive(pid) {
+                    let _ = process::kill_process(pid).await;
+                }
+            }
+            // Remove DNS + Caddy route.
+            if let Some(ref url_str) = ns.url {
+                let hostname = url_str.strip_prefix("https://").unwrap_or(url_str);
+                let _ = self.helper_client.remove_host(hostname).await;
+                let route_id = format!("veld-{}-{}-{}", run_name, ns.node_name, ns.variant);
+                let _ = self.helper_client.remove_route(&route_id).await;
+            }
+        }
+
+        // Remove from state and registry.
+        let mut project_state = project_state;
+        project_state.runs.remove(run_name);
+        let _ = project_state.save(&self.project_root);
+        self.remove_from_registry(run_name);
     }
 
     /// Run the `on_stop` hook for a node if one is defined in the config.

--- a/crates/veld/src/commands/status.rs
+++ b/crates/veld/src/commands/status.rs
@@ -1,4 +1,5 @@
 use veld_core::config;
+use veld_core::process;
 use veld_core::state::{NodeStatus, ProjectState, RunStatus};
 
 use crate::output;
@@ -29,15 +30,33 @@ pub async fn run(name: Option<String>, json: bool) -> i32 {
     let run_name = run_name.as_str();
 
     let run_state = match project_state.get_run(run_name) {
-        Some(r) => r,
+        Some(r) => r.clone(),
         None => {
             output::print_error(&format!("Run '{run_name}' not found."), json);
             return 1;
         }
     };
 
+    // Check PID liveness for each node and compute effective statuses.
+    let effective_statuses = compute_effective_statuses(&run_state);
+
     if json {
-        match serde_json::to_string_pretty(&run_state) {
+        // Build a modified run state with effective statuses for JSON output.
+        let mut run_for_json = run_state.clone();
+        for (key, effective) in &effective_statuses {
+            if let Some(ns) = run_for_json.nodes.get_mut(*key) {
+                ns.status = effective.clone();
+            }
+        }
+        // If any node is dead, mark the run as degraded (failed).
+        if effective_statuses
+            .values()
+            .any(|s| matches!(s, NodeStatus::Failed))
+            && run_for_json.status == RunStatus::Running
+        {
+            run_for_json.status = RunStatus::Failed;
+        }
+        match serde_json::to_string_pretty(&run_for_json) {
             Ok(s) => println!("{s}"),
             Err(e) => {
                 output::print_error(&format!("JSON serialization failed: {e}"), json);
@@ -45,16 +64,27 @@ pub async fn run(name: Option<String>, json: bool) -> i32 {
             }
         }
     } else {
+        // Check if any nodes are dead.
+        let has_dead = effective_statuses.values().any(|s| {
+            matches!(s, NodeStatus::Failed)
+                && run_state
+                    .nodes
+                    .values()
+                    .any(|ns| ns.status == NodeStatus::Healthy || ns.status == NodeStatus::Starting)
+        });
+
+        let run_status_display = if has_dead && run_state.status == RunStatus::Running {
+            output::red("degraded")
+        } else {
+            format_run_status(&run_state.status)
+        };
+
         println!(
             "{} {}",
             output::bold("Environment:"),
             output::cyan(run_name),
         );
-        println!(
-            "{} {}",
-            output::bold("State:"),
-            format_run_status(&run_state.status),
-        );
+        println!("{} {}", output::bold("State:"), run_status_display,);
         println!();
 
         let mut rows: Vec<Vec<String>> = Vec::new();
@@ -62,10 +92,17 @@ pub async fn run(name: Option<String>, json: bool) -> i32 {
         node_keys.sort();
         for key in node_keys {
             let ns = &run_state.nodes[key];
+            let effective = effective_statuses.get(key.as_str()).unwrap_or(&ns.status);
+            let status_str = if *effective != ns.status {
+                // The process died — show "dead" instead of the stored status.
+                format!("{} {}", output::cross(), output::red("dead"))
+            } else {
+                format_node_status(&ns.status)
+            };
             rows.push(vec![
                 ns.node_name.clone(),
                 ns.variant.clone(),
-                format_node_status(&ns.status),
+                status_str,
                 ns.url.clone().unwrap_or_default(),
             ]);
         }
@@ -74,6 +111,32 @@ pub async fn run(name: Option<String>, json: bool) -> i32 {
     }
 
     0
+}
+
+/// Check PID liveness for each node and return effective statuses.
+/// If a node is supposedly running but the process is dead, mark it as Failed.
+fn compute_effective_statuses(
+    run_state: &veld_core::state::RunState,
+) -> std::collections::HashMap<&str, NodeStatus> {
+    let mut result = std::collections::HashMap::new();
+    for (key, ns) in &run_state.nodes {
+        let effective = match ns.status {
+            NodeStatus::Healthy | NodeStatus::Starting | NodeStatus::HealthChecking => {
+                if let Some(pid) = ns.pid {
+                    if process::is_alive(pid) {
+                        ns.status.clone()
+                    } else {
+                        NodeStatus::Failed
+                    }
+                } else {
+                    ns.status.clone()
+                }
+            }
+            _ => ns.status.clone(),
+        };
+        result.insert(key.as_str(), effective);
+    }
+    result
 }
 
 fn format_run_status(status: &RunStatus) -> String {


### PR DESCRIPTION
## Summary
- **Stale run cleanup on start**: Before starting a run, `cleanup_stale_run()` kills leftover processes, removes stale Caddy routes/DNS entries, and clears state. This prevents "duplicate route ID" Caddy errors when reusing run names.
- **PID liveness checking in status**: `veld status` now checks whether each node's process is actually alive (via signal 0). Dead processes show as "dead" instead of stale "healthy". The overall run shows "degraded" when any node has died.
- **JSON output reflects live state**: JSON output from `veld status --json` also reports effective (live-checked) statuses.

## Test plan
- [ ] Start environment, kill a server process manually, run `veld status` — should show "dead"
- [ ] Start environment, stop it, start again with same name — should not get Caddy duplicate route errors
- [ ] `veld status --json` should show `"failed"` for dead processes
- [ ] CI passes (clippy, fmt, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)