### PR TITLE
fix: detached processes die immediately as zombies

### DIFF
--- a/crates/veld-core/src/orchestrator.rs
+++ b/crates/veld-core/src/orchestrator.rs
@@ -5,7 +5,6 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use thiserror::Error;
-use tokio::process::Child;
 use tracing;
 
 use crate::config::{self, Outputs, StepType, VeldConfig};
@@ -84,7 +83,7 @@ pub struct Orchestrator {
     pub port_allocator: PortAllocator,
     pub helper_client: HelperClient,
     /// Active child processes keyed by `"node:variant"`.
-    children: HashMap<String, Child>,
+    children: HashMap<String, process::ServerHandle>,
     /// Debug mode — writes orchestration trace to `veld-debug.log`.
     debug: bool,
     /// Debug log writer (created on demand when debug is true).
@@ -422,7 +421,7 @@ impl Orchestrator {
         // the OS level so the process survives after the CLI exits.
         let log_path = logging::log_file(&self.project_root, &run.name, &sel.node, &sel.variant);
 
-        let child = process::start_server(
+        let handle = process::start_server(
             &resolved_cmd,
             &self.project_root,
             &env,
@@ -430,11 +429,11 @@ impl Orchestrator {
             self.foreground,
         )
         .await?;
-        let pid = child.id().unwrap_or(0);
+        let pid = handle.pid();
         node_state.pid = Some(pid);
 
         self.children
-            .insert(RunState::node_key(&sel.node, &sel.variant), child);
+            .insert(RunState::node_key(&sel.node, &sel.variant), handle);
 
         // Health check.
         self.debug_log(&format!(

--- a/crates/veld-core/src/process.rs
+++ b/crates/veld-core/src/process.rs
@@ -37,24 +37,60 @@ pub struct BashOutput {
 }
 
 // ---------------------------------------------------------------------------
+// Server handle — abstracts over foreground (tokio Child) vs detached (PID only)
+// ---------------------------------------------------------------------------
+
+/// Handle to a spawned server process.
+///
+/// In foreground mode this wraps a `tokio::process::Child` so the orchestrator
+/// can manage the async I/O pipes.  In detached mode the process is fully
+/// decoupled from the tokio runtime — we only keep the PID.
+pub enum ServerHandle {
+    /// Foreground: tokio-managed child with piped stdout/stderr.
+    Foreground(Child),
+    /// Detached: process runs independently; only the PID is tracked.
+    Detached { pid: u32 },
+}
+
+impl ServerHandle {
+    /// Return the OS process ID.
+    pub fn pid(&self) -> u32 {
+        match self {
+            ServerHandle::Foreground(child) => child.id().unwrap_or(0),
+            ServerHandle::Detached { pid } => *pid,
+        }
+    }
+
+    /// Take the inner tokio `Child` if this is a foreground handle.
+    pub fn into_child(self) -> Option<Child> {
+        match self {
+            ServerHandle::Foreground(child) => Some(child),
+            ServerHandle::Detached { .. } => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Start a long-running server process
 // ---------------------------------------------------------------------------
 
-/// Spawn a long-running server process. Returns the `Child` handle.
+/// Spawn a long-running server process.
 ///
 /// When `foreground` is true, stdout/stderr are piped through background
 /// tasks that prepend ISO 8601 timestamps to each line. The process will
 /// die when the CLI exits (pipes close).
 ///
-/// When `foreground` is false (detached mode), stdout/stderr are redirected
-/// directly to the log file so the process survives after the CLI exits.
+/// When `foreground` is false (detached mode), the process is spawned via
+/// `std::process::Command` in its own process group so it is fully
+/// independent of the CLI process and the tokio runtime. stdout/stderr are
+/// redirected directly to the log file.
 pub async fn start_server(
     command: &str,
     working_dir: &Path,
     env: &HashMap<String, String>,
     log_file: &Path,
     foreground: bool,
-) -> Result<Child, ProcessError> {
+) -> Result<ServerHandle, ProcessError> {
     // Ensure log directory exists.
     if let Some(parent) = log_file.parent() {
         let _ = std::fs::create_dir_all(parent);
@@ -63,7 +99,7 @@ pub async fn start_server(
     if foreground {
         start_server_foreground(command, working_dir, env, log_file).await
     } else {
-        start_server_detached(command, working_dir, env, log_file).await
+        start_server_detached(command, working_dir, env, log_file)
     }
 }
 
@@ -73,7 +109,7 @@ async fn start_server_foreground(
     working_dir: &Path,
     env: &HashMap<String, String>,
     log_file: &Path,
-) -> Result<Child, ProcessError> {
+) -> Result<ServerHandle, ProcessError> {
     let mut child = Command::new("sh")
         .arg("-c")
         .arg(command)
@@ -108,17 +144,25 @@ async fn start_server_foreground(
         });
     }
 
-    Ok(child)
+    Ok(ServerHandle::Foreground(child))
 }
 
-/// Detached mode: redirect stdout/stderr directly to the log file.
-/// The process survives after the CLI exits.
-async fn start_server_detached(
+/// Detached mode: spawn via std::process::Command in its own process group.
+///
+/// Using `std::process::Command` (not tokio) avoids registering the child
+/// with tokio's SIGCHLD reaper, and `process_group(0)` ensures the process
+/// is in its own process group so it won't receive signals intended for the
+/// CLI (e.g. SIGHUP on terminal close, SIGINT from Ctrl-C).
+///
+/// The process survives after the CLI exits and is reparented to init/launchd.
+fn start_server_detached(
     command: &str,
     working_dir: &Path,
     env: &HashMap<String, String>,
     log_file: &Path,
-) -> Result<Child, ProcessError> {
+) -> Result<ServerHandle, ProcessError> {
+    use std::os::unix::process::CommandExt;
+
     let file = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
@@ -126,7 +170,7 @@ async fn start_server_detached(
         .map_err(ProcessError::SpawnFailed)?;
     let stderr_file = file.try_clone().map_err(ProcessError::SpawnFailed)?;
 
-    let child = Command::new("sh")
+    let child = std::process::Command::new("sh")
         .arg("-c")
         .arg(command)
         .current_dir(working_dir)
@@ -134,17 +178,24 @@ async fn start_server_detached(
         .stdin(Stdio::null())
         .stdout(Stdio::from(file))
         .stderr(Stdio::from(stderr_file))
-        .kill_on_drop(false)
+        .process_group(0) // own process group — immune to parent signals
         .spawn()
         .map_err(ProcessError::SpawnFailed)?;
 
+    let pid = child.id();
+
     tracing::info!(
-        pid = child.id().unwrap_or(0),
+        pid = pid,
         command = command,
-        "started server process (detached)"
+        "started server process (detached, pgid=own)"
     );
 
-    Ok(child)
+    // Intentionally drop the std Child handle. The process is fully
+    // independent — it will be reparented to init/launchd and reaped
+    // by the OS. We only track the PID for later stop/status checks.
+    drop(child);
+
+    Ok(ServerHandle::Detached { pid })
 }
 
 /// Read lines from an async reader, prepend timestamps, and append to the log file.


### PR DESCRIPTION
## Summary
- **Root cause**: Detached server processes were spawned via `tokio::process::Command`, which registers them with tokio's SIGCHLD reaper and keeps them in the parent's process group. This caused processes (especially Node.js/pnpm/tsx) to die immediately as zombies.
- **Fix**: Use `std::process::Command` for detached mode with `process_group(0)`, making the child fully independent of the CLI process and tokio runtime.
- Introduces `ServerHandle` enum to cleanly abstract over foreground (tokio `Child`) vs detached (PID-only) handles.

## What changed
- `start_server_detached` now uses `std::process::Command` (not tokio's)
- Child gets its own process group via `.process_group(0)` — immune to SIGHUP/SIGINT sent to the CLI
- `std::process::Child` handle is dropped immediately — process is reparented to init/launchd
- `ServerHandle` enum replaces raw `Child` in the orchestrator's children map

## Test plan
- [ ] `veld start` in detached mode — processes should survive and not become zombies
- [ ] `veld start` in foreground mode — still works with piped timestamps
- [ ] Node.js/pnpm/tsx processes should start and stay running in detached mode
- [ ] `veld stop` still correctly kills detached processes via PID
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)