### PR TITLE
fix: don't show update banner for older cached versions

### DIFF
--- a/crates/veld-core/src/setup.rs
+++ b/crates/veld-core/src/setup.rs
@@ -893,7 +893,7 @@ pub async fn check_update() -> Result<Option<String>, anyhow::Error> {
 
 /// Compare two semver-like version strings. Returns true if `latest` is
 /// newer than `current`.
-fn is_newer(latest: &str, current: &str) -> bool {
+pub fn is_newer(latest: &str, current: &str) -> bool {
     let parse = |v: &str| -> (u64, u64, u64) {
         let mut parts = v.split('.');
         let major = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);

--- a/crates/veld/src/main.rs
+++ b/crates/veld/src/main.rs
@@ -488,7 +488,7 @@ async fn maybe_show_update_banner() {
     if let Ok(latest) = std::fs::read_to_string(&cache) {
         let latest = latest.trim();
         let current = env!("CARGO_PKG_VERSION");
-        if !latest.is_empty() && latest != current {
+        if !latest.is_empty() && veld_core::setup::is_newer(latest, current) {
             eprintln!();
             eprintln!(
                 "  {} {} → {}. Run {} to upgrade.",


### PR DESCRIPTION
## Summary
- The update banner compared cached version with `!=` instead of semver comparison, causing it to suggest downgrades (e.g. "Update available: 2.0.0 → 1.18.0") when a stale cache file persisted from a pre-2.0.0 install
- Now uses `is_newer()` for proper semver comparison in the banner display logic
- Made `is_newer` public in `veld-core::setup` to reuse the existing implementation instead of duplicating it

## Test plan
- [ ] Install veld 2.0.0, place `1.18.0` in `~/Library/Application Support/veld/.latest-version`, verify no downgrade banner appears
- [ ] Place `2.1.0` in the cache file, verify upgrade banner still shows correctly
- [ ] Run `cargo check` / `cargo test` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)