### PR TITLE
feat: in-browser feedback overlay with CLI integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +351,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,6 +521,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +539,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -742,6 +807,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,6 +849,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,6 +868,12 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -1175,6 +1258,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,6 +1370,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1406,6 +1513,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1510,6 +1630,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1548,6 +1669,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1719,6 +1841,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "slug",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",
@@ -1730,6 +1853,7 @@ name = "veld-daemon"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "axum",
  "chrono",
  "dirs",
  "libc",
@@ -1739,6 +1863,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "veld-core",
 ]
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ veld stop --name dev
 | `veld nodes` | List all nodes and variants |
 | `veld presets` | List presets |
 | `veld runs` | List all runs |
+| `veld feedback [--name <n>] [--wait] [--history]` | Read or wait for in-browser feedback |
 | `veld gc` | Clean up stale state and logs |
 | `veld setup` | One-time system setup |
 | `veld init` | Create a new veld.json |

--- a/crates/veld-core/Cargo.toml
+++ b/crates/veld-core/Cargo.toml
@@ -21,3 +21,6 @@ reqwest = { workspace = true }
 sha2 = { workspace = true }
 base64 = { workspace = true }
 petname = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/veld-core/src/feedback.rs
+++ b/crates/veld-core/src/feedback.rs
@@ -1,0 +1,228 @@
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeedbackComment {
+    pub id: String,
+    pub page_url: String,
+    pub element_selector: Option<String>,
+    pub selected_text: Option<String>,
+    pub comment: String,
+    pub position: Option<ElementPosition>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ElementPosition {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeedbackBatch {
+    pub id: String,
+    pub run_name: String,
+    pub comments: Vec<FeedbackComment>,
+    pub submitted_at: DateTime<Utc>,
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+/// File-based feedback store. Layout:
+///   .veld/feedback/{run_name}/drafts.json   — current draft comments
+///   .veld/feedback/{run_name}/batches/      — submitted batches
+pub struct FeedbackStore {
+    drafts_path: PathBuf,
+    batches_dir: PathBuf,
+    run_name: String,
+}
+
+impl FeedbackStore {
+    pub fn new(project_root: &Path, run_name: &str) -> Self {
+        let base = project_root.join(".veld").join("feedback").join(run_name);
+        Self {
+            drafts_path: base.join("drafts.json"),
+            batches_dir: base.join("batches"),
+            run_name: run_name.to_owned(),
+        }
+    }
+
+    fn ensure_dirs(&self) -> anyhow::Result<()> {
+        if let Some(parent) = self.drafts_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::create_dir_all(&self.batches_dir)?;
+        Ok(())
+    }
+
+    // -- Drafts ---------------------------------------------------------------
+
+    pub fn get_comments(&self) -> anyhow::Result<Vec<FeedbackComment>> {
+        if !self.drafts_path.exists() {
+            return Ok(Vec::new());
+        }
+        let data = std::fs::read_to_string(&self.drafts_path)?;
+        let comments: Vec<FeedbackComment> = serde_json::from_str(&data)?;
+        Ok(comments)
+    }
+
+    pub fn save_comment(&self, comment: &FeedbackComment) -> anyhow::Result<()> {
+        self.ensure_dirs()?;
+        let mut comments = self.get_comments()?;
+        comments.push(comment.clone());
+        std::fs::write(&self.drafts_path, serde_json::to_string_pretty(&comments)?)?;
+        Ok(())
+    }
+
+    pub fn update_comment(&self, updated: &FeedbackComment) -> anyhow::Result<bool> {
+        let mut comments = self.get_comments()?;
+        if let Some(existing) = comments.iter_mut().find(|c| c.id == updated.id) {
+            *existing = updated.clone();
+            std::fs::write(&self.drafts_path, serde_json::to_string_pretty(&comments)?)?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    pub fn delete_comment(&self, id: &str) -> anyhow::Result<bool> {
+        let mut comments = self.get_comments()?;
+        let before = comments.len();
+        comments.retain(|c| c.id != id);
+        if comments.len() == before {
+            return Ok(false);
+        }
+        std::fs::write(&self.drafts_path, serde_json::to_string_pretty(&comments)?)?;
+        Ok(true)
+    }
+
+    // -- Batches --------------------------------------------------------------
+
+    pub fn submit_batch(&self) -> anyhow::Result<FeedbackBatch> {
+        self.ensure_dirs()?;
+        let comments = self.get_comments()?;
+        let batch = FeedbackBatch {
+            id: Uuid::new_v4().to_string(),
+            run_name: self.run_name.clone(),
+            comments,
+            submitted_at: Utc::now(),
+        };
+        let batch_path = self.batches_dir.join(format!("{}.json", batch.id));
+        std::fs::write(&batch_path, serde_json::to_string_pretty(&batch)?)?;
+        // Clear drafts after submit.
+        std::fs::write(&self.drafts_path, "[]")?;
+        Ok(batch)
+    }
+
+    pub fn get_batches(&self) -> anyhow::Result<Vec<FeedbackBatch>> {
+        if !self.batches_dir.exists() {
+            return Ok(Vec::new());
+        }
+        let mut batches = Vec::new();
+        for entry in std::fs::read_dir(&self.batches_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().is_some_and(|e| e == "json") {
+                let data = std::fs::read_to_string(&path)?;
+                if let Ok(batch) = serde_json::from_str::<FeedbackBatch>(&data) {
+                    batches.push(batch);
+                }
+            }
+        }
+        batches.sort_by(|a, b| a.submitted_at.cmp(&b.submitted_at));
+        Ok(batches)
+    }
+
+    pub fn get_latest_batch(&self) -> anyhow::Result<Option<FeedbackBatch>> {
+        let batches = self.get_batches()?;
+        Ok(batches.into_iter().last())
+    }
+
+    pub fn get_batches_since(&self, since: DateTime<Utc>) -> anyhow::Result<Vec<FeedbackBatch>> {
+        let batches = self.get_batches()?;
+        Ok(batches
+            .into_iter()
+            .filter(|b| b.submitted_at > since)
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_comment(text: &str) -> FeedbackComment {
+        FeedbackComment {
+            id: Uuid::new_v4().to_string(),
+            page_url: "https://example.com".into(),
+            element_selector: Some("div.main".into()),
+            selected_text: None,
+            comment: text.into(),
+            position: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_crud_comments() {
+        let tmp = TempDir::new().unwrap();
+        let store = FeedbackStore::new(tmp.path(), "test-run");
+
+        assert!(store.get_comments().unwrap().is_empty());
+
+        let c1 = make_comment("first");
+        store.save_comment(&c1).unwrap();
+        assert_eq!(store.get_comments().unwrap().len(), 1);
+
+        let c2 = make_comment("second");
+        store.save_comment(&c2).unwrap();
+        assert_eq!(store.get_comments().unwrap().len(), 2);
+
+        let mut updated = c1.clone();
+        updated.comment = "updated first".into();
+        assert!(store.update_comment(&updated).unwrap());
+
+        let comments = store.get_comments().unwrap();
+        assert_eq!(comments[0].comment, "updated first");
+
+        assert!(store.delete_comment(&c2.id).unwrap());
+        assert_eq!(store.get_comments().unwrap().len(), 1);
+
+        assert!(!store.delete_comment("nonexistent").unwrap());
+    }
+
+    #[test]
+    fn test_submit_batch() {
+        let tmp = TempDir::new().unwrap();
+        let store = FeedbackStore::new(tmp.path(), "test-run");
+
+        store.save_comment(&make_comment("a")).unwrap();
+        store.save_comment(&make_comment("b")).unwrap();
+
+        let batch = store.submit_batch().unwrap();
+        assert_eq!(batch.comments.len(), 2);
+        assert_eq!(batch.run_name, "test-run");
+
+        // Drafts should be cleared after submit.
+        assert!(store.get_comments().unwrap().is_empty());
+
+        // Batch should be retrievable.
+        let batches = store.get_batches().unwrap();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].id, batch.id);
+    }
+}

--- a/crates/veld-core/src/lib.rs
+++ b/crates/veld-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod feedback;
 pub mod graph;
 pub mod health;
 pub mod helper;

--- a/crates/veld-core/src/orchestrator.rs
+++ b/crates/veld-core/src/orchestrator.rs
@@ -459,11 +459,14 @@ impl Orchestrator {
         if let Err(e) = self.helper_client.add_host(&node_url, "127.0.0.1").await {
             tracing::warn!(error = %e, "failed to add DNS host via helper");
         }
-        let route = serde_json::json!({
+        let mut route = serde_json::json!({
             "route_id": format!("veld-{}-{}-{}", run.name, sel.node, sel.variant),
             "hostname": &node_url,
             "upstream": format!("localhost:{port}"),
         });
+        // Include feedback proxy upstream so Caddy routes /__veld__/* to the
+        // daemon's feedback HTTP server.
+        route["feedback_upstream"] = serde_json::json!("localhost:19899");
         if let Err(e) = self.helper_client.add_route(route).await {
             tracing::warn!(error = %e, "failed to add Caddy route via helper");
         }

--- a/crates/veld-daemon/Cargo.toml
+++ b/crates/veld-daemon/Cargo.toml
@@ -21,3 +21,5 @@ tracing-subscriber = { workspace = true }
 chrono = { workspace = true }
 dirs = { workspace = true }
 libc = "0.2"
+axum = "0.8"
+uuid = { workspace = true }

--- a/crates/veld-daemon/src/feedback_assets.rs
+++ b/crates/veld-daemon/src/feedback_assets.rs
@@ -1,0 +1,949 @@
+//! Feedback overlay assets served by the feedback HTTP server.
+
+/// HTML page that registers the feedback Service Worker.
+pub const INSTALLER_HTML: &str = r###"
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Veld Feedback</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      display: flex; align-items: center; justify-content: center;
+      min-height: 100vh; background: #0f172a; color: #e2e8f0;
+    }
+    .msg { text-align: center; }
+    .msg h1 { font-size: 1.25rem; font-weight: 500; margin-bottom: 0.5rem; }
+    .msg p { font-size: 0.875rem; color: #94a3b8; }
+    .error { color: #f87171; display: none; margin-top: 1rem; font-size: 0.875rem; }
+  </style>
+</head>
+<body>
+  <div class="msg">
+    <h1>Enabling Veld Feedback&hellip;</h1>
+    <p>Registering the feedback service worker.</p>
+    <p class="error" id="err"></p>
+  </div>
+  <script>
+    (function () {
+      if (!("serviceWorker" in navigator)) {
+        document.getElementById("err").textContent = "Service Workers are not supported in this browser.";
+        document.getElementById("err").style.display = "block";
+        return;
+      }
+      navigator.serviceWorker.register("/__veld__/sw.js", { scope: "/" })
+        .then(function () { window.location.href = "/"; })
+        .catch(function (e) {
+          var el = document.getElementById("err");
+          el.textContent = "Failed to register service worker: " + e.message;
+          el.style.display = "block";
+        });
+    })();
+  </script>
+</body>
+</html>
+"###;
+
+/// Service Worker that injects the feedback script into HTML responses.
+pub const SERVICE_WORKER_JS: &str = r###"
+// Veld Feedback Service Worker
+// Intercepts navigation requests and injects the feedback overlay script.
+
+self.addEventListener("install", function () {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", function (event) {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("fetch", function (event) {
+  if (event.request.mode !== "navigate") {
+    return;
+  }
+
+  event.respondWith(
+    fetch(event.request).then(function (response) {
+      var ct = response.headers.get("content-type") || "";
+      if (!ct.includes("text/html")) {
+        return response;
+      }
+
+      return response.text().then(function (html) {
+        var script = '<script src="/__veld__/feedback/script.js"><\/script>';
+        if (html.indexOf("/__veld__/feedback/script.js") !== -1) {
+          // Script already present, do not inject again.
+          return new Response(html, {
+            status: response.status,
+            statusText: response.statusText,
+            headers: response.headers
+          });
+        }
+        var idx = html.lastIndexOf("</body>");
+        if (idx !== -1) {
+          html = html.slice(0, idx) + script + "\n" + html.slice(idx);
+        } else {
+          html = html + script;
+        }
+        return new Response(html, {
+          status: response.status,
+          statusText: response.statusText,
+          headers: response.headers
+        });
+      });
+    })
+  );
+});
+"###;
+
+/// Self-contained feedback overlay UI script.
+pub const OVERLAY_JS: &str = r###"
+// ---------------------------------------------------------------------------
+// Veld Feedback Overlay
+// Self-contained feedback UI injected into the host page via the Service Worker.
+// All DOM elements and styles are created dynamically. No external dependencies.
+// ---------------------------------------------------------------------------
+
+(function () {
+  "use strict";
+
+  // Guard: only initialise once.
+  if (window.__veld_feedback_initialised) return;
+  window.__veld_feedback_initialised = true;
+
+  // ---------- constants ---------------------------------------------------
+
+  var API = "/__veld__/feedback/api";
+  var Z = 999999;
+  var PREFIX = "veld-feedback-";
+
+  // ---------- state -------------------------------------------------------
+
+  var __veld_comments = [];      // array of comment objects
+  var __veld_nextLocalId = 1;    // local counter for new drafts
+  var __veld_feedbackMode = false;
+  var __veld_hoveredEl = null;
+  var __veld_panelOpen = false;
+  var __veld_activePopover = null;
+
+  // ---------- helpers -----------------------------------------------------
+
+  /** Generate a reasonably unique CSS selector for an element. */
+  function selectorFor(el) {
+    if (el.id) return "#" + CSS.escape(el.id);
+    var parts = [];
+    var cur = el;
+    while (cur && cur !== document.body && cur !== document.documentElement) {
+      var seg = cur.tagName.toLowerCase();
+      if (cur.id) {
+        parts.unshift("#" + CSS.escape(cur.id));
+        break;
+      }
+      if (cur.className && typeof cur.className === "string") {
+        var classes = cur.className.trim().split(/\s+/).filter(function (c) {
+          return c && !c.startsWith(PREFIX);
+        });
+        if (classes.length) {
+          seg += "." + classes.map(CSS.escape).join(".");
+        }
+      }
+      var parent = cur.parentElement;
+      if (parent) {
+        var siblings = Array.from(parent.children).filter(function (s) {
+          return s.tagName === cur.tagName;
+        });
+        if (siblings.length > 1) {
+          seg += ":nth-child(" + (Array.from(parent.children).indexOf(cur) + 1) + ")";
+        }
+      }
+      parts.unshift(seg);
+      cur = parent;
+    }
+    return parts.join(" > ");
+  }
+
+  /** Shortcut to create an element with optional classes and text. */
+  function mkEl(tag, cls, text) {
+    var el = document.createElement(tag);
+    if (cls) el.className = PREFIX + cls;
+    if (text !== undefined) el.textContent = text;
+    return el;
+  }
+
+  /** POST / PUT / DELETE JSON helper. */
+  function api(method, path, body) {
+    var opts = {
+      method: method,
+      headers: { "Content-Type": "application/json" }
+    };
+    if (body !== undefined) opts.body = JSON.stringify(body);
+    return fetch(API + path, opts).then(function (r) {
+      if (!r.ok) throw new Error("API " + method + " " + path + " failed: " + r.status);
+      if (r.status === 204) return null;
+      return r.json();
+    });
+  }
+
+  /** Show a brief toast notification. */
+  function toast(msg, isError) {
+    var t = mkEl("div", "toast", msg);
+    if (isError) t.style.background = "#dc2626";
+    document.body.appendChild(t);
+    requestAnimationFrame(function () { t.classList.add(PREFIX + "toast-show"); });
+    setTimeout(function () {
+      t.classList.remove(PREFIX + "toast-show");
+      setTimeout(function () { t.remove(); }, 300);
+    }, 2800);
+  }
+
+  /** Rect of an element relative to the document. */
+  function docRect(el) {
+    var r = el.getBoundingClientRect();
+    return {
+      x: r.left + window.scrollX,
+      y: r.top + window.scrollY,
+      width: r.width,
+      height: r.height
+    };
+  }
+
+  // ---------- styles ------------------------------------------------------
+
+  function injectStyles() {
+    if (document.getElementById(PREFIX + "styles")) return;
+    var style = document.createElement("style");
+    style.id = PREFIX + "styles";
+    style.textContent = [
+      // CSS custom properties
+      ":root {",
+      "  --vf-primary: #3b82f6;",
+      "  --vf-primary-hover: #2563eb;",
+      "  --vf-danger: #ef4444;",
+      "  --vf-bg-dark: #1e293b;",
+      "  --vf-bg-card: #273449;",
+      "  --vf-text: #f1f5f9;",
+      "  --vf-text-muted: #94a3b8;",
+      "  --vf-border: #334155;",
+      "  --vf-shadow: 0 8px 30px rgba(0,0,0,.35);",
+      "  --vf-radius: 10px;",
+      "  --vf-z: " + Z + ";",
+      "}",
+
+      // Toast
+      "." + PREFIX + "toast {",
+      "  position: fixed; bottom: 100px; left: 50%; transform: translateX(-50%) translateY(20px);",
+      "  background: var(--vf-primary); color: #fff; padding: 10px 22px; border-radius: 8px;",
+      "  font: 500 14px/1.4 -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;",
+      "  z-index: calc(var(--vf-z) + 10); opacity: 0; transition: opacity .3s, transform .3s;",
+      "  pointer-events: none; white-space: nowrap;",
+      "}",
+      "." + PREFIX + "toast-show { opacity: 1; transform: translateX(-50%) translateY(0); }",
+
+      // FAB container
+      "." + PREFIX + "fab-container {",
+      "  position: fixed; bottom: 24px; right: 24px; display: flex; align-items: center;",
+      "  gap: 10px; z-index: var(--vf-z);",
+      "}",
+
+      // FAB
+      "." + PREFIX + "fab {",
+      "  width: 54px; height: 54px; border-radius: 50%; border: none; cursor: pointer;",
+      "  background: var(--vf-primary); color: #fff; font-size: 24px; display: flex;",
+      "  align-items: center; justify-content: center; box-shadow: var(--vf-shadow);",
+      "  transition: background .2s, transform .15s; position: relative;",
+      "}",
+      "." + PREFIX + "fab:hover { background: var(--vf-primary-hover); transform: scale(1.07); }",
+      "." + PREFIX + "fab-active { background: var(--vf-danger) !important; }",
+      "." + PREFIX + "fab-active:hover { background: #dc2626 !important; }",
+
+      // Badge
+      "." + PREFIX + "badge {",
+      "  position: absolute; top: -4px; right: -4px; min-width: 20px; height: 20px;",
+      "  border-radius: 10px; background: var(--vf-danger); color: #fff; font-size: 11px;",
+      "  font-weight: 700; display: flex; align-items: center; justify-content: center;",
+      "  padding: 0 5px; pointer-events: none;",
+      "}",
+      "." + PREFIX + "badge-hidden { display: none; }",
+
+      // Panel toggle button (list icon)
+      "." + PREFIX + "panel-btn {",
+      "  width: 40px; height: 40px; border-radius: 50%; border: none; cursor: pointer;",
+      "  background: var(--vf-bg-dark); color: var(--vf-text); font-size: 18px;",
+      "  display: flex; align-items: center; justify-content: center;",
+      "  box-shadow: var(--vf-shadow); transition: background .2s;",
+      "}",
+      "." + PREFIX + "panel-btn:hover { background: var(--vf-bg-card); }",
+
+      // Feedback mode overlay
+      "." + PREFIX + "overlay {",
+      "  position: fixed; inset: 0; z-index: calc(var(--vf-z) - 2);",
+      "  background: rgba(15,23,42,.12); pointer-events: none; display: none;",
+      "}",
+      "." + PREFIX + "overlay-active { display: block; }",
+
+      // Hover outline
+      "." + PREFIX + "hover-outline {",
+      "  position: absolute; border: 2px dashed var(--vf-primary); pointer-events: none;",
+      "  z-index: calc(var(--vf-z) - 1); border-radius: 3px;",
+      "  transition: top .1s, left .1s, width .1s, height .1s;",
+      "  display: none;",
+      "}",
+
+      // Popover (comment create / detail)
+      "." + PREFIX + "popover {",
+      "  position: absolute; z-index: var(--vf-z); width: 320px;",
+      "  background: var(--vf-bg-dark); color: var(--vf-text); border-radius: var(--vf-radius);",
+      "  box-shadow: var(--vf-shadow); font: 14px/1.5 -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;",
+      "  overflow: hidden; animation: " + PREFIX + "fadeIn .15s ease;",
+      "}",
+      "@keyframes " + PREFIX + "fadeIn { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: translateY(0); } }",
+
+      "." + PREFIX + "popover-header {",
+      "  padding: 10px 14px; background: var(--vf-bg-card); font-size: 12px;",
+      "  color: var(--vf-text-muted); white-space: nowrap; overflow: hidden;",
+      "  text-overflow: ellipsis; border-bottom: 1px solid var(--vf-border);",
+      "}",
+      "." + PREFIX + "popover-body { padding: 14px; }",
+
+      "." + PREFIX + "textarea {",
+      "  width: 100%; min-height: 80px; resize: vertical; background: var(--vf-bg-card);",
+      "  color: var(--vf-text); border: 1px solid var(--vf-border); border-radius: 6px;",
+      "  padding: 8px 10px; font: inherit; outline: none;",
+      "}",
+      "." + PREFIX + "textarea:focus { border-color: var(--vf-primary); }",
+
+      "." + PREFIX + "popover-actions {",
+      "  display: flex; gap: 8px; justify-content: flex-end; margin-top: 10px;",
+      "}",
+
+      "." + PREFIX + "btn {",
+      "  padding: 6px 14px; border-radius: 6px; border: none; cursor: pointer;",
+      "  font: 500 13px/1.4 inherit; transition: background .15s;",
+      "}",
+      "." + PREFIX + "btn-primary { background: var(--vf-primary); color: #fff; }",
+      "." + PREFIX + "btn-primary:hover { background: var(--vf-primary-hover); }",
+      "." + PREFIX + "btn-secondary { background: var(--vf-border); color: var(--vf-text); }",
+      "." + PREFIX + "btn-secondary:hover { background: #475569; }",
+      "." + PREFIX + "btn-danger { background: var(--vf-danger); color: #fff; }",
+      "." + PREFIX + "btn-danger:hover { background: #dc2626; }",
+      "." + PREFIX + "btn-sm { padding: 4px 10px; font-size: 12px; }",
+
+      // Pins
+      "." + PREFIX + "pin {",
+      "  position: absolute; z-index: calc(var(--vf-z) - 1); width: 26px; height: 26px;",
+      "  border-radius: 50%; background: var(--vf-primary); color: #fff; font-size: 12px;",
+      "  font-weight: 700; display: flex; align-items: center; justify-content: center;",
+      "  cursor: pointer; box-shadow: 0 2px 8px rgba(0,0,0,.4);",
+      "  transition: transform .15s; border: 2px solid #fff;",
+      "}",
+      "." + PREFIX + "pin:hover { transform: scale(1.2); }",
+
+      // Side panel
+      "." + PREFIX + "panel {",
+      "  position: fixed; top: 0; right: 0; bottom: 0; width: 360px; max-width: 90vw;",
+      "  background: var(--vf-bg-dark); color: var(--vf-text); z-index: var(--vf-z);",
+      "  box-shadow: -4px 0 30px rgba(0,0,0,.4); display: flex; flex-direction: column;",
+      "  font: 14px/1.5 -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;",
+      "  transform: translateX(100%); transition: transform .25s ease;",
+      "}",
+      "." + PREFIX + "panel-open { transform: translateX(0); }",
+
+      "." + PREFIX + "panel-head {",
+      "  padding: 16px 18px; font-size: 16px; font-weight: 600;",
+      "  border-bottom: 1px solid var(--vf-border); display: flex;",
+      "  align-items: center; justify-content: space-between;",
+      "}",
+      "." + PREFIX + "panel-close {",
+      "  background: none; border: none; color: var(--vf-text-muted); cursor: pointer;",
+      "  font-size: 20px; line-height: 1; padding: 0 2px;",
+      "}",
+      "." + PREFIX + "panel-close:hover { color: var(--vf-text); }",
+
+      "." + PREFIX + "panel-body {",
+      "  flex: 1; overflow-y: auto; padding: 12px 18px;",
+      "}",
+
+      "." + PREFIX + "panel-item {",
+      "  background: var(--vf-bg-card); border-radius: 8px; padding: 12px;",
+      "  margin-bottom: 10px; border: 1px solid var(--vf-border);",
+      "}",
+      "." + PREFIX + "panel-item-selector {",
+      "  font-size: 11px; color: var(--vf-text-muted); margin-bottom: 6px;",
+      "  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;",
+      "}",
+      "." + PREFIX + "panel-item-comment {",
+      "  font-size: 13px; margin-bottom: 8px; white-space: pre-wrap; word-break: break-word;",
+      "}",
+      "." + PREFIX + "panel-item-actions { display: flex; gap: 6px; }",
+
+      "." + PREFIX + "panel-footer {",
+      "  padding: 14px 18px; border-top: 1px solid var(--vf-border);",
+      "}",
+      "." + PREFIX + "panel-footer .veld-feedback-btn { width: 100%; text-align: center; padding: 10px; }",
+
+      "." + PREFIX + "panel-empty {",
+      "  text-align: center; color: var(--vf-text-muted); padding: 40px 0; font-size: 13px;",
+      "}",
+
+      // Selection tooltip
+      "." + PREFIX + "sel-tip {",
+      "  position: absolute; z-index: var(--vf-z); background: var(--vf-primary);",
+      "  color: #fff; padding: 5px 12px; border-radius: 6px; font: 500 12px/1.4 sans-serif;",
+      "  cursor: pointer; box-shadow: 0 2px 10px rgba(0,0,0,.3);",
+      "  animation: " + PREFIX + "fadeIn .12s ease; white-space: nowrap;",
+      "}",
+      "." + PREFIX + "sel-tip:hover { background: var(--vf-primary-hover); }",
+
+      // Comment text preview in detail popover
+      "." + PREFIX + "comment-text {",
+      "  white-space: pre-wrap; word-break: break-word; font-size: 13px; margin-bottom: 8px;",
+      "}"
+    ].join("\n");
+    document.head.appendChild(style);
+  }
+
+  // ---------- DOM scaffolding ---------------------------------------------
+
+  var fabContainer, fab, fabBadge, panelBtn;
+  var overlay, hoverOutline;
+  var panel, panelBody, panelFooter;
+  var selTip;
+
+  function buildDOM() {
+    // Overlay
+    overlay = mkEl("div", "overlay");
+    document.body.appendChild(overlay);
+
+    // Hover outline
+    hoverOutline = mkEl("div", "hover-outline");
+    document.body.appendChild(hoverOutline);
+
+    // FAB container
+    fabContainer = mkEl("div", "fab-container");
+
+    panelBtn = mkEl("button", "panel-btn");
+    panelBtn.title = "Comment list";
+    panelBtn.innerHTML = "&#9776;"; // hamburger
+    panelBtn.addEventListener("click", togglePanel);
+    fabContainer.appendChild(panelBtn);
+
+    fab = mkEl("button", "fab");
+    fab.title = "Toggle feedback mode";
+    fab.innerHTML = "&#128172;"; // speech balloon
+    fabBadge = mkEl("span", "badge badge-hidden");
+    fab.appendChild(fabBadge);
+    fab.addEventListener("click", toggleFeedbackMode);
+    fabContainer.appendChild(fab);
+
+    document.body.appendChild(fabContainer);
+
+    // Panel
+    panel = mkEl("div", "panel");
+
+    var panelHead = mkEl("div", "panel-head");
+    panelHead.appendChild(mkEl("span", null, "Feedback Comments"));
+    var closeBtn = mkEl("button", "panel-close");
+    closeBtn.innerHTML = "&times;";
+    closeBtn.addEventListener("click", togglePanel);
+    panelHead.appendChild(closeBtn);
+    panel.appendChild(panelHead);
+
+    panelBody = mkEl("div", "panel-body");
+    panel.appendChild(panelBody);
+
+    panelFooter = mkEl("div", "panel-footer");
+    var submitBtn = mkEl("button", "btn btn-primary", "Submit All Feedback");
+    submitBtn.addEventListener("click", submitAll);
+    panelFooter.appendChild(submitBtn);
+    panel.appendChild(panelFooter);
+
+    document.body.appendChild(panel);
+  }
+
+  // ---------- badge -------------------------------------------------------
+
+  function updateBadge() {
+    var count = __veld_comments.length;
+    fabBadge.textContent = count;
+    if (count > 0) {
+      fabBadge.className = PREFIX + "badge";
+    } else {
+      fabBadge.className = PREFIX + "badge " + PREFIX + "badge-hidden";
+    }
+  }
+
+  // ---------- feedback mode -----------------------------------------------
+
+  function toggleFeedbackMode() {
+    __veld_feedbackMode = !__veld_feedbackMode;
+    if (__veld_feedbackMode) {
+      fab.classList.add(PREFIX + "fab-active");
+      overlay.classList.add(PREFIX + "overlay-active");
+    } else {
+      fab.classList.remove(PREFIX + "fab-active");
+      overlay.classList.remove(PREFIX + "overlay-active");
+      hoverOutline.style.display = "none";
+      __veld_hoveredEl = null;
+      removeSelTip();
+      closeActivePopover();
+    }
+  }
+
+  // ---------- hover highlight ---------------------------------------------
+
+  function onMouseMove(e) {
+    if (!__veld_feedbackMode) return;
+    var target = document.elementFromPoint(e.clientX, e.clientY);
+    if (!target || isOwnElement(target)) {
+      hoverOutline.style.display = "none";
+      __veld_hoveredEl = null;
+      return;
+    }
+    __veld_hoveredEl = target;
+    var r = target.getBoundingClientRect();
+    hoverOutline.style.display = "block";
+    hoverOutline.style.top = (r.top + window.scrollY) + "px";
+    hoverOutline.style.left = (r.left + window.scrollX) + "px";
+    hoverOutline.style.width = r.width + "px";
+    hoverOutline.style.height = r.height + "px";
+  }
+
+  function isOwnElement(el) {
+    while (el) {
+      if (el.className && typeof el.className === "string" && el.className.indexOf(PREFIX) !== -1) return true;
+      el = el.parentElement;
+    }
+    return false;
+  }
+
+  // ---------- click to create comment -------------------------------------
+
+  function onDocClick(e) {
+    if (!__veld_feedbackMode) return;
+    if (isOwnElement(e.target)) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    var target = __veld_hoveredEl || e.target;
+    var sel = window.getSelection();
+    var selectedText = sel ? sel.toString().trim() : "";
+    var rect = docRect(target);
+    var selector = selectorFor(target);
+    var tagInfo = target.tagName.toLowerCase();
+    if (target.className && typeof target.className === "string") {
+      var cls = target.className.trim().split(/\s+/).filter(function (c) { return !c.startsWith(PREFIX); });
+      if (cls.length) tagInfo += "." + cls.slice(0, 3).join(".");
+    }
+
+    showCreatePopover(rect, selector, tagInfo, selectedText, target);
+  }
+
+  // ---------- text selection tooltip --------------------------------------
+
+  function onMouseUp() {
+    if (!__veld_feedbackMode) return;
+    removeSelTip();
+    var sel = window.getSelection();
+    if (!sel || sel.isCollapsed || !sel.toString().trim()) return;
+
+    var range = sel.getRangeAt(0);
+    var rects = range.getClientRects();
+    if (!rects.length) return;
+    var last = rects[rects.length - 1];
+
+    selTip = mkEl("div", "sel-tip", "Add Comment");
+    selTip.style.top = (last.bottom + window.scrollY + 6) + "px";
+    selTip.style.left = (last.right + window.scrollX) + "px";
+    selTip.addEventListener("click", function (e) {
+      e.stopPropagation();
+      var target = range.startContainer.parentElement;
+      if (!target) return;
+      var selectedText = sel.toString().trim();
+      var rect = docRect(target);
+      var selector = selectorFor(target);
+      var tagInfo = target.tagName.toLowerCase();
+      removeSelTip();
+      showCreatePopover(rect, selector, tagInfo, selectedText, target);
+    });
+    document.body.appendChild(selTip);
+  }
+
+  function removeSelTip() {
+    if (selTip) { selTip.remove(); selTip = null; }
+  }
+
+  // ---------- create popover ----------------------------------------------
+
+  function showCreatePopover(rect, selector, tagInfo, selectedText, targetEl) {
+    closeActivePopover();
+
+    var pop = mkEl("div", "popover");
+    positionPopover(pop, rect);
+
+    var header = mkEl("div", "popover-header", tagInfo);
+    pop.appendChild(header);
+
+    var body = mkEl("div", "popover-body");
+    var ta = mkEl("textarea", "textarea");
+    ta.placeholder = "Add your feedback\u2026";
+    body.appendChild(ta);
+
+    var actions = mkEl("div", "popover-actions");
+    var cancelBtn = mkEl("button", "btn btn-secondary", "Cancel");
+    cancelBtn.addEventListener("click", function () { closeActivePopover(); });
+    var saveBtn = mkEl("button", "btn btn-primary", "Save");
+    saveBtn.addEventListener("click", function () {
+      var text = ta.value.trim();
+      if (!text) { ta.focus(); return; }
+      saveComment(selector, selectedText, text, rect, targetEl, pop);
+    });
+    actions.appendChild(cancelBtn);
+    actions.appendChild(saveBtn);
+    body.appendChild(actions);
+    pop.appendChild(body);
+
+    document.body.appendChild(pop);
+    __veld_activePopover = pop;
+    ta.focus();
+  }
+
+  function positionPopover(pop, rect) {
+    var topPos = rect.y + rect.height + 10;
+    var leftPos = Math.max(10, Math.min(rect.x, window.innerWidth + window.scrollX - 340));
+    pop.style.top = topPos + "px";
+    pop.style.left = leftPos + "px";
+  }
+
+  function closeActivePopover() {
+    if (__veld_activePopover) {
+      __veld_activePopover.remove();
+      __veld_activePopover = null;
+    }
+  }
+
+  // ---------- save comment ------------------------------------------------
+
+  function saveComment(selector, selectedText, comment, position, targetEl, popoverEl) {
+    var payload = {
+      page_url: window.location.pathname + window.location.search,
+      element_selector: selector,
+      selected_text: selectedText || "",
+      comment: comment,
+      position: { x: position.x, y: position.y, width: position.width, height: position.height }
+    };
+
+    api("POST", "/comments", payload)
+      .then(function (res) {
+        var c = res || payload;
+        if (!c.id) c.id = "local_" + (__veld_nextLocalId++);
+        __veld_comments.push(c);
+        updateBadge();
+        renderPanel();
+        addPin(c);
+        closeActivePopover();
+        toast("Comment saved");
+      })
+      .catch(function (err) {
+        toast("Failed to save comment: " + err.message, true);
+      });
+  }
+
+  // ---------- pins --------------------------------------------------------
+
+  var __veld_pins = {}; // id -> pin element
+
+  function addPin(comment) {
+    removePin(comment.id);
+    var idx = __veld_comments.indexOf(comment);
+    var num = idx >= 0 ? idx + 1 : Object.keys(__veld_pins).length + 1;
+
+    var pin = mkEl("div", "pin", String(num));
+    pin.dataset.commentId = comment.id;
+    pin.style.top = (comment.position.y - 13) + "px";
+    pin.style.left = (comment.position.x + comment.position.width - 13) + "px";
+    pin.addEventListener("click", function (e) {
+      e.stopPropagation();
+      showDetailPopover(comment, pin);
+    });
+    document.body.appendChild(pin);
+    __veld_pins[comment.id] = pin;
+  }
+
+  function removePin(id) {
+    if (__veld_pins[id]) { __veld_pins[id].remove(); delete __veld_pins[id]; }
+  }
+
+  function renderAllPins() {
+    // Remove old pins
+    Object.keys(__veld_pins).forEach(function (id) { __veld_pins[id].remove(); });
+    __veld_pins = {};
+    __veld_comments.forEach(addPin);
+  }
+
+  /** Reposition pins when the user scrolls or resizes (elements may have moved). */
+  function repositionPins() {
+    __veld_comments.forEach(function (c) {
+      var pin = __veld_pins[c.id];
+      if (!pin) return;
+      // Try to find the element to get its current position.
+      try {
+        var el = document.querySelector(c.element_selector);
+        if (el) {
+          var r = docRect(el);
+          c.position = { x: r.x, y: r.y, width: r.width, height: r.height };
+          pin.style.top = (r.y - 13) + "px";
+          pin.style.left = (r.x + r.width - 13) + "px";
+        }
+      } catch (_) { /* selector may be invalid */ }
+    });
+  }
+
+  var __veld_rafPending = false;
+  function scheduleReposition() {
+    if (__veld_rafPending) return;
+    __veld_rafPending = true;
+    requestAnimationFrame(function () {
+      __veld_rafPending = false;
+      repositionPins();
+    });
+  }
+
+  // ---------- detail popover ----------------------------------------------
+
+  function showDetailPopover(comment, pinEl) {
+    closeActivePopover();
+
+    var pop = mkEl("div", "popover");
+    var pinRect = pinEl.getBoundingClientRect();
+    pop.style.top = (pinRect.bottom + window.scrollY + 8) + "px";
+    pop.style.left = Math.max(10, pinRect.left + window.scrollX - 140) + "px";
+
+    var header = mkEl("div", "popover-header", comment.element_selector);
+    pop.appendChild(header);
+
+    var body = mkEl("div", "popover-body");
+
+    // Comment text (or edit textarea)
+    var textEl = mkEl("div", "comment-text", comment.comment);
+    body.appendChild(textEl);
+
+    var actions = mkEl("div", "popover-actions");
+    var editBtn = mkEl("button", "btn btn-secondary btn-sm", "Edit");
+    var delBtn = mkEl("button", "btn btn-danger btn-sm", "Delete");
+    var cancelBtn = mkEl("button", "btn btn-secondary btn-sm", "Close");
+    cancelBtn.addEventListener("click", function () { closeActivePopover(); });
+
+    editBtn.addEventListener("click", function () {
+      // Replace text with textarea
+      var ta = mkEl("textarea", "textarea");
+      ta.value = comment.comment;
+      textEl.replaceWith(ta);
+      ta.focus();
+
+      // Swap buttons
+      editBtn.style.display = "none";
+      var saveBtn = mkEl("button", "btn btn-primary btn-sm", "Save");
+      saveBtn.addEventListener("click", function () {
+        var newText = ta.value.trim();
+        if (!newText) { ta.focus(); return; }
+        api("PUT", "/comments/" + encodeURIComponent(comment.id), { comment: newText })
+          .then(function () {
+            comment.comment = newText;
+            renderPanel();
+            closeActivePopover();
+            toast("Comment updated");
+          })
+          .catch(function (err) { toast("Update failed: " + err.message, true); });
+      });
+      actions.insertBefore(saveBtn, delBtn);
+    });
+
+    delBtn.addEventListener("click", function () {
+      if (!confirm("Delete this comment?")) return;
+      api("DELETE", "/comments/" + encodeURIComponent(comment.id))
+        .then(function () {
+          __veld_comments = __veld_comments.filter(function (c) { return c.id !== comment.id; });
+          removePin(comment.id);
+          updateBadge();
+          renderPanel();
+          closeActivePopover();
+          toast("Comment deleted");
+        })
+        .catch(function (err) { toast("Delete failed: " + err.message, true); });
+    });
+
+    actions.appendChild(editBtn);
+    actions.appendChild(delBtn);
+    actions.appendChild(cancelBtn);
+    body.appendChild(actions);
+    pop.appendChild(body);
+
+    document.body.appendChild(pop);
+    __veld_activePopover = pop;
+  }
+
+  // ---------- panel -------------------------------------------------------
+
+  function togglePanel() {
+    __veld_panelOpen = !__veld_panelOpen;
+    if (__veld_panelOpen) {
+      panel.classList.add(PREFIX + "panel-open");
+      renderPanel();
+    } else {
+      panel.classList.remove(PREFIX + "panel-open");
+    }
+  }
+
+  function renderPanel() {
+    panelBody.innerHTML = "";
+
+    if (__veld_comments.length === 0) {
+      panelBody.appendChild(mkEl("div", "panel-empty", "No comments yet. Click elements on the page to add feedback."));
+      panelFooter.style.display = "none";
+      return;
+    }
+    panelFooter.style.display = "";
+
+    __veld_comments.forEach(function (c, i) {
+      var item = mkEl("div", "panel-item");
+
+      var sel = mkEl("div", "panel-item-selector", (i + 1) + ". " + c.element_selector);
+      item.appendChild(sel);
+
+      var txt = mkEl("div", "panel-item-comment", c.comment);
+      item.appendChild(txt);
+
+      var acts = mkEl("div", "panel-item-actions");
+
+      var editBtn = mkEl("button", "btn btn-secondary btn-sm", "Edit");
+      editBtn.addEventListener("click", function () { startInlineEdit(c, item, i); });
+      acts.appendChild(editBtn);
+
+      var delBtn = mkEl("button", "btn btn-danger btn-sm", "Delete");
+      delBtn.addEventListener("click", function () {
+        if (!confirm("Delete this comment?")) return;
+        api("DELETE", "/comments/" + encodeURIComponent(c.id))
+          .then(function () {
+            __veld_comments = __veld_comments.filter(function (x) { return x.id !== c.id; });
+            removePin(c.id);
+            updateBadge();
+            renderPanel();
+            toast("Comment deleted");
+          })
+          .catch(function (err) { toast("Delete failed: " + err.message, true); });
+      });
+      acts.appendChild(delBtn);
+
+      item.appendChild(acts);
+      panelBody.appendChild(item);
+    });
+  }
+
+  function startInlineEdit(comment, itemEl, idx) {
+    itemEl.innerHTML = "";
+
+    var sel = mkEl("div", "panel-item-selector", (idx + 1) + ". " + comment.element_selector);
+    itemEl.appendChild(sel);
+
+    var ta = mkEl("textarea", "textarea");
+    ta.value = comment.comment;
+    itemEl.appendChild(ta);
+
+    var acts = mkEl("div", "popover-actions");
+    acts.style.marginTop = "8px";
+
+    var saveBtn = mkEl("button", "btn btn-primary btn-sm", "Save");
+    saveBtn.addEventListener("click", function () {
+      var newText = ta.value.trim();
+      if (!newText) { ta.focus(); return; }
+      api("PUT", "/comments/" + encodeURIComponent(comment.id), { comment: newText })
+        .then(function () {
+          comment.comment = newText;
+          renderPanel();
+          toast("Comment updated");
+        })
+        .catch(function (err) { toast("Update failed: " + err.message, true); });
+    });
+    acts.appendChild(saveBtn);
+
+    var cancelBtn = mkEl("button", "btn btn-secondary btn-sm", "Cancel");
+    cancelBtn.addEventListener("click", function () { renderPanel(); });
+    acts.appendChild(cancelBtn);
+
+    itemEl.appendChild(acts);
+    ta.focus();
+  }
+
+  // ---------- submit all --------------------------------------------------
+
+  function submitAll() {
+    api("POST", "/submit", { page_url: window.location.pathname + window.location.search })
+      .then(function () {
+        __veld_comments = [];
+        renderAllPins();
+        updateBadge();
+        renderPanel();
+        toast("Feedback submitted successfully!");
+        if (__veld_panelOpen) togglePanel();
+      })
+      .catch(function (err) { toast("Submit failed: " + err.message, true); });
+  }
+
+  // ---------- keyboard shortcut -------------------------------------------
+
+  function onKeyDown(e) {
+    if (e.key === "Escape" && __veld_feedbackMode) {
+      if (__veld_activePopover) {
+        closeActivePopover();
+      } else {
+        toggleFeedbackMode();
+      }
+    }
+  }
+
+  // ---------- fetch existing comments on load -----------------------------
+
+  function loadExisting() {
+    var pageUrl = window.location.pathname + window.location.search;
+    api("GET", "/comments?page_url=" + encodeURIComponent(pageUrl))
+      .then(function (data) {
+        if (Array.isArray(data) && data.length) {
+          __veld_comments = data;
+          updateBadge();
+          renderAllPins();
+        }
+      })
+      .catch(function () {
+        // API may not be ready yet; silently ignore.
+      });
+  }
+
+  // ---------- init --------------------------------------------------------
+
+  function init() {
+    injectStyles();
+    buildDOM();
+    updateBadge();
+
+    document.addEventListener("mousemove", onMouseMove, true);
+    document.addEventListener("click", onDocClick, true);
+    document.addEventListener("mouseup", onMouseUp, true);
+    document.addEventListener("keydown", onKeyDown, true);
+    window.addEventListener("scroll", scheduleReposition, true);
+    window.addEventListener("resize", scheduleReposition);
+
+    loadExisting();
+  }
+
+  // Start when DOM is ready.
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();
+"###;

--- a/crates/veld-daemon/src/feedback_server.rs
+++ b/crates/veld-daemon/src/feedback_server.rs
@@ -1,0 +1,288 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::extract::{Path, Query, State};
+use axum::http::{StatusCode, header};
+use axum::response::{Html, IntoResponse, Response};
+use axum::routing::{delete, get, post, put};
+use axum::{Json, Router};
+use serde::Deserialize;
+use tokio::sync::Notify;
+use tracing::{info, warn};
+use veld_core::feedback::{FeedbackComment, FeedbackStore};
+use veld_core::state::GlobalRegistry;
+
+#[path = "feedback_assets.rs"]
+mod feedback_assets;
+
+/// Port the feedback HTTP server listens on.
+pub const FEEDBACK_PORT: u16 = 19899;
+
+// ---------------------------------------------------------------------------
+// Shared state
+// ---------------------------------------------------------------------------
+
+struct AppState {
+    /// Notifier for long-poll: signalled whenever a batch is submitted.
+    batch_notify: Notify,
+}
+
+// ---------------------------------------------------------------------------
+// Startup
+// ---------------------------------------------------------------------------
+
+/// Start the feedback HTTP server on `127.0.0.1:FEEDBACK_PORT`.
+pub async fn run_feedback_server() {
+    let state = Arc::new(AppState {
+        batch_notify: Notify::new(),
+    });
+
+    let app = Router::new()
+        // Service Worker installer page.
+        .route("/", get(installer_page))
+        // Service Worker script.
+        .route("/sw.js", get(service_worker))
+        // Overlay script.
+        .route("/feedback/script.js", get(overlay_script))
+        // Feedback CRUD API.
+        .route("/feedback/api/comments", get(list_comments))
+        .route("/feedback/api/comments", post(create_comment))
+        .route("/feedback/api/comments/{id}", put(update_comment))
+        .route("/feedback/api/comments/{id}", delete(delete_comment))
+        // Submit / batches.
+        .route("/feedback/api/submit", post(submit_batch))
+        .route("/feedback/api/batches", get(list_batches))
+        .route("/feedback/api/batches/wait", get(wait_for_batch))
+        .with_state(state);
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], FEEDBACK_PORT));
+    info!("feedback server listening on {addr}");
+
+    match tokio::net::TcpListener::bind(addr).await {
+        Ok(listener) => {
+            if let Err(e) = axum::serve(listener, app).await {
+                warn!("feedback server error: {e}");
+            }
+        }
+        Err(e) => {
+            warn!("failed to bind feedback server on {addr}: {e}");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Query params
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct RunQuery {
+    run: Option<String>,
+    project: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct WaitQuery {
+    run: Option<String>,
+    project: Option<String>,
+    #[serde(default = "default_timeout")]
+    timeout_secs: u64,
+}
+
+fn default_timeout() -> u64 {
+    300
+}
+
+// ---------------------------------------------------------------------------
+// Resolve project + run from query params or headers
+// ---------------------------------------------------------------------------
+
+fn resolve_store(
+    run: Option<&str>,
+    project: Option<&str>,
+    headers: &axum::http::HeaderMap,
+) -> Result<FeedbackStore, StatusCode> {
+    let run_name = run
+        .or_else(|| headers.get("x-veld-run").and_then(|v| v.to_str().ok()))
+        .ok_or(StatusCode::BAD_REQUEST)?;
+
+    // Try explicit project path first, then header, then search registry.
+    if let Some(project_path) =
+        project.or_else(|| headers.get("x-veld-project").and_then(|v| v.to_str().ok()))
+    {
+        return Ok(FeedbackStore::new(
+            std::path::Path::new(project_path),
+            run_name,
+        ));
+    }
+
+    // Fallback: search the global registry for a project with this run.
+    let registry = GlobalRegistry::load().map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    for entry in registry.projects.values() {
+        if entry.runs.contains_key(run_name) {
+            return Ok(FeedbackStore::new(&entry.project_root, run_name));
+        }
+    }
+
+    Err(StatusCode::NOT_FOUND)
+}
+
+// ---------------------------------------------------------------------------
+// Asset handlers
+// ---------------------------------------------------------------------------
+
+async fn installer_page() -> Html<&'static str> {
+    Html(feedback_assets::INSTALLER_HTML)
+}
+
+async fn service_worker() -> Response {
+    (
+        [(header::CONTENT_TYPE, "application/javascript")],
+        feedback_assets::SERVICE_WORKER_JS,
+    )
+        .into_response()
+}
+
+async fn overlay_script() -> Response {
+    (
+        [(header::CONTENT_TYPE, "application/javascript")],
+        feedback_assets::OVERLAY_JS,
+    )
+        .into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Comment CRUD
+// ---------------------------------------------------------------------------
+
+async fn list_comments(
+    headers: axum::http::HeaderMap,
+    Query(q): Query<RunQuery>,
+) -> Result<Json<Vec<FeedbackComment>>, StatusCode> {
+    let store = resolve_store(q.run.as_deref(), q.project.as_deref(), &headers)?;
+    let comments = store
+        .get_comments()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(Json(comments))
+}
+
+async fn create_comment(
+    headers: axum::http::HeaderMap,
+    Json(mut comment): Json<FeedbackComment>,
+) -> Result<(StatusCode, Json<FeedbackComment>), StatusCode> {
+    let run_name = headers
+        .get("x-veld-run")
+        .and_then(|v| v.to_str().ok())
+        .ok_or(StatusCode::BAD_REQUEST)?;
+    let store = resolve_store(Some(run_name), None, &headers)?;
+
+    // Ensure ID and timestamps.
+    if comment.id.is_empty() {
+        comment.id = uuid::Uuid::new_v4().to_string();
+    }
+    let now = chrono::Utc::now();
+    comment.created_at = now;
+    comment.updated_at = now;
+
+    store
+        .save_comment(&comment)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok((StatusCode::CREATED, Json(comment)))
+}
+
+async fn update_comment(
+    headers: axum::http::HeaderMap,
+    Path(id): Path<String>,
+    Json(mut comment): Json<FeedbackComment>,
+) -> Result<Json<FeedbackComment>, StatusCode> {
+    let run_name = headers
+        .get("x-veld-run")
+        .and_then(|v| v.to_str().ok())
+        .ok_or(StatusCode::BAD_REQUEST)?;
+    let store = resolve_store(Some(run_name), None, &headers)?;
+
+    comment.id = id;
+    comment.updated_at = chrono::Utc::now();
+
+    if store
+        .update_comment(&comment)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    {
+        Ok(Json(comment))
+    } else {
+        Err(StatusCode::NOT_FOUND)
+    }
+}
+
+async fn delete_comment(
+    headers: axum::http::HeaderMap,
+    Path(id): Path<String>,
+) -> Result<StatusCode, StatusCode> {
+    let run_name = headers
+        .get("x-veld-run")
+        .and_then(|v| v.to_str().ok())
+        .ok_or(StatusCode::BAD_REQUEST)?;
+    let store = resolve_store(Some(run_name), None, &headers)?;
+
+    if store
+        .delete_comment(&id)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(StatusCode::NOT_FOUND)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Batch submission
+// ---------------------------------------------------------------------------
+
+async fn submit_batch(
+    headers: axum::http::HeaderMap,
+    state: State<Arc<AppState>>,
+) -> Result<Json<veld_core::feedback::FeedbackBatch>, StatusCode> {
+    let run_name = headers
+        .get("x-veld-run")
+        .and_then(|v| v.to_str().ok())
+        .ok_or(StatusCode::BAD_REQUEST)?;
+    let store = resolve_store(Some(run_name), None, &headers)?;
+
+    let batch = store
+        .submit_batch()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    // Notify any long-poll waiters.
+    state.batch_notify.notify_waiters();
+
+    Ok(Json(batch))
+}
+
+async fn list_batches(
+    headers: axum::http::HeaderMap,
+    Query(q): Query<RunQuery>,
+) -> Result<Json<Vec<veld_core::feedback::FeedbackBatch>>, StatusCode> {
+    let store = resolve_store(q.run.as_deref(), q.project.as_deref(), &headers)?;
+    let batches = store
+        .get_batches()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(Json(batches))
+}
+
+async fn wait_for_batch(
+    headers: axum::http::HeaderMap,
+    Query(q): Query<WaitQuery>,
+    state: State<Arc<AppState>>,
+) -> Result<Json<Vec<veld_core::feedback::FeedbackBatch>>, StatusCode> {
+    let store = resolve_store(q.run.as_deref(), q.project.as_deref(), &headers)?;
+
+    let timeout = tokio::time::Duration::from_secs(q.timeout_secs.min(600));
+
+    // Wait for a notification or timeout.
+    let _ = tokio::time::timeout(timeout, state.batch_notify.notified()).await;
+
+    // Return all batches (the caller can filter by timestamp).
+    let batches = store
+        .get_batches()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(Json(batches))
+}

--- a/crates/veld-daemon/src/main.rs
+++ b/crates/veld-daemon/src/main.rs
@@ -1,4 +1,5 @@
 mod broadcaster;
+mod feedback_server;
 mod gc;
 mod monitor;
 
@@ -110,6 +111,10 @@ async fn main() -> Result<()> {
         gc::run_gc_scheduler().await;
     });
 
+    let feedback_handle = tokio::spawn(async move {
+        feedback_server::run_feedback_server().await;
+    });
+
     let accept_broadcaster = broadcaster.clone();
     let accept_handle = tokio::spawn(async move {
         accept_connections(listener, accept_broadcaster).await;
@@ -123,6 +128,7 @@ async fn main() -> Result<()> {
     monitor_handle.abort();
     gc_handle.abort();
     accept_handle.abort();
+    feedback_handle.abort();
 
     // Clean up the socket file.
     let _ = tokio::fs::remove_file(&args.socket_path).await;

--- a/crates/veld-helper/src/caddy.rs
+++ b/crates/veld-helper/src/caddy.rs
@@ -150,8 +150,14 @@ impl CaddyManager {
     }
 
     /// Add a reverse-proxy route via the Caddy admin API.
-    pub async fn add_route(&self, route_id: &str, hostname: &str, upstream: &str) -> Result<()> {
-        let route = build_route_json(route_id, hostname, upstream);
+    pub async fn add_route(
+        &self,
+        route_id: &str,
+        hostname: &str,
+        upstream: &str,
+        feedback_upstream: Option<&str>,
+    ) -> Result<()> {
+        let route = build_route_json(route_id, hostname, upstream, feedback_upstream);
 
         let url = format!("{CADDY_ADMIN_API}/config/apps/http/servers/veld/routes",);
 
@@ -245,7 +251,43 @@ fn build_base_config() -> serde_json::Value {
 }
 
 /// Build a single route entry with hostname matching, TLS, and reverse proxy.
-fn build_route_json(route_id: &str, hostname: &str, upstream: &str) -> serde_json::Value {
+/// When `feedback_upstream` is provided, a `/__veld__/*` subroute is added
+/// that proxies feedback API/asset requests to the daemon's HTTP server.
+fn build_route_json(
+    route_id: &str,
+    hostname: &str,
+    upstream: &str,
+    feedback_upstream: Option<&str>,
+) -> serde_json::Value {
+    let mut subroutes = Vec::new();
+
+    // If feedback is enabled, add /__veld__/* handler before the main proxy.
+    if let Some(fb_upstream) = feedback_upstream {
+        subroutes.push(serde_json::json!({
+            "match": [{ "path": ["/__veld__/*"] }],
+            "handle": [
+                {
+                    "handler": "rewrite",
+                    "strip_path_prefix": "/__veld__"
+                },
+                {
+                    "handler": "reverse_proxy",
+                    "upstreams": [{ "dial": fb_upstream }]
+                }
+            ]
+        }));
+    }
+
+    // Main app reverse proxy (catch-all).
+    subroutes.push(serde_json::json!({
+        "handle": [{
+            "handler": "reverse_proxy",
+            "upstreams": [{
+                "dial": upstream
+            }]
+        }]
+    }));
+
     serde_json::json!({
         "@id": route_id,
         "match": [{
@@ -254,14 +296,7 @@ fn build_route_json(route_id: &str, hostname: &str, upstream: &str) -> serde_jso
         "handle": [
             {
                 "handler": "subroute",
-                "routes": [{
-                    "handle": [{
-                        "handler": "reverse_proxy",
-                        "upstreams": [{
-                            "dial": upstream
-                        }]
-                    }]
-                }]
+                "routes": subroutes
             }
         ],
         "terminal": true
@@ -285,9 +320,26 @@ mod tests {
 
     #[test]
     fn test_build_route_json() {
-        let route = build_route_json("test-route", "app.test.localhost", "localhost:3000");
+        let route = build_route_json("test-route", "app.test.localhost", "localhost:3000", None);
         assert_eq!(route["@id"], "test-route");
         assert_eq!(route["match"][0]["host"][0], "app.test.localhost");
+        // Without feedback, only one subroute (the main proxy).
+        let subroutes = route["handle"][0]["routes"].as_array().unwrap();
+        assert_eq!(subroutes.len(), 1);
+    }
+
+    #[test]
+    fn test_build_route_json_with_feedback() {
+        let route = build_route_json(
+            "test-route",
+            "app.test.localhost",
+            "localhost:3000",
+            Some("localhost:19899"),
+        );
+        let subroutes = route["handle"][0]["routes"].as_array().unwrap();
+        assert_eq!(subroutes.len(), 2);
+        // First subroute matches /__veld__/*
+        assert_eq!(subroutes[0]["match"][0]["path"][0], "/__veld__/*");
     }
 
     #[test]

--- a/crates/veld-helper/src/handler.rs
+++ b/crates/veld-helper/src/handler.rs
@@ -84,8 +84,13 @@ impl State {
             Some(v) => v,
             None => return Response::err("missing 'upstream' in args"),
         };
+        let feedback_upstream = args.get("feedback_upstream").and_then(Value::as_str);
 
-        match self.caddy.add_route(route_id, hostname, upstream).await {
+        match self
+            .caddy
+            .add_route(route_id, hostname, upstream, feedback_upstream)
+            .await
+        {
             Ok(()) => Response::ok(),
             Err(e) => Response::err(format!("{e:#}")),
         }

--- a/crates/veld/src/commands/feedback.rs
+++ b/crates/veld/src/commands/feedback.rs
@@ -1,0 +1,153 @@
+use veld_core::feedback::FeedbackStore;
+use veld_core::state::ProjectState;
+
+use crate::output;
+
+/// `veld feedback` — read, wait for, or list feedback batches.
+pub async fn run(name: Option<String>, wait: bool, history: bool, json: bool) -> i32 {
+    let (project_root, _config) = match super::load_config(json) {
+        Some(pair) => pair,
+        None => return 1,
+    };
+
+    let project_state = match ProjectState::load(&project_root) {
+        Ok(ps) => ps,
+        Err(e) => {
+            output::print_error(&format!("Failed to load project state: {e}"), json);
+            return 1;
+        }
+    };
+
+    let run_name = match super::resolve_run_name(name, &project_state, true, json) {
+        Some(n) => n,
+        None => return 1,
+    };
+
+    let store = FeedbackStore::new(&project_root, &run_name);
+
+    if wait {
+        return run_wait(&store, &run_name, json).await;
+    }
+
+    if history {
+        return run_history(&store, json);
+    }
+
+    // Default: show latest batch.
+    run_latest(&store, json)
+}
+
+fn run_latest(store: &FeedbackStore, json: bool) -> i32 {
+    match store.get_latest_batch() {
+        Ok(Some(batch)) => {
+            if json {
+                println!("{}", serde_json::to_string_pretty(&batch).unwrap());
+            } else {
+                print_batch(&batch);
+            }
+            0
+        }
+        Ok(None) => {
+            if json {
+                println!("null");
+            } else {
+                output::print_info("No feedback batches submitted yet.");
+            }
+            0
+        }
+        Err(e) => {
+            output::print_error(&format!("Failed to read feedback: {e}"), json);
+            1
+        }
+    }
+}
+
+fn run_history(store: &FeedbackStore, json: bool) -> i32 {
+    match store.get_batches() {
+        Ok(batches) => {
+            if json {
+                println!("{}", serde_json::to_string_pretty(&batches).unwrap());
+            } else if batches.is_empty() {
+                output::print_info("No feedback batches submitted yet.");
+            } else {
+                for (i, batch) in batches.iter().enumerate() {
+                    if i > 0 {
+                        println!();
+                    }
+                    print_batch(batch);
+                }
+            }
+            0
+        }
+        Err(e) => {
+            output::print_error(&format!("Failed to read feedback: {e}"), json);
+            1
+        }
+    }
+}
+
+async fn run_wait(store: &FeedbackStore, run_name: &str, json: bool) -> i32 {
+    if !json {
+        output::print_info(&format!(
+            "Waiting for feedback on run '{run_name}'... (Ctrl+C to cancel)"
+        ));
+    }
+
+    let existing_count = store.get_batches().map(|b| b.len()).unwrap_or(0);
+
+    // Poll every 2 seconds for new batches.
+    loop {
+        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+        match store.get_batches() {
+            Ok(batches) => {
+                if batches.len() > existing_count {
+                    // New batch(es) arrived.
+                    let new_batches = &batches[existing_count..];
+                    if json {
+                        println!("{}", serde_json::to_string_pretty(&new_batches).unwrap());
+                    } else {
+                        for batch in new_batches {
+                            print_batch(batch);
+                        }
+                    }
+                    return 0;
+                }
+            }
+            Err(e) => {
+                output::print_error(&format!("Failed to read feedback: {e}"), json);
+                return 1;
+            }
+        }
+    }
+}
+
+fn print_batch(batch: &veld_core::feedback::FeedbackBatch) {
+    println!(
+        "{} Batch {} ({})",
+        output::bold("Feedback"),
+        output::dim(&batch.id[..8]),
+        batch.submitted_at.format("%Y-%m-%d %H:%M:%S UTC"),
+    );
+    println!(
+        "  {} comment(s) in run '{}'",
+        batch.comments.len(),
+        batch.run_name,
+    );
+    println!();
+    for (i, comment) in batch.comments.iter().enumerate() {
+        println!("  {}. {}", i + 1, comment.comment);
+        if let Some(ref sel) = comment.element_selector {
+            println!("     Element: {}", output::dim(sel));
+        }
+        if let Some(ref text) = comment.selected_text {
+            let preview = if text.len() > 80 {
+                format!("{}...", &text[..80])
+            } else {
+                text.clone()
+            };
+            println!("     Selected: \"{}\"", output::dim(&preview));
+        }
+        println!("     Page: {}", output::dim(&comment.page_url));
+    }
+}

--- a/crates/veld/src/commands/mod.rs
+++ b/crates/veld/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod feedback;
 pub mod gc;
 pub mod graph;
 pub mod init;

--- a/crates/veld/src/main.rs
+++ b/crates/veld/src/main.rs
@@ -168,6 +168,25 @@ enum Command {
         json: bool,
     },
 
+    /// Read or wait for feedback submitted via the in-browser overlay.
+    Feedback {
+        /// Name of the run.
+        #[arg(long)]
+        name: Option<String>,
+
+        /// Block until new feedback is submitted.
+        #[arg(long)]
+        wait: bool,
+
+        /// Show all submitted feedback batches.
+        #[arg(long)]
+        history: bool,
+
+        /// Output as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Garbage-collect stale state and logs.
     Gc,
 
@@ -280,6 +299,13 @@ async fn main() {
         Command::Init => commands::init::run().await,
 
         Command::List { urls, json } => commands::list::run(urls, json).await,
+
+        Command::Feedback {
+            name,
+            wait,
+            history,
+            json,
+        } => commands::feedback::run(name, wait, history, json).await,
 
         Command::Gc => commands::gc::run().await,
 


### PR DESCRIPTION
## Summary
- **Browser feedback overlay**: Click elements or select text to leave comments on any running veld environment. Service Worker auto-injects the overlay after visiting `/__veld__/` once per origin.
- **Same-origin routing**: Caddy routes `/__veld__/*` to the daemon's feedback HTTP server on every node — zero CORS issues, the script appears to load from the app's own URL.
- **Feedback API**: Full CRUD for comments + batch submission, stored as JSON in `.veld/feedback/{run_name}/`
- **CLI for agents**: `veld feedback` reads latest batch, `--wait` blocks until submission, `--history` shows all batches, `--json` for machine consumption

## New files
- `crates/veld-core/src/feedback.rs` — Data model + FeedbackStore (with tests)
- `crates/veld-daemon/src/feedback_server.rs` — axum HTTP server
- `crates/veld-daemon/src/feedback_assets.rs` — Embedded JS overlay, Service Worker, installer page
- `crates/veld/src/commands/feedback.rs` — CLI command

## Modified files
- Caddy route builder now includes `/__veld__/*` subroute when feedback_upstream is set
- Orchestrator passes `feedback_upstream: "localhost:19899"` on every route
- Daemon spawns feedback HTTP server alongside monitor and GC

## Test plan
- [ ] `cargo test` — 3 new tests (feedback CRUD, batch submit, Caddy route with feedback)
- [ ] Start an environment, visit `https://<node>.__veld__/` to activate SW
- [ ] Add comments via overlay, submit, run `veld feedback` to see them
- [ ] `veld feedback --wait` blocks until new submission arrives
- [ ] Verify `/__veld__/feedback/script.js` loads from the app's origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)