### PR TITLE
Auto-generate fun run names, default to detached mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ nix = { version = "0.29", features = ["signal", "process", "net"] }
 reqwest = { version = "0.12", features = ["rustls-tls", "json"], default-features = false }
 sha2 = "0.10"
 base64 = "0.22"
+petname = "2"

--- a/crates/veld-core/Cargo.toml
+++ b/crates/veld-core/Cargo.toml
@@ -20,3 +20,4 @@ nix = { workspace = true }
 reqwest = { workspace = true }
 sha2 = { workspace = true }
 base64 = { workspace = true }
+petname = { workspace = true }

--- a/crates/veld-core/src/url.rs
+++ b/crates/veld-core/src/url.rs
@@ -46,6 +46,18 @@ pub fn slugify(input: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
+// Run name generation
+// ---------------------------------------------------------------------------
+
+/// Generate a random, human-friendly run name (e.g. "swift-falcon").
+///
+/// Uses two-word petnames (adjective-noun) with hyphen separators,
+/// similar to Docker container names.
+pub fn generate_run_name() -> String {
+    petname::petname(2, "-").unwrap_or_else(|| "default".to_owned())
+}
+
+// ---------------------------------------------------------------------------
 // URL template resolution (cascade: variant > node > project > built-in)
 // ---------------------------------------------------------------------------
 

--- a/crates/veld/src/commands/start.rs
+++ b/crates/veld/src/commands/start.rs
@@ -5,18 +5,18 @@ use veld_core::config::VeldConfig;
 use veld_core::graph::{self, NodeSelection};
 use veld_core::logging;
 use veld_core::orchestrator::Orchestrator;
-use veld_core::url::slugify;
+use veld_core::url::generate_run_name;
 
 use tokio::io::{AsyncBufReadExt, AsyncSeekExt, BufReader};
 
 use crate::output::{self, is_tty};
 
-/// `veld start [node:variant...] [--preset <n>] [--name <n>] [-d] [--debug]`
+/// `veld start [node:variant...] [--preset <n>] [--name <n>] [-a] [--debug]`
 pub async fn run(
     selections: Vec<String>,
     preset: Option<String>,
     name: Option<String>,
-    detach: bool,
+    attach: bool,
     _debug: bool,
 ) -> i32 {
     if !super::require_setup(false).await {
@@ -69,28 +69,20 @@ pub async fn run(
 
     let run_name = match name {
         Some(ref n) => n.clone(),
-        None => {
-            // Use the project root (directory containing veld.json) for the default name.
-            let project_root = veld_core::config::project_root(&config_path);
-            let dir_name = project_root
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("default");
-            slugify(dir_name)
-        }
+        None => generate_run_name(),
     };
     let run_name_str = run_name.as_str();
 
     // Build the orchestrator.
-    let foreground = !detach && is_tty();
+    let foreground = attach && is_tty();
     let mut orchestrator = Orchestrator::new(config_path.clone(), config);
     orchestrator.set_debug(_debug);
     orchestrator.set_foreground(foreground);
 
     println!(
-        "{} Starting environment '{}'...",
+        "{} Starting environment {}...",
         output::bold("veld"),
-        run_name_str,
+        output::bold(&format!("'{run_name_str}'")),
     );
     println!();
 

--- a/crates/veld/src/main.rs
+++ b/crates/veld/src/main.rs
@@ -35,9 +35,9 @@ enum Command {
         #[arg(long)]
         name: Option<String>,
 
-        /// Run in the background (default when not a TTY).
-        #[arg(long, short = 'd')]
-        detach: bool,
+        /// Stay in the foreground and stream logs (default is detached).
+        #[arg(long, short = 'a')]
+        attach: bool,
 
         /// Enable debug logging for the started environment.
         #[arg(long)]
@@ -227,9 +227,9 @@ async fn main() {
             selections,
             preset,
             name,
-            detach,
+            attach,
             debug,
-        } => commands::start::run(selections, preset, name, detach, debug).await,
+        } => commands::start::run(selections, preset, name, attach, debug).await,
 
         Command::Stop { name, all } => commands::stop::run(name, all).await,
 


### PR DESCRIPTION
## Summary
- Run names are now auto-generated petnames (e.g. `swift-falcon`, `calm-otter`) instead of directory names
- `veld start` now detaches by default — agents don't need `-d` anymore
- New `--attach` / `-a` flag for humans who want foreground + log streaming
- Run name is always printed prominently on start so agents can parse and reference it

## Rationale
Agents are first-class users of Veld. They always use detached mode and parse output — making detach the default removes friction. Fun petnames make runs easy to distinguish and reference.

## Test plan
- [ ] `veld start` with no `--name` → generates a random two-word name
- [ ] `veld start --name custom` → uses "custom", prints it prominently
- [ ] `veld start` → detaches by default (exits after startup)
- [ ] `veld start --attach` → stays in foreground, streams logs, stops on Ctrl+C
- [ ] Multiple starts → each gets a unique petname

🤖 Generated with [Claude Code](https://claude.com/claude-code)