### PR TITLE
feat: GC route/DNS cleanup, auto-GC, and update check banner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1696,6 +1696,7 @@ dependencies = [
  "chrono",
  "clap",
  "dirs",
+ "libc",
  "serde_json",
  "tokio",
  "tracing",

--- a/crates/veld-daemon/src/gc.rs
+++ b/crates/veld-daemon/src/gc.rs
@@ -1,5 +1,6 @@
 use tracing::{debug, info, warn};
-use veld_core::state::{GlobalRegistry, ProjectState, RunStatus};
+use veld_core::helper::HelperClient;
+use veld_core::state::{GlobalRegistry, ProjectState, RunState, RunStatus};
 
 /// Interval between garbage-collection runs (seconds).
 const GC_INTERVAL_SECS: u64 = 600; // 10 minutes
@@ -22,8 +23,11 @@ pub async fn run_gc_scheduler() {
         match run_gc().await {
             Ok(summary) => {
                 info!(
-                    "gc complete: {} stale entries removed, {} orphans killed, {} log files pruned",
-                    summary.stale_removed, summary.orphans_killed, summary.logs_pruned
+                    "gc complete: {} stale removed, {} orphans killed, {} logs pruned, {} routes cleaned",
+                    summary.stale_removed,
+                    summary.orphans_killed,
+                    summary.logs_pruned,
+                    summary.routes_cleaned
                 );
             }
             Err(e) => {
@@ -39,11 +43,13 @@ pub struct GcSummary {
     pub stale_removed: usize,
     pub orphans_killed: usize,
     pub logs_pruned: usize,
+    pub routes_cleaned: usize,
 }
 
 /// Perform a single garbage-collection pass.
 pub async fn run_gc() -> anyhow::Result<GcSummary> {
     let mut summary = GcSummary::default();
+    let helper = HelperClient::default_client();
 
     let mut registry = GlobalRegistry::load()?;
     let mut registry_changed = false;
@@ -108,6 +114,11 @@ pub async fn run_gc() -> anyhow::Result<GcSummary> {
                                         }
                                     }
                                 }
+
+                                // Clean up Caddy routes and DNS entries.
+                                summary.routes_cleaned +=
+                                    cleanup_routes_and_dns(run, run_name, &helper).await;
+
                                 project_changed = true;
                             }
 
@@ -132,6 +143,10 @@ pub async fn run_gc() -> anyhow::Result<GcSummary> {
                                     run_name,
                                     project_root.display()
                                 );
+                                // Best-effort route/DNS cleanup before removing state.
+                                summary.routes_cleaned +=
+                                    cleanup_routes_and_dns(run_state, run_name, &helper).await;
+
                                 project_state.runs.remove(run_name);
                                 project_changed = true;
                                 // Will remove from registry below.
@@ -196,6 +211,29 @@ pub async fn run_gc() -> anyhow::Result<GcSummary> {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// Remove Caddy routes and DNS entries for all nodes in a run.
+/// Returns the number of routes/hosts cleaned up.
+async fn cleanup_routes_and_dns(run: &RunState, run_name: &str, helper: &HelperClient) -> usize {
+    let mut cleaned = 0;
+    for ns in run.nodes.values() {
+        // Remove Caddy route (ID follows the convention from orchestrator).
+        let route_id = format!("veld-{}-{}-{}", run_name, ns.node_name, ns.variant);
+        if helper.remove_route(&route_id).await.is_ok() {
+            debug!("removed Caddy route: {route_id}");
+            cleaned += 1;
+        }
+
+        // Remove DNS host entry.
+        if let Some(ref url_str) = ns.url {
+            let hostname = url_str.strip_prefix("https://").unwrap_or(url_str);
+            if helper.remove_host(hostname).await.is_ok() {
+                debug!("removed DNS entry: {hostname}");
+            }
+        }
+    }
+    cleaned
+}
 
 fn is_process_alive(pid: u32) -> bool {
     unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }

--- a/crates/veld/Cargo.toml
+++ b/crates/veld/Cargo.toml
@@ -19,3 +19,4 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 chrono = { workspace = true }
 dirs = { workspace = true }
+libc = "0.2"

--- a/crates/veld/src/commands/gc.rs
+++ b/crates/veld/src/commands/gc.rs
@@ -1,10 +1,13 @@
-use veld_core::state::GlobalRegistry;
+use veld_core::helper::HelperClient;
+use veld_core::state::{GlobalRegistry, NodeStatus, ProjectState, RunStatus};
 
 use crate::output;
 
-/// `veld gc` -- garbage-collect stale state, logs and orphaned processes.
+/// `veld gc` -- garbage-collect stale state, logs, orphaned processes, and routes.
 pub async fn run() -> i32 {
-    output::print_info("Garbage collecting stale state...");
+    output::print_info("Running garbage collection...");
+
+    let helper = HelperClient::default_client();
 
     let mut registry = match GlobalRegistry::load() {
         Ok(r) => r,
@@ -14,26 +17,108 @@ pub async fn run() -> i32 {
         }
     };
 
-    let before = registry.projects.len();
+    let mut registry_changed = false;
+    let mut orphans_cleaned = 0usize;
+    let mut routes_cleaned = 0usize;
 
     // Remove entries whose project root no longer exists.
+    let before = registry.projects.len();
     registry
         .projects
         .retain(|_, entry| entry.project_root.exists());
-
-    let removed = before - registry.projects.len();
-
-    if let Err(e) = registry.save() {
-        output::print_error(&format!("Failed to save registry: {e}"), false);
-        return 1;
+    let projects_removed = before - registry.projects.len();
+    if projects_removed > 0 {
+        registry_changed = true;
     }
 
-    if removed > 0 {
-        output::print_success(&format!(
-            "Removed {removed} stale project(s) from registry."
-        ));
-    } else {
+    // Process each project: find orphaned runs and clean them up.
+    for reg_entry in registry.projects.values_mut() {
+        let project_root = reg_entry.project_root.clone();
+        let mut project_state = match ProjectState::load(&project_root) {
+            Ok(ps) => ps,
+            Err(_) => continue,
+        };
+        let mut project_changed = false;
+
+        let run_names: Vec<String> = project_state.runs.keys().cloned().collect();
+
+        for run_name in &run_names {
+            let is_orphan = {
+                let run = match project_state.get_run(run_name) {
+                    Some(r) => r,
+                    None => continue,
+                };
+                match run.status {
+                    RunStatus::Running | RunStatus::Starting => {
+                        // Check if all processes are dead.
+                        let has_pids = run.nodes.values().any(|n| n.pid.is_some());
+                        let all_dead = run
+                            .nodes
+                            .values()
+                            .filter_map(|n| n.pid)
+                            .all(|pid| unsafe { libc::kill(pid as libc::pid_t, 0) != 0 });
+                        has_pids && all_dead
+                    }
+                    _ => false,
+                }
+            };
+
+            if is_orphan {
+                if let Some(run) = project_state.get_run_mut(run_name) {
+                    // Clean up Caddy routes and DNS entries.
+                    for ns in run.nodes.values() {
+                        let route_id = format!("veld-{}-{}-{}", run_name, ns.node_name, ns.variant);
+                        if helper.remove_route(&route_id).await.is_ok() {
+                            routes_cleaned += 1;
+                        }
+                        if let Some(ref url_str) = ns.url {
+                            let hostname = url_str.strip_prefix("https://").unwrap_or(url_str);
+                            let _ = helper.remove_host(hostname).await;
+                        }
+                    }
+
+                    run.status = RunStatus::Stopped;
+                    run.stopped_at = Some(chrono::Utc::now());
+                    for node in run.nodes.values_mut() {
+                        node.status = NodeStatus::Stopped;
+                    }
+                    project_changed = true;
+                    orphans_cleaned += 1;
+                }
+
+                if let Some(info) = reg_entry.runs.get_mut(run_name) {
+                    info.status = RunStatus::Stopped;
+                    info.urls.clear();
+                    registry_changed = true;
+                }
+            }
+        }
+
+        if project_changed {
+            let _ = project_state.save(&project_root);
+        }
+    }
+
+    if registry_changed {
+        let _ = registry.save();
+    }
+
+    // Print summary.
+    let mut parts = Vec::new();
+    if projects_removed > 0 {
+        parts.push(format!("{projects_removed} stale project(s) removed"));
+    }
+    if orphans_cleaned > 0 {
+        parts.push(format!("{orphans_cleaned} orphan run(s) cleaned"));
+    }
+    if routes_cleaned > 0 {
+        parts.push(format!("{routes_cleaned} route(s) removed"));
+    }
+
+    if parts.is_empty() {
         output::print_success("Nothing to clean up.");
+    } else {
+        output::print_success(&parts.join(", "));
     }
 
     0

--- a/crates/veld/src/main.rs
+++ b/crates/veld/src/main.rs
@@ -1,6 +1,9 @@
 mod commands;
 mod output;
 
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime};
+
 use clap::{CommandFactory, Parser, Subcommand};
 
 /// Veld -- local development environment orchestrator.
@@ -226,6 +229,16 @@ async fn main() {
         }
     }
 
+    // Auto-GC: trigger background GC if it hasn't run in >30 minutes.
+    if needs_version_check {
+        maybe_auto_gc().await;
+    }
+
+    // Update check: show banner if a newer version is available (once per day).
+    if needs_version_check {
+        maybe_show_update_banner().await;
+    }
+
     let exit_code = match command {
         Command::Start {
             selections,
@@ -283,4 +296,188 @@ async fn main() {
     };
 
     std::process::exit(exit_code);
+}
+
+// ---------------------------------------------------------------------------
+// Auto-GC
+// ---------------------------------------------------------------------------
+
+/// Path to the timestamp file that records the last auto-GC run.
+fn auto_gc_stamp_path() -> Option<PathBuf> {
+    dirs::data_dir().map(|d| d.join("veld").join(".last-gc"))
+}
+
+/// Minimum interval between auto-GC runs.
+const AUTO_GC_INTERVAL: Duration = Duration::from_secs(30 * 60); // 30 minutes
+
+/// Trigger a background GC if the last run was more than AUTO_GC_INTERVAL ago.
+async fn maybe_auto_gc() {
+    let stamp = match auto_gc_stamp_path() {
+        Some(p) => p,
+        None => return,
+    };
+
+    if let Ok(meta) = std::fs::metadata(&stamp) {
+        if let Ok(modified) = meta.modified() {
+            if SystemTime::now()
+                .duration_since(modified)
+                .unwrap_or_default()
+                < AUTO_GC_INTERVAL
+            {
+                return; // Recent enough, skip.
+            }
+        }
+    }
+
+    // Touch the stamp before running to avoid concurrent triggers.
+    if let Some(parent) = stamp.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(&stamp, "");
+
+    // Run GC in background (non-blocking).
+    tokio::spawn(async {
+        let registry = match veld_core::state::GlobalRegistry::load() {
+            Ok(r) => r,
+            Err(_) => return,
+        };
+
+        let helper = veld_core::helper::HelperClient::default_client();
+
+        for reg_entry in registry.projects.values() {
+            let project_root = &reg_entry.project_root;
+            let mut project_state = match veld_core::state::ProjectState::load(project_root) {
+                Ok(ps) => ps,
+                Err(_) => continue,
+            };
+
+            let mut changed = false;
+            let run_names: Vec<String> = project_state.runs.keys().cloned().collect();
+
+            for run_name in &run_names {
+                let should_clean = {
+                    let run = match project_state.get_run(run_name) {
+                        Some(r) => r,
+                        None => continue,
+                    };
+                    match run.status {
+                        veld_core::state::RunStatus::Running => {
+                            // Check if all processes are dead.
+                            run.nodes
+                                .values()
+                                .filter_map(|n| n.pid)
+                                .all(|pid| unsafe { libc::kill(pid as libc::pid_t, 0) != 0 })
+                                && run.nodes.values().any(|n| n.pid.is_some())
+                        }
+                        _ => false,
+                    }
+                };
+
+                if should_clean {
+                    if let Some(run) = project_state.get_run_mut(run_name) {
+                        // Clean up routes/DNS for each node.
+                        for ns in run.nodes.values() {
+                            let route_id =
+                                format!("veld-{}-{}-{}", run_name, ns.node_name, ns.variant);
+                            let _ = helper.remove_route(&route_id).await;
+                            if let Some(ref url_str) = ns.url {
+                                let hostname = url_str.strip_prefix("https://").unwrap_or(url_str);
+                                let _ = helper.remove_host(hostname).await;
+                            }
+                        }
+                        run.status = veld_core::state::RunStatus::Stopped;
+                        run.stopped_at = Some(chrono::Utc::now());
+                        for node in run.nodes.values_mut() {
+                            node.status = veld_core::state::NodeStatus::Stopped;
+                        }
+                        changed = true;
+                    }
+                }
+            }
+
+            if changed {
+                let _ = project_state.save(project_root);
+            }
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Update check banner
+// ---------------------------------------------------------------------------
+
+/// Path to the timestamp file that records the last update check.
+fn update_check_stamp_path() -> Option<PathBuf> {
+    dirs::data_dir().map(|d| d.join("veld").join(".last-update-check"))
+}
+
+/// Path to a file caching the latest known version.
+fn update_cache_path() -> Option<PathBuf> {
+    dirs::data_dir().map(|d| d.join("veld").join(".latest-version"))
+}
+
+/// Minimum interval between update checks.
+const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60); // 24 hours
+
+/// Check for a new version and print a banner if one is available.
+/// This is non-blocking: if the check was done recently, it reads from cache.
+/// Otherwise, it spawns a background fetch and shows cached results.
+async fn maybe_show_update_banner() {
+    let stamp = match update_check_stamp_path() {
+        Some(p) => p,
+        None => return,
+    };
+    let cache = match update_cache_path() {
+        Some(p) => p,
+        None => return,
+    };
+
+    let needs_fetch = match std::fs::metadata(&stamp) {
+        Ok(meta) => match meta.modified() {
+            Ok(modified) => {
+                SystemTime::now()
+                    .duration_since(modified)
+                    .unwrap_or_default()
+                    >= UPDATE_CHECK_INTERVAL
+            }
+            Err(_) => true,
+        },
+        Err(_) => true,
+    };
+
+    if needs_fetch {
+        // Touch stamp to avoid concurrent checks.
+        if let Some(parent) = stamp.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let _ = std::fs::write(&stamp, "");
+
+        // Fetch in background, write to cache.
+        let cache_path = cache.clone();
+        tokio::spawn(async move {
+            if let Ok(Some(version)) = veld_core::setup::check_update().await {
+                let _ = std::fs::write(&cache_path, &version);
+            } else {
+                // No update or error — clear cache.
+                let _ = std::fs::remove_file(&cache_path);
+            }
+        });
+    }
+
+    // Show banner from cache (may be from a previous check).
+    if let Ok(latest) = std::fs::read_to_string(&cache) {
+        let latest = latest.trim();
+        let current = env!("CARGO_PKG_VERSION");
+        if !latest.is_empty() && latest != current {
+            eprintln!();
+            eprintln!(
+                "  {} {} → {}. Run {} to upgrade.",
+                output::bold("Update available:"),
+                output::dim(current),
+                output::green(latest),
+                output::bold("`veld update`"),
+            );
+            eprintln!();
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- **GC cleans Caddy routes & DNS**: Both daemon GC and CLI `veld gc` now remove orphaned Caddy routes and DNS entries via HelperClient when cleaning up stale/orphaned runs
- **Auto-GC on CLI invocation**: Background GC triggers automatically when running `veld start/stop/restart/status/urls/logs` if last GC was >30 minutes ago (timestamp file in data dir)
- **Update check banner**: Shows "Update available: x.y.z → a.b.c" banner when a newer version exists, checked at most once per 24 hours with cached results

## Test plan
- [ ] Run `veld gc` manually and verify it reports cleaned routes
- [ ] Start and stop an environment, then kill processes manually — verify `veld gc` detects orphans and cleans routes
- [ ] Run any CLI command twice within 30 minutes — verify auto-GC only triggers once
- [ ] Verify update banner appears when cached version differs from current

🤖 Generated with [Claude Code](https://claude.com/claude-code)