### PR TITLE
docs: add MIT license, contribution guidelines, update README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to Veld
+
+Veld is 100% vibe coded with [Claude Code](https://claude.com/claude-code). The first well-working version was shipped in 3 days — entirely through agentic contributions. We want to keep it that way.
+
+## We only accept agentic contributions
+
+This means: your PR should be authored, reviewed, or substantially driven by an AI coding agent (Claude Code, Cursor, Copilot Workspace, Aider, etc.). We're not gatekeeping which tool you use — just that you're using one.
+
+Why? Because that's how this project was built, and it's how we believe modern software should be maintained. If an agent can't understand the codebase well enough to make a change, that's a signal the codebase needs to be clearer — not that we need more manual labor.
+
+## How to contribute
+
+1. **Fork the repo** and create a branch from `main`.
+2. **Use an AI coding agent** to implement your changes.
+3. **Follow conventional commits** — we use [Conventional Commits](https://www.conventionalcommits.org/) for semantic versioning. Prefix your commit messages with `feat:`, `fix:`, `docs:`, `chore:`, etc.
+4. **Make sure CI passes** — `cargo fmt`, `cargo clippy`, and `cargo test` must all be green.
+5. **Open a PR** with a clear description of what changed and why.
+
+## Development setup
+
+```sh
+git clone https://github.com/prosperity-solutions/veld.git
+cd veld
+cargo build
+cargo test
+```
+
+The workspace has four crates:
+
+| Crate | Description |
+|-------|-------------|
+| `veld` | CLI binary |
+| `veld-core` | Shared library (config, orchestrator, state, health checks) |
+| `veld-helper` | Privileged daemon for DNS/Caddy management |
+| `veld-daemon` | User-space daemon for health monitoring and GC |
+
+## Guidelines
+
+- Keep PRs focused — one feature or fix per PR.
+- Don't break existing behavior without discussion.
+- Add tests where it makes sense, but don't over-test trivial code.
+- If CI fails, fix it before requesting review.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Prosperity Solutions
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Veld
 
+> This fucking thing is 100% vibe coded with [Claude Code](https://claude.com/claude-code).
+
 Local development environment orchestrator for monorepos. Spin up fully configured preview environments with real HTTPS URLs from a single command.
 
 ```sh
@@ -177,6 +179,10 @@ Caddy handles HTTPS termination and reverse proxying. Its internal CA is trusted
 - Ports 80, 443, and 2019 available
 - sudo access once for `veld setup`
 
+## Contributing
+
+We only accept agentic contributions — see [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+
 ## License
 
-MIT
+[MIT](LICENSE)


### PR DESCRIPTION
## Summary
- Added `LICENSE` file (MIT)
- Added `CONTRIBUTING.md` — agentic contributions only policy, conventional commits, dev setup guide
- Updated `README.md` with the vibe-coded declaration and link to contributing guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)