### PR TITLE
fix: port allocator checks both IPv4 and IPv6 availability

### DIFF
--- a/crates/veld-core/src/health.rs
+++ b/crates/veld-core/src/health.rs
@@ -13,8 +13,8 @@ use crate::config::HealthCheck;
 
 #[derive(Debug, Error)]
 pub enum HealthError {
-    #[error("health check timed out after {timeout_seconds}s")]
-    Timeout { timeout_seconds: u64 },
+    #[error("health check timed out after {timeout_seconds}s{hint}")]
+    Timeout { timeout_seconds: u64, hint: String },
 
     #[error("port check failed: {0}")]
     PortCheckFailed(String),
@@ -31,25 +31,45 @@ pub enum HealthError {
 // ---------------------------------------------------------------------------
 
 /// Repeatedly try to connect to `port` on localhost until success or timeout.
+///
+/// Tries both IPv4 (127.0.0.1) and IPv6 (::1) on each attempt since modern
+/// runtimes (Node.js 18+, Next.js, etc.) may bind to either address family.
 pub async fn wait_for_port(port: u16, hc: &HealthCheck) -> Result<(), HealthError> {
     let deadline = Duration::from_secs(hc.timeout_seconds);
     let interval = Duration::from_millis(hc.interval_ms);
 
+    let ipv4: std::net::SocketAddr = ([127, 0, 0, 1], port).into();
+    let ipv6: std::net::SocketAddr = ([0, 0, 0, 0, 0, 0, 0, 1], port).into();
+
     let result = timeout(deadline, async {
         loop {
-            match TcpStream::connect(("127.0.0.1", port)).await {
-                Ok(_) => return Ok(()),
-                Err(_) => sleep(interval).await,
+            // Accept either IPv4 or IPv6 — whichever the process bound to.
+            if TcpStream::connect(ipv4).await.is_ok() || TcpStream::connect(ipv6).await.is_ok() {
+                return Ok(());
             }
+            sleep(interval).await;
         }
     })
     .await;
 
     match result {
         Ok(inner) => inner,
-        Err(_) => Err(HealthError::Timeout {
-            timeout_seconds: hc.timeout_seconds,
-        }),
+        Err(_) => {
+            // Before returning timeout, check if the port is in use by
+            // something other than the expected process (stale process hint).
+            let hint = if !crate::port::is_port_available(port) {
+                format!(
+                    " (note: port {port} is currently in use — \
+                     a stale process may be occupying it)"
+                )
+            } else {
+                String::new()
+            };
+            Err(HealthError::Timeout {
+                timeout_seconds: hc.timeout_seconds,
+                hint,
+            })
+        }
     }
 }
 
@@ -109,6 +129,7 @@ pub async fn wait_for_http(url: &str, hc: &HealthCheck) -> Result<(), HealthErro
         Ok(inner) => inner,
         Err(_) => Err(HealthError::Timeout {
             timeout_seconds: hc.timeout_seconds,
+            hint: String::new(),
         }),
     }
 }
@@ -162,6 +183,7 @@ pub async fn wait_for_bash_check(
         Ok(inner) => inner,
         Err(_) => Err(HealthError::Timeout {
             timeout_seconds: hc.timeout_seconds,
+            hint: String::new(),
         }),
     }
 }

--- a/crates/veld-core/src/port.rs
+++ b/crates/veld-core/src/port.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::net::TcpListener;
+use std::net::{SocketAddr, TcpListener};
 use std::sync::Mutex;
 
 use thiserror::Error;
@@ -78,7 +78,16 @@ impl Default for PortAllocator {
     }
 }
 
-/// Check whether a TCP port is available by attempting to bind.
+/// Check whether a TCP port is available by attempting to bind on both
+/// IPv4 (127.0.0.1) and IPv6 (::1).
+///
+/// Modern runtimes (Node.js 18+, Next.js, etc.) often default to IPv6.
+/// A stale process on `[::1]:port` would pass an IPv4-only check, so we
+/// must verify both address families.
 pub fn is_port_available(port: u16) -> bool {
-    TcpListener::bind(("127.0.0.1", port)).is_ok()
+    let ipv4: SocketAddr = ([127, 0, 0, 1], port).into();
+    let ipv6: SocketAddr = ([0, 0, 0, 0, 0, 0, 0, 1], port).into();
+
+    // Both must succeed — if either is in use, the port is occupied.
+    TcpListener::bind(ipv4).is_ok() && TcpListener::bind(ipv6).is_ok()
 }


### PR DESCRIPTION
## Summary
Closes #31

- **Root cause**: `is_port_available` only tested `127.0.0.1` (IPv4). Modern runtimes (Node.js 18+, Next.js) default to IPv6 (`::1`), so a stale process on `[::1]:port` passed the IPv4-only check — Veld allocated the occupied port and the health check timed out with a confusing error.
- **Port allocator**: Now checks both `127.0.0.1` and `::1` — both must be free for a port to be considered available.
- **Health check**: `wait_for_port` now tries connecting on both IPv4 and IPv6 on each attempt.
- **Better error**: On timeout, checks if the port is occupied and adds a hint like `(note: port 19001 is currently in use — a stale process may be occupying it)`.

## Test plan
- [ ] Start a process on `::1:19001`, run `veld start` — should skip 19001 and allocate 19002
- [ ] Start a process on `127.0.0.1:19001`, run `veld start` — should skip 19001
- [ ] No stale processes — should allocate 19001 normally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)