### PR TITLE
fix: use veld.oss.life.li URLs and fix /health content-type

### DIFF
--- a/crates/veld-core/src/setup.rs
+++ b/crates/veld-core/src/setup.rs
@@ -705,7 +705,7 @@ fn is_newer(latest: &str, current: &str) -> bool {
 
 /// Download and run the install script to update to the given version.
 pub async fn perform_update(version: &str) -> Result<(), anyhow::Error> {
-    let install_url = format!("https://raw.githubusercontent.com/{GITHUB_REPO}/main/install.sh");
+    let install_url = "https://veld.oss.life.li/get".to_string();
 
     let client = reqwest::Client::builder()
         .user_agent(format!("veld/{}", env!("CARGO_PKG_VERSION")))

--- a/crates/veld/src/commands/init.rs
+++ b/crates/veld/src/commands/init.rs
@@ -9,7 +9,7 @@ use crate::output;
 // ---------------------------------------------------------------------------
 
 const INIT_TEMPLATE: &str = r#"{
-  "$schema": "https://veld.dev/schema/v1.json",
+  "$schema": "https://veld.oss.life.li/schema/v1/veld.schema.json",
   "schemaVersion": "1",
   "name": "my-project",
   "url_template": "{service}.{run}.{project}.localhost",
@@ -522,7 +522,7 @@ fn generate_veld_json(
 ) -> String {
     let mut json = String::new();
     json.push_str("{\n");
-    json.push_str("  \"$schema\": \"https://veld.dev/schema/v1.json\",\n");
+    json.push_str("  \"$schema\": \"https://veld.oss.life.li/schema/v1/veld.schema.json\",\n");
     json.push_str("  \"schemaVersion\": \"1\",\n");
     json.push_str(&format!("  \"name\": \"{}\",\n", escape_json(project_name)));
     json.push_str(&format!(
@@ -869,7 +869,7 @@ pub async fn run() -> i32 {
         // No services detected/selected: write basic template with project name
         format!(
             r#"{{
-  "$schema": "https://veld.dev/schema/v1.json",
+  "$schema": "https://veld.oss.life.li/schema/v1/veld.schema.json",
   "schemaVersion": "1",
   "name": "{}",
   "url_template": "{}",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,7 @@ All relative paths in the configuration resolve relative to the directory contai
 
 ```json
 {
-  "$schema": "https://veld.dev/schema/v1/veld.schema.json",
+  "$schema": "https://veld.oss.life.li/schema/v1/veld.schema.json",
   "schemaVersion": "1",
   "name": "my-app",
   "nodes": {
@@ -622,7 +622,7 @@ Below is a realistic `veld.json` for a monorepo with a database, backend API, fr
 
 ```json
 {
-  "$schema": "https://veld.dev/schema/v1/veld.schema.json",
+  "$schema": "https://veld.oss.life.li/schema/v1/veld.schema.json",
   "schemaVersion": "1",
   "name": "my-project",
   "url_template": "{service}.{branch ?? run}.my-project.localhost",
@@ -826,7 +826,7 @@ Veld provides a JSON Schema for editor autocompletion and validation. Add the `$
 
 ```json
 {
-  "$schema": "https://veld.dev/schema/v1/veld.schema.json",
+  "$schema": "https://veld.oss.life.li/schema/v1/veld.schema.json",
   ...
 }
 ```

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 # Veld installer — detects OS/arch and installs the latest release.
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/prosperity-solutions/veld/main/install.sh | bash
+#   curl -fsSL https://veld.oss.life.li/get | bash
 #
 # Options (via env vars):
 #   VELD_VERSION=1.0.0    Install a specific version (default: latest)

--- a/schema/v1/veld.schema.json
+++ b/schema/v1/veld.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://veld.dev/schema/v1/veld.schema.json",
+  "$id": "https://veld.oss.life.li/schema/v1/veld.schema.json",
   "title": "Veld Project Configuration",
   "description": "Configuration file for a Veld local development environment. Place this as veld.json in your project root.",
   "type": "object",

--- a/website/nginx.conf
+++ b/website/nginx.conf
@@ -48,8 +48,8 @@ server {
     }
 
     # Health check
-    location /health {
+    location = /health {
+        default_type text/plain;
         return 200 'ok';
-        add_header Content-Type text/plain;
     }
 }


### PR DESCRIPTION
## Summary
- **Fix /health endpoint**: `add_header` after `return` in nginx never executes — moved `default_type text/plain` before `return 200` so browsers get the correct content-type instead of downloading
- **Canonical install URL**: `veld update` now fetches via `veld.oss.life.li/get` instead of hitting `raw.githubusercontent.com` directly — single point of indirection
- **Schema URLs**: Replaced all stale `veld.dev` references with `veld.oss.life.li` across schema JSON, `veld init` templates, and docs

## Files changed
- `website/nginx.conf` — /health content-type fix
- `crates/veld-core/src/setup.rs` — install URL
- `crates/veld/src/commands/init.rs` — schema URL in templates
- `schema/v1/veld.schema.json` — schema $id
- `docs/configuration.md` — schema URLs in examples
- `install.sh` — comment URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)