### PR TITLE
fix: snap toolbar bubble to viewport on resize

### DIFF
--- a/crates/veld-daemon/assets/feedback-overlay.js
+++ b/crates/veld-daemon/assets/feedback-overlay.js
@@ -474,7 +474,7 @@
     if (cx < minXY) { cx = minXY; clamped = true; }
     if (cy > maxY) { cy = maxY; clamped = true; }
     if (cy < minXY) { cy = minXY; clamped = true; }
-    if (clamped) { positionFab(cx, cy, true); saveFabPos(cx, cy); }
+    if (clamped) { positionFab(cx, cy, false); saveFabPos(cx, cy); }
   }
 
   // ---------- toolbar toggle ----------------------------------------------
@@ -1833,6 +1833,7 @@
     buildDOM();
     updateBadge();
     restoreFabPos();
+    clampFabToViewport();
 
     if (__veld_hidden) {
       toolbarContainer.classList.add(PREFIX + "hidden");


### PR DESCRIPTION
## Summary
- **Instant clamp on resize**: `clampFabToViewport()` now repositions without animation (`animate = false`), so the FAB never visibly drifts outside the viewport when the window shrinks.
- **Clamp on init**: Call `clampFabToViewport()` right after `restoreFabPos()` so a stale saved position from a larger window doesn't leave the FAB off-screen on page load.

## Test plan
- [ ] Drag the FAB to the bottom-right corner, then resize the window smaller — FAB should snap to stay within bounds instantly
- [ ] Save a FAB position in a large window, reload in a smaller window — FAB should be visible
- [ ] Verify normal FAB dragging still animates smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)