### PR TITLE
fix: clean up processes on Ctrl+C during veld start

### DIFF
--- a/crates/veld-core/src/orchestrator.rs
+++ b/crates/veld-core/src/orchestrator.rs
@@ -508,6 +508,16 @@ impl Orchestrator {
         self.children
             .insert(RunState::node_key(&sel.node, &sel.variant), handle);
 
+        // Checkpoint: persist the PID immediately so Ctrl+C during health
+        // checks still allows `veld stop` to find and kill this process.
+        {
+            let key = RunState::node_key(&sel.node, &sel.variant);
+            let mut checkpoint_run = run.clone();
+            checkpoint_run.execution_order.push(key.clone());
+            checkpoint_run.nodes.insert(key, node_state.clone());
+            let _ = self.save_state(&checkpoint_run);
+        }
+
         // Health check — inlined to emit progress events between phases.
         self.debug_log(&format!(
             "{}:{} — process started (pid {}), beginning health checks",

--- a/crates/veld/src/commands/start.rs
+++ b/crates/veld/src/commands/start.rs
@@ -102,8 +102,10 @@ pub async fn run(
             let _ = progress_handle.await;
             eprintln!();
             output::print_info("Interrupted — stopping partially started environment...");
-            let _ = orchestrator.stop(run_name_str).await;
-            output::print_success(&format!("Environment '{}' cleaned up.", run_name_str));
+            match orchestrator.stop(run_name_str).await {
+                Ok(_) => output::print_success(&format!("Environment '{}' cleaned up.", run_name_str)),
+                Err(e) => output::print_error(&format!("Cleanup failed: {e}"), false),
+            }
             return 130; // Standard exit code for SIGINT
         }
     };


### PR DESCRIPTION
## Summary
- Interrupting `veld start` with Ctrl+C mid-startup no longer leaves orphaned processes
- Partial state is saved after each stage so PIDs are always on disk for `veld stop` to find
- Ctrl+C is intercepted during startup to run graceful cleanup (kill processes, remove DNS/Caddy routes)

## Changes
- **`crates/veld-core/src/orchestrator.rs`**: Save partial `RunState` after each stage completes (incremental persistence)
- **`crates/veld/src/commands/start.rs`**: Wrap `orchestrator.start()` in `tokio::select!` with `ctrl_c()` handler that calls `orchestrator.stop()`

## Root cause
Processes are spawned in their own process group (`process_group(0)`) so they survive CLI exit. State was only saved once after all stages completed. If Ctrl+C killed the CLI mid-startup, processes continued running but had no state record — `veld stop` couldn't find them.

## Test plan
- [x] `cargo test` — all 20 tests pass
- [x] `cargo clippy` — no warnings
- [ ] CI green
- [ ] Manual: start a multi-node environment, Ctrl+C during health check, verify processes are killed

🤖 Generated with [Claude Code](https://claude.com/claude-code)