### PR TITLE
feat: show node outputs in start/status, enforce conventional commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,38 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  commits:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Validate PR commits follow conventional format
+        run: |
+          set -e
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          PATTERN='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?: .+'
+          FAILED=0
+          while IFS= read -r sha; do
+            MSG=$(git log --format='%s' -1 "$sha")
+            if ! echo "$MSG" | grep -qE "$PATTERN"; then
+              echo "❌ $sha: $MSG"
+              FAILED=1
+            else
+              echo "✅ $sha: $MSG"
+            fi
+          done < <(git rev-list "$BASE".."$HEAD")
+          if [ "$FAILED" -eq 1 ]; then
+            echo ""
+            echo "Some commits do not follow conventional commit format."
+            echo "Expected: type(scope)?: description"
+            echo "Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert"
+            exit 1
+          fi
+
   schema:
     name: Validate JSON Schema
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.0.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args:
+          - feat
+          - fix
+          - docs
+          - style
+          - refactor
+          - perf
+          - test
+          - build
+          - ci
+          - chore
+          - revert

--- a/crates/veld/src/commands/start.rs
+++ b/crates/veld/src/commands/start.rs
@@ -112,6 +112,29 @@ pub async fn run(
                     output::step(i + 1, total, &padded),
                     output::dim(&detail),
                 );
+
+                // Show non-trivial outputs (skip port/url which are already shown).
+                let skip_keys = ["port", "url", "exit_code"];
+                let mut output_keys: Vec<&String> = ns
+                    .outputs
+                    .keys()
+                    .filter(|k| !skip_keys.contains(&k.as_str()))
+                    .collect();
+                output_keys.sort();
+                for okey in output_keys {
+                    let val = if ns.sensitive_keys.contains(okey) {
+                        "***".to_owned()
+                    } else {
+                        ns.outputs[okey].clone()
+                    };
+                    eprintln!(
+                        "{}  {} {}={}",
+                        output::pad_right("", 36),
+                        output::dim("↳"),
+                        output::dim(okey),
+                        output::dim(&val),
+                    );
+                }
             }
 
             // Print URLs on success.

--- a/crates/veld/src/commands/status.rs
+++ b/crates/veld/src/commands/status.rs
@@ -4,8 +4,8 @@ use veld_core::state::{NodeStatus, ProjectState, RunStatus};
 
 use crate::output;
 
-/// `veld status [--name <n>] [--json]`
-pub async fn run(name: Option<String>, json: bool) -> i32 {
+/// `veld status [--name <n>] [--outputs] [--json]`
+pub async fn run(name: Option<String>, show_outputs: bool, json: bool) -> i32 {
     if !super::require_setup(json).await {
         return 1;
     }
@@ -90,8 +90,8 @@ pub async fn run(name: Option<String>, json: bool) -> i32 {
         let mut rows: Vec<Vec<String>> = Vec::new();
         let mut node_keys: Vec<&String> = run_state.nodes.keys().collect();
         node_keys.sort();
-        for key in node_keys {
-            let ns = &run_state.nodes[key];
+        for key in &node_keys {
+            let ns = &run_state.nodes[*key];
             let effective = effective_statuses.get(key.as_str()).unwrap_or(&ns.status);
             let status_str = if *effective != ns.status {
                 // The process died — show "dead" instead of the stored status.
@@ -108,6 +108,38 @@ pub async fn run(name: Option<String>, json: bool) -> i32 {
         }
 
         output::print_table(&["NODE", "VARIANT", "STATUS", "URL"], &rows);
+
+        // Show outputs per node when --outputs is passed.
+        if show_outputs {
+            println!();
+            println!("{}", output::bold("Outputs:"));
+            let mut any = false;
+            for key in &node_keys {
+                let ns = &run_state.nodes[*key];
+                if ns.outputs.is_empty() {
+                    continue;
+                }
+                any = true;
+                println!();
+                println!(
+                    "  {}",
+                    output::cyan(&format!("{}:{}", ns.node_name, ns.variant))
+                );
+                let mut okeys: Vec<&String> = ns.outputs.keys().collect();
+                okeys.sort();
+                for okey in okeys {
+                    let val = if ns.sensitive_keys.contains(okey) {
+                        "***".to_owned()
+                    } else {
+                        ns.outputs[okey].clone()
+                    };
+                    println!("    {} = {}", output::dim(okey), val);
+                }
+            }
+            if !any {
+                println!("  {}", output::dim("No outputs recorded."));
+            }
+        }
     }
 
     0

--- a/crates/veld/src/main.rs
+++ b/crates/veld/src/main.rs
@@ -83,6 +83,10 @@ enum Command {
         #[arg(long)]
         name: Option<String>,
 
+        /// Show node outputs (environment variables, ports, etc.).
+        #[arg(long)]
+        outputs: bool,
+
         /// Output as JSON.
         #[arg(long)]
         json: bool,
@@ -237,7 +241,11 @@ async fn main() {
 
         Command::Runs { name, json } => commands::runs::list(name.as_deref(), json).await,
 
-        Command::Status { name, json } => commands::status::run(name, json).await,
+        Command::Status {
+            name,
+            outputs,
+            json,
+        } => commands::status::run(name, outputs, json).await,
 
         Command::Urls { name, json } => commands::urls::run(name, json).await,
 


### PR DESCRIPTION
## Summary
- `veld start` now prints non-sensitive outputs inline after each node (e.g. `DATABASE_URL=postgres://...`), sensitive outputs masked with `***`
- `veld status --outputs` shows all persisted outputs per node for post-hoc debugging
- JSON output from `veld status --json` already includes outputs (no change needed)
- New CI job validates all PR commits follow conventional commit format
- Added `.pre-commit-config.yaml` with `conventional-pre-commit` hook for local validation

## Example output (start)
```
[1/3] database:local               ✓ https://db.local
                                      ↳ DATABASE_URL=postgres://localhost:19001/dev
                                      ↳ SECRET_KEY=***
[2/3] backend:local                 ✓ https://api.local
[3/3] frontend:local                ✓ https://app.local
```

## Test plan
- [ ] `veld start` with command steps that produce outputs → outputs shown inline
- [ ] Sensitive outputs masked with `***` in start output
- [ ] `veld status --outputs` shows outputs per node
- [ ] `veld status --outputs --json` includes outputs in JSON
- [ ] CI conventional commit check passes for this PR
- [ ] CI conventional commit check would fail for non-conventional messages
- [ ] `pre-commit install --hook-type commit-msg` works locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)