### PR TITLE
feat: strict output filtering for command steps

### DIFF
--- a/crates/veld-core/src/config.rs
+++ b/crates/veld-core/src/config.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Deserializer, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
@@ -119,6 +119,11 @@ pub struct VariantConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sensitive_outputs: Option<Vec<String>>,
 
+    /// When true (default), fail if a command produces outputs not declared in `outputs`.
+    /// Set to `false` to allow undeclared outputs to pass through.
+    #[serde(default = "default_strict_outputs")]
+    pub strict_outputs: bool,
+
     /// Idempotency verify command (command steps only).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub verify: Option<String>,
@@ -144,6 +149,16 @@ pub enum Outputs {
     Declared(Vec<String>),
     /// Synthetic output templates for `start_server` steps.
     Synthetic(HashMap<String, String>),
+}
+
+impl Outputs {
+    /// Return the set of declared output key names.
+    pub fn declared_keys(&self) -> HashSet<&str> {
+        match self {
+            Outputs::Declared(keys) => keys.iter().map(|s| s.as_str()).collect(),
+            Outputs::Synthetic(map) => map.keys().map(|s| s.as_str()).collect(),
+        }
+    }
 }
 
 impl<'de> Deserialize<'de> for Outputs {
@@ -221,6 +236,10 @@ pub struct HealthCheck {
     /// Milliseconds between checks (default 1000).
     #[serde(default = "default_interval")]
     pub interval_ms: u64,
+}
+
+fn default_strict_outputs() -> bool {
+    true
 }
 
 fn default_timeout() -> u64 {

--- a/crates/veld-core/src/graph.rs
+++ b/crates/veld-core/src/graph.rs
@@ -55,6 +55,15 @@ pub enum GraphError {
 
     #[error("unknown preset \"{0}\"")]
     UnknownPreset(String),
+
+    #[error(
+        "node \"{node}:{variant}\" has sensitive_outputs {undeclared:?} not declared in outputs"
+    )]
+    UndeclaredSensitiveOutputs {
+        node: String,
+        variant: String,
+        undeclared: Vec<String>,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -164,7 +173,10 @@ pub fn build_execution_plan(
     // 3. Validate variable references for ambiguity.
     validate_variable_references(&all_nodes, config)?;
 
-    // 4. Kahn's algorithm for topological sort into stages.
+    // 4. Validate sensitive_outputs are subsets of declared outputs.
+    validate_sensitive_outputs(&all_nodes, config)?;
+
+    // 5. Kahn's algorithm for topological sort into stages.
     topological_stages(&all_nodes, &deps)
 }
 
@@ -316,6 +328,36 @@ fn validate_variable_references(
         }
     }
 
+    Ok(())
+}
+
+/// Validate that sensitive_outputs are subsets of declared outputs.
+fn validate_sensitive_outputs(
+    all_nodes: &[NodeSelection],
+    config: &VeldConfig,
+) -> Result<(), GraphError> {
+    for sel in all_nodes {
+        let variant_cfg = &config.nodes[&sel.node].variants[&sel.variant];
+        if let Some(ref sensitive) = variant_cfg.sensitive_outputs {
+            let declared = variant_cfg
+                .outputs
+                .as_ref()
+                .map(|o| o.declared_keys())
+                .unwrap_or_default();
+            let undeclared: Vec<String> = sensitive
+                .iter()
+                .filter(|k| !declared.contains(k.as_str()))
+                .cloned()
+                .collect();
+            if !undeclared.is_empty() {
+                return Err(GraphError::UndeclaredSensitiveOutputs {
+                    node: sel.node.clone(),
+                    variant: sel.variant.clone(),
+                    undeclared,
+                });
+            }
+        }
+    }
     Ok(())
 }
 

--- a/crates/veld-core/src/orchestrator.rs
+++ b/crates/veld-core/src/orchestrator.rs
@@ -541,8 +541,33 @@ impl Orchestrator {
         node_state
             .outputs
             .insert("exit_code".to_owned(), result.exit_code.to_string());
-        for (k, v) in result.outputs {
-            node_state.outputs.insert(k, v);
+
+        // Filter outputs against declared keys.
+        let declared_keys = variant_cfg
+            .outputs
+            .as_ref()
+            .map(|o| o.declared_keys())
+            .unwrap_or_default();
+
+        for (k, v) in &result.outputs {
+            if declared_keys.contains(k.as_str()) {
+                node_state.outputs.insert(k.clone(), v.clone());
+            } else if variant_cfg.strict_outputs {
+                return Err(OrchestratorError::NodeFailed {
+                    node: sel.node.clone(),
+                    variant: sel.variant.clone(),
+                    reason: format!(
+                        "undeclared output \"{k}\" — add it to \"outputs\" or set \"strict_outputs\": false"
+                    ),
+                });
+            } else {
+                tracing::warn!(
+                    node = sel.node,
+                    variant = sel.variant,
+                    key = k,
+                    "ignoring undeclared output"
+                );
+            }
         }
 
         if result.exit_code == 0 {

--- a/schema/v1/veld.schema.json
+++ b/schema/v1/veld.schema.json
@@ -144,6 +144,11 @@
           },
           "description": "Output keys whose values are sensitive. These are masked in logs and encrypted at rest."
         },
+        "strict_outputs": {
+          "type": "boolean",
+          "default": true,
+          "description": "When true (default), fail if the command produces VELD_OUTPUT keys not declared in \"outputs\". Set to false to silently ignore undeclared outputs."
+        },
         "verify": {
           "type": "string",
           "description": "Idempotency verification command. Only applies to \"command\" type variants. If this command exits 0, the step is considered already complete and is skipped."


### PR DESCRIPTION
## Summary
- Command steps now only capture `VELD_OUTPUT` keys that are declared in the variant's `outputs` array
- **Strict by default**: undeclared outputs fail the step with an actionable error: `undeclared output "FOO" — add it to "outputs" or set "strict_outputs": false`
- `"strict_outputs": false` on a variant opts out — undeclared outputs are silently dropped (warning logged)
- Graph validation now checks that `sensitive_outputs` keys are a subset of declared `outputs`
- `exit_code` is always captured (built-in, no declaration needed)

## Rationale
The veld config should be the source of truth. If a command produces outputs, they must be declared — this prevents accidental leakage of sensitive data and makes the config self-documenting.

## Test plan
- [ ] Command with declared outputs → only those are captured
- [ ] Command with undeclared outputs + strict (default) → fails with error
- [ ] Command with undeclared outputs + `strict_outputs: false` → silently dropped
- [ ] `sensitive_outputs` not in `outputs` → graph validation error
- [ ] `exit_code` always captured regardless of declarations
- [ ] Schema validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)