### PR TITLE
feat: pre-compute ports/URLs, expose ${veld.url}, port reservations

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ cargo build --release
           "type": "start_server",
           "command": "npm run dev -- --port ${veld.port}",
           "health_check": { "type": "http", "path": "/", "timeout_seconds": 30 },
-          "depends_on": { "backend": "local" }
+          "depends_on": { "backend": "local" },
+          "env": { "NEXT_PUBLIC_API_URL": "${nodes.backend.url}" }
         }
       }
     }
@@ -170,7 +171,9 @@ Fallback operator: `{branch ?? run}` uses the first non-empty value.
 
 ### Variable interpolation
 
-Commands and env values support `${veld.port}`, `${veld.run}`, `${veld.root}`, `${nodes.backend.url}`, `${nodes.backend.port}`, etc.
+Commands, env values, and output templates support `${veld.port}`, `${veld.url}`, `${veld.run}`, `${veld.root}`, `${nodes.backend.url}`, `${nodes.backend.port}`, etc.
+
+Ports and URLs for all `start_server` nodes are pre-computed before execution, so `${nodes.X.url}` works everywhere — even across nodes with no dependency relationship. Frontend can reference backend's URL and backend can reference frontend's URL without a cycle.
 
 ## Architecture
 

--- a/crates/veld-core/src/orchestrator.rs
+++ b/crates/veld-core/src/orchestrator.rs
@@ -79,6 +79,20 @@ pub enum StopResult {
     AlreadyStopped,
 }
 
+/// Pre-computed port and URL for a `start_server` node, resolved before
+/// any node begins execution so that all nodes can reference any other
+/// node's URL/port without requiring a dependency edge.
+struct PrecomputedServer {
+    port: u16,
+    /// Raw hostname (without scheme), used for DNS/Caddy configuration.
+    hostname: String,
+    /// Full `https://` URL including port suffix when not 443.
+    https_url: String,
+    /// Held TCP listeners that reserve the port from other processes.
+    /// Taken (released) right before the child process is spawned.
+    reservation: Option<crate::port::PortReservation>,
+}
+
 pub struct Orchestrator {
     pub config: VeldConfig,
     pub config_path: PathBuf,
@@ -89,6 +103,11 @@ pub struct Orchestrator {
     pub https_port: u16,
     /// Active child processes keyed by `"node:variant"`.
     children: HashMap<String, process::ServerHandle>,
+    /// Pre-computed ports and URLs for all `start_server` nodes, keyed by
+    /// `"node:variant"`. Populated once before execution begins so that
+    /// every node can reference any `start_server` node's `url`/`port`
+    /// regardless of dependency order.
+    precomputed_servers: HashMap<String, PrecomputedServer>,
     /// Debug mode — writes orchestration trace to `veld-debug.log`.
     debug: bool,
     /// Debug log writer (created on demand when debug is true).
@@ -112,6 +131,7 @@ impl Orchestrator {
             helper_client: HelperClient::default_client(),
             https_port: 443,
             children: HashMap::new(),
+            precomputed_servers: HashMap::new(),
             debug: false,
             debug_writer: None,
             foreground: false,
@@ -237,6 +257,74 @@ impl Orchestrator {
         // Outputs collected as we execute stages (for variable resolution).
         let mut all_outputs: HashMap<String, HashMap<String, String>> = HashMap::new();
 
+        // Pre-compute ports and URLs for ALL start_server nodes before any
+        // execution begins.  This makes ${nodes.X.url} and ${nodes.X.port}
+        // available to every node regardless of dependency order — frontend
+        // can reference backend's URL and vice versa without a cycle.
+        self.precomputed_servers.clear();
+        for stage in &plan {
+            for sel in stage {
+                let variant_cfg = &self.config.nodes[&sel.node].variants[&sel.variant];
+                if variant_cfg.step_type != config::StepType::StartServer {
+                    continue;
+                }
+
+                let reservation = self.port_allocator.allocate()?;
+                let port = reservation.port;
+
+                let node_cfg = &self.config.nodes[&sel.node];
+                let effective_template = url::resolve_url_template(
+                    &self.config.url_template,
+                    node_cfg.url_template.as_deref(),
+                    variant_cfg.url_template.as_deref(),
+                );
+                let url_values = url::build_url_template_values(
+                    &sel.node,
+                    &sel.variant,
+                    &run.name,
+                    &self.config.name,
+                    &branch,
+                    &worktree,
+                    &username,
+                    &hostname,
+                );
+                let node_url = url::evaluate_url_template(effective_template, &url_values)?;
+                let https_url = if self.https_port == 443 {
+                    format!("https://{node_url}")
+                } else {
+                    format!("https://{node_url}:{}", self.https_port)
+                };
+
+                let key = RunState::node_key(&sel.node, &sel.variant);
+                self.debug_log(&format!(
+                    "{}:{} — pre-computed port {} → {}",
+                    sel.node, sel.variant, port, https_url
+                ))
+                .await;
+
+                // Pre-populate all_outputs so every node can resolve
+                // ${nodes.X.url} and ${nodes.X.port} references.
+                let mut node_out = HashMap::new();
+                node_out.insert("port".to_owned(), port.to_string());
+                node_out.insert("url".to_owned(), https_url.clone());
+                all_outputs.insert(format!("{}:{}", sel.node, sel.variant), node_out.clone());
+                all_outputs
+                    .entry(sel.node.clone())
+                    .or_default()
+                    .extend(node_out);
+
+                self.precomputed_servers.insert(
+                    key,
+                    PrecomputedServer {
+                        port,
+                        hostname: node_url,
+                        https_url,
+                        reservation: Some(reservation),
+                    },
+                );
+            }
+        }
+
         // Count total nodes for progress reporting.
         let total_nodes: usize = plan.iter().map(|s| s.len()).sum();
         self.emit(ProgressEvent::PlanResolved {
@@ -244,32 +332,46 @@ impl Orchestrator {
             stages: plan.len(),
         });
 
-        // Execute stages in order.
+        // Execute stages in order. On failure, release any remaining port
+        // reservations so the ports become available again immediately.
         let mut node_index: usize = 0;
-        for stage in &plan {
-            let results = self
-                .execute_stage(
-                    stage,
-                    &run,
-                    &branch,
-                    &worktree,
-                    &username,
-                    &hostname,
-                    &mut all_outputs,
-                    total_nodes,
-                    &mut node_index,
-                )
-                .await?;
+        let execute_result: Result<(), OrchestratorError> = async {
+            for stage in &plan {
+                let results = self
+                    .execute_stage(
+                        stage,
+                        &run,
+                        &branch,
+                        &worktree,
+                        &username,
+                        &mut all_outputs,
+                        total_nodes,
+                        &mut node_index,
+                    )
+                    .await?;
 
-            for (key, node_state) in results {
-                run.execution_order.push(key.clone());
-                run.nodes.insert(key, node_state);
+                for (key, node_state) in results {
+                    run.execution_order.push(key.clone());
+                    run.nodes.insert(key, node_state);
+                }
+
+                // Save partial state after each stage so that Ctrl+C or crashes
+                // leave enough information for `veld stop` to find and kill PIDs.
+                self.save_state(&run)?;
             }
-
-            // Save partial state after each stage so that Ctrl+C or crashes
-            // leave enough information for `veld stop` to find and kill PIDs.
-            self.save_state(&run)?;
+            Ok(())
         }
+        .await;
+
+        if let Err(e) = execute_result {
+            // Release all remaining port reservations so the ports become
+            // available to the system immediately.
+            self.precomputed_servers.clear();
+            return Err(e);
+        }
+
+        // All reservations have been consumed — clear the map.
+        self.precomputed_servers.clear();
 
         run.status = RunStatus::Running;
 
@@ -287,7 +389,6 @@ impl Orchestrator {
         branch: &str,
         worktree: &str,
         username: &str,
-        hostname: &str,
         all_outputs: &mut HashMap<String, HashMap<String, String>>,
         total_nodes: usize,
         node_index: &mut usize,
@@ -308,7 +409,7 @@ impl Orchestrator {
             let key = RunState::node_key(&sel.node, &sel.variant);
             let start_time = std::time::Instant::now();
             let node_state = self
-                .execute_node(sel, run, branch, worktree, username, hostname, all_outputs)
+                .execute_node(sel, run, branch, worktree, username, all_outputs)
                 .await?;
 
             // Store this node's outputs for downstream resolution.
@@ -364,7 +465,6 @@ impl Orchestrator {
         branch: &str,
         worktree: &str,
         username: &str,
-        hostname: &str,
         all_outputs: &HashMap<String, HashMap<String, String>>,
     ) -> Result<NodeState, OrchestratorError> {
         let variant_cfg = &self.config.nodes[&sel.node].variants[&sel.variant];
@@ -391,17 +491,8 @@ impl Orchestrator {
 
         match variant_cfg.step_type {
             StepType::StartServer => {
-                self.execute_start_server(
-                    sel,
-                    run,
-                    branch,
-                    worktree,
-                    username,
-                    hostname,
-                    &mut ctx,
-                    &mut node_state,
-                )
-                .await?;
+                self.execute_start_server(sel, run, &mut ctx, &mut node_state)
+                    .await?;
             }
             StepType::Command => {
                 self.execute_command(sel, &mut ctx, &mut node_state).await?;
@@ -422,54 +513,43 @@ impl Orchestrator {
         &mut self,
         sel: &NodeSelection,
         run: &RunState,
-        branch: &str,
-        worktree: &str,
-        username: &str,
-        hostname: &str,
         ctx: &mut VariableContext,
         node_state: &mut NodeState,
     ) -> Result<(), OrchestratorError> {
         let variant_cfg = &self.config.nodes[&sel.node].variants[&sel.variant];
 
-        // Allocate port.
-        let port = self.port_allocator.allocate()?;
+        // Look up the pre-computed port and URL (allocated before any node
+        // executed so that cross-references work without dependency edges).
+        let key = RunState::node_key(&sel.node, &sel.variant);
+        let precomputed = self
+            .precomputed_servers
+            .get_mut(&key)
+            .expect("precomputed server info missing — bug in pre-computation phase");
+        let port = precomputed.port;
+        let node_url = precomputed.hostname.clone();
+        let https_url = precomputed.https_url.clone();
+        // Take the port reservation — we'll release it right before spawning
+        // the child process to minimise the TOCTOU window.
+        let port_reservation = precomputed
+            .reservation
+            .take()
+            .expect("port reservation already consumed — node executed twice?");
+
         node_state.port = Some(port);
         ctx.set_builtin("port", port.to_string());
+        node_state.url = Some(https_url.clone());
+        ctx.set_builtin("url", https_url.clone());
+
         self.emit(ProgressEvent::PortAllocated {
             node: sel.node.clone(),
             variant: sel.variant.clone(),
             port,
         });
         self.debug_log(&format!(
-            "{}:{} — allocated port {}",
-            sel.node, sel.variant, port
+            "{}:{} — using pre-computed port {} → {}",
+            sel.node, sel.variant, port, https_url
         ))
         .await;
-
-        // Build URL using the most specific template (variant > node > project).
-        let node_cfg = &self.config.nodes[&sel.node];
-        let effective_template = url::resolve_url_template(
-            &self.config.url_template,
-            node_cfg.url_template.as_deref(),
-            variant_cfg.url_template.as_deref(),
-        );
-        let url_values = url::build_url_template_values(
-            &sel.node,
-            &sel.variant,
-            &run.name,
-            &self.config.name,
-            branch,
-            worktree,
-            username,
-            hostname,
-        );
-        let node_url = url::evaluate_url_template(effective_template, &url_values)?;
-        let https_url = if self.https_port == 443 {
-            format!("https://{node_url}")
-        } else {
-            format!("https://{node_url}:{}", self.https_port)
-        };
-        node_state.url = Some(https_url.clone());
 
         // Configure DNS + Caddy via helper (best-effort).
         self.debug_log(&format!(
@@ -519,6 +599,12 @@ impl Orchestrator {
         // Start the process. stdout/stderr are redirected to the log file at
         // the OS level so the process survives after the CLI exits.
         let log_path = logging::log_file(&self.project_root, &run.name, &sel.node, &sel.variant);
+
+        // Release the port reservation immediately before spawning so the
+        // child process can bind. The window between release and bind is
+        // microseconds — effectively eliminating the TOCTOU race between
+        // concurrent `veld start` commands.
+        port_reservation.release();
 
         let handle = process::start_server(
             &resolved_cmd,

--- a/crates/veld-core/src/port.rs
+++ b/crates/veld-core/src/port.rs
@@ -25,6 +25,35 @@ pub enum PortError {
 // Port allocator
 // ---------------------------------------------------------------------------
 
+/// A reserved port with TCP listeners held to prevent other processes from
+/// claiming it. Dropping the reservation (or calling [`PortReservation::release`])
+/// frees the port so the child process can bind immediately.
+pub struct PortReservation {
+    pub port: u16,
+    /// Held listeners that block other processes from binding this port.
+    /// The Vec is non-empty while the reservation is active.
+    _guards: Vec<TcpListener>,
+}
+
+impl PortReservation {
+    /// Release the port reservation by dropping the guard listeners.
+    /// Call this immediately before spawning the child process that will
+    /// bind the port, to minimise the race window.
+    pub fn release(self) -> u16 {
+        // `_guards` are dropped here, freeing the port.
+        self.port
+    }
+}
+
+// Manual Debug impl — TcpListener's Debug output is noisy.
+impl std::fmt::Debug for PortReservation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PortReservation")
+            .field("port", &self.port)
+            .finish()
+    }
+}
+
 /// Tracks allocated ports for a single run and finds free ones.
 #[derive(Debug)]
 pub struct PortAllocator {
@@ -45,13 +74,24 @@ impl PortAllocator {
         }
     }
 
-    /// Allocate the next available port from the managed range.
-    pub fn allocate(&self) -> Result<u16, PortError> {
+    /// Allocate the next available port from the managed range and return a
+    /// [`PortReservation`] that holds TCP listeners on the port. Other
+    /// processes will see the port as occupied until the reservation is
+    /// released. Call [`PortReservation::release`] immediately before
+    /// spawning the child process.
+    pub fn allocate(&self) -> Result<PortReservation, PortError> {
         let mut allocated = self.allocated.lock().expect("port allocator lock poisoned");
         for port in PORT_RANGE_START..=PORT_RANGE_END {
             if !allocated.contains(&port) && is_port_available(port) {
-                allocated.insert(port);
-                return Ok(port);
+                // Port is free — now grab reservation listeners to hold it.
+                // If the reservation fails (extremely rare race), skip.
+                if let Some(guards) = try_reserve_port(port) {
+                    allocated.insert(port);
+                    return Ok(PortReservation {
+                        port,
+                        _guards: guards,
+                    });
+                }
             }
         }
         Err(PortError::Exhausted)
@@ -78,6 +118,26 @@ impl Default for PortAllocator {
     }
 }
 
+/// Try to bind TCP listeners to reserve `port` from other processes.
+/// Returns the held listeners on success, or `None` if any bind fails.
+///
+/// We bind on IPv4 wildcard and IPv6 loopback:
+/// - `0.0.0.0` covers all IPv4 addresses (including `127.0.0.1`)
+/// - `[::1]` covers IPv6 loopback
+///
+/// We intentionally do NOT also bind `127.0.0.1` because on Linux,
+/// binding a specific address after the wildcard on the same port fails
+/// with EADDRINUSE (the wildcard already covers it). On macOS this overlap
+/// is allowed, but we avoid it for cross-platform correctness.
+fn try_reserve_port(port: u16) -> Option<Vec<TcpListener>> {
+    let wildcard: SocketAddr = ([0, 0, 0, 0], port).into();
+    let ipv6: SocketAddr = ([0, 0, 0, 0, 0, 0, 0, 1], port).into();
+
+    let l1 = TcpListener::bind(wildcard).ok()?;
+    let l2 = TcpListener::bind(ipv6).ok()?;
+    Some(vec![l1, l2])
+}
+
 /// Check whether a TCP port is available by attempting to bind on all
 /// relevant address families: IPv4 loopback, IPv6 loopback, and IPv4
 /// wildcard (`0.0.0.0`).
@@ -85,15 +145,26 @@ impl Default for PortAllocator {
 /// Modern runtimes (Node.js 18+, Next.js, etc.) often default to IPv6.
 /// Docker containers bind on `0.0.0.0`. A stale process on any of these
 /// addresses would cause the new process to fail, so we check all three.
+///
+/// Each bind is attempted and immediately dropped, so there is no overlap
+/// issue between addresses (unlike `try_reserve_port` which holds them).
 pub fn is_port_available(port: u16) -> bool {
     let ipv4: SocketAddr = ([127, 0, 0, 1], port).into();
     let ipv6: SocketAddr = ([0, 0, 0, 0, 0, 0, 0, 1], port).into();
     let wildcard: SocketAddr = ([0, 0, 0, 0], port).into();
 
-    // All must succeed — if any is in use, the port is occupied.
-    TcpListener::bind(ipv4).is_ok()
-        && TcpListener::bind(ipv6).is_ok()
-        && TcpListener::bind(wildcard).is_ok()
+    // Each must succeed independently — drop before the next to avoid
+    // same-process overlap on Linux.
+    if TcpListener::bind(ipv4).is_err() {
+        return false;
+    }
+    if TcpListener::bind(ipv6).is_err() {
+        return false;
+    }
+    if TcpListener::bind(wildcard).is_err() {
+        return false;
+    }
+    true
 }
 
 #[cfg(test)]
@@ -133,13 +204,30 @@ mod tests {
     fn test_allocator_skips_occupied_ports() {
         // Find the first port the allocator would pick, then occupy it.
         let allocator = PortAllocator::new();
-        let first_port = allocator.allocate().unwrap();
+        let first_reservation = allocator.allocate().unwrap();
+        let first_port = first_reservation.port;
         allocator.release(first_port);
+        // Release the reservation so we can manually occupy the port.
+        first_reservation.release();
 
         // Now occupy that port and allocate again — should skip it.
         let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], first_port))).unwrap();
-        let second_port = allocator.allocate().unwrap();
-        assert_ne!(second_port, first_port);
+        let second_reservation = allocator.allocate().unwrap();
+        assert_ne!(second_reservation.port, first_port);
         drop(listener);
+    }
+
+    #[test]
+    fn test_reservation_holds_port() {
+        let allocator = PortAllocator::new();
+        let reservation = allocator.allocate().unwrap();
+        let port = reservation.port;
+
+        // While the reservation is held, the port should NOT be available.
+        assert!(!is_port_available(port));
+
+        // After releasing, it should be available again.
+        reservation.release();
+        assert!(is_port_available(port));
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -184,6 +184,8 @@ Starts and manages a long-lived process. Veld allocates a port, injects it as `$
 - Must specify `command` (required)
 - The process **must** bind to `${veld.port}` -- if it does not, the health check fails with a clear error
 - Built-in outputs: `url` (the full HTTPS URL) and `port` (the allocated port number)
+- Built-in variables: `${veld.port}` and `${veld.url}` are available in this node's `command`, `env`, and `outputs` templates
+- Ports and URLs are **pre-computed** before any node executes, so `${nodes.X.url}` and `${nodes.X.port}` for any `start_server` node are available everywhere -- no dependency edge required
 - Supports the `health_check` field (required)
 - Users never see or deal with port numbers -- only clean HTTPS URLs
 
@@ -329,7 +331,7 @@ Every `command` variant also automatically provides the built-in output `exit_co
 
 #### For `start_server` variants: Object (key-value map)
 
-Defines synthetic outputs whose values are string templates interpolated after the port is allocated. This is especially useful for Docker infrastructure nodes where stdout cannot be used for `VELD_OUTPUT`.
+Defines synthetic outputs whose values are string templates interpolated after the port and URL are resolved. Templates support all `${veld.*}` and `${nodes.*}` variables. This is especially useful for Docker infrastructure nodes where stdout cannot be used for `VELD_OUTPUT`.
 
 ```json
 {
@@ -340,6 +342,15 @@ Defines synthetic outputs whose values are string templates interpolated after t
     "DATABASE_URL": "postgresql://postgres:veld@localhost:${veld.port}/app",
     "REDIS_URL": "redis://localhost:${veld.port}"
   }
+}
+```
+
+Since `${veld.url}` is available in output templates, you can build derived URLs:
+
+```json
+"outputs": {
+  "API_URL": "${veld.url}/api/v1",
+  "WEBSOCKET_URL": "${veld.url}/ws"
 }
 ```
 
@@ -452,6 +463,7 @@ Available to all node variants without any declaration:
 | Variable            | Value                                                |
 |---------------------|------------------------------------------------------|
 | `${veld.port}`      | Allocated port for this node in this run             |
+| `${veld.url}`       | Full HTTPS URL for this node (`start_server` only)   |
 | `${veld.run}`       | Run name                                             |
 | `${veld.run_id}`    | Stable run UUID                                      |
 | `${veld.root}`      | Absolute path to the directory containing `veld.json`|
@@ -462,7 +474,28 @@ Available to all node variants without any declaration:
 
 ### Node Output References (`${nodes.*}`)
 
-Downstream nodes can reference outputs from their upstream dependencies.
+References to other nodes' outputs. There are two categories with different availability rules:
+
+#### Pre-computed outputs (available to ALL nodes)
+
+The built-in `url` and `port` outputs for `start_server` nodes are **pre-computed** before any node executes. This means every node in the graph can reference any `start_server` node's URL or port — regardless of dependency order.
+
+This is especially powerful for cross-referencing: the frontend can know the backend's URL and the backend can know the frontend's URL, without creating a dependency cycle. `depends_on` controls execution order only, not variable availability for URLs and ports.
+
+```
+${nodes.backend.url}               # start_server built-in: full HTTPS URL
+${nodes.backend.port}              # start_server built-in: allocated port (rarely needed)
+${nodes.frontend.url}              # works even if frontend runs AFTER this node
+```
+
+#### Execution-order outputs (available to downstream nodes only)
+
+Custom outputs — from synthetic output templates (`outputs` object) or `VELD_OUTPUT` lines in command nodes — are only available after the producing node has executed. These require a `depends_on` edge.
+
+```
+${nodes.database.DATABASE_URL}     # custom output from bash or outputs declaration
+${nodes.clone-db.exit_code}        # bash built-in: exit code
+```
 
 #### Short Form
 

--- a/docs/scenarios.md
+++ b/docs/scenarios.md
@@ -1,0 +1,1504 @@
+# Veld Scenarios Guide
+
+This is a collection of real-world configuration patterns for Veld. Each scenario presents a practical problem, a complete (or near-complete) `veld.json` config, and a brief explanation of what happens at runtime. These patterns are composable -- combine them freely to match your actual project structure.
+
+For the full field reference, see [configuration.md](./configuration.md).
+
+---
+
+## Table of Contents
+
+1. [Fullstack Monorepo](#1-fullstack-monorepo)
+2. [Cross-Referencing URLs Without Cyclic Dependencies](#2-cross-referencing-urls-without-cyclic-dependencies)
+3. [Multiple Databases (Postgres + Redis)](#3-multiple-databases-postgres--redis)
+4. [Local vs. Staging Backend with Variants](#4-local-vs-staging-backend-with-variants)
+5. [Database Cloning with Idempotency](#5-database-cloning-with-idempotency)
+6. [Microservices with Complex Dependency Graph](#6-microservices-with-complex-dependency-graph)
+7. [Monorepo with Shared Setup Steps](#7-monorepo-with-shared-setup-steps)
+8. [Docker Infrastructure with Synthetic Outputs](#8-docker-infrastructure-with-synthetic-outputs)
+9. [Feature Branch Isolation](#9-feature-branch-isolation)
+10. [Multi-Developer / Team URL Isolation](#10-multi-developer--team-url-isolation)
+11. [Sensitive Credentials](#11-sensitive-credentials)
+12. [Custom Apex Domains](#12-custom-apex-domains)
+13. [Hybrid Local/Remote Services](#13-hybrid-localremote-services)
+14. [Build Step Before Server](#14-build-step-before-server)
+15. [Worker Processes Alongside API Servers](#15-worker-processes-alongside-api-servers)
+16. [Polyglot Monorepo (Mixed Languages)](#16-polyglot-monorepo-mixed-languages)
+17. [End-to-End Test Runner](#17-end-to-end-test-runner)
+
+---
+
+## 1. Fullstack Monorepo
+
+**When to use:** You have a typical monorepo with a frontend app, a backend API, and a database. All three run locally during development.
+
+```json
+{
+  "$schema": "https://veld.oss.life.li/schema/v1/veld.schema.json",
+  "schemaVersion": "1",
+  "name": "shopfront",
+  "url_template": "{service}.{branch ?? run}.shopfront.localhost",
+
+  "nodes": {
+    "database": {
+      "variants": {
+        "docker": {
+          "type": "start_server",
+          "command": "docker run --rm --name veld-pg-${veld.run} -e POSTGRES_PASSWORD=veld -e POSTGRES_DB=shopfront -p ${veld.port}:5432 postgres:16",
+          "on_stop": "docker stop veld-pg-${veld.run}",
+          "health_check": { "type": "port", "timeout_seconds": 30 },
+          "outputs": {
+            "DATABASE_URL": "postgresql://postgres:veld@localhost:${veld.port}/shopfront"
+          }
+        }
+      }
+    },
+
+    "backend": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "pnpm --filter @shopfront/api dev --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/health" },
+          "depends_on": { "database": "docker" },
+          "env": {
+            "DATABASE_URL": "${nodes.database.DATABASE_URL}",
+            "NODE_ENV": "development"
+          }
+        }
+      }
+    },
+
+    "frontend": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "pnpm --filter @shopfront/web dev",
+          "health_check": { "type": "http", "path": "/" },
+          "depends_on": { "backend": "local" },
+          "env": {
+            "PORT": "${veld.port}",
+            "NEXT_PUBLIC_API_URL": "${nodes.backend.url}"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**What happens:** Veld starts `database:docker` first. Once the port accepts connections, `backend:local` starts with the Postgres connection string injected. Once the backend's `/health` returns 200, `frontend:local` starts with the backend's HTTPS URL wired into `NEXT_PUBLIC_API_URL`. Each service gets a URL like `https://frontend.feature-login.shopfront.localhost`.
+
+---
+
+## 2. Cross-Referencing URLs Without Cyclic Dependencies
+
+**When to use:** The frontend needs the backend URL for API calls, and the backend needs the frontend URL for CORS origin configuration. Normally this would create a cycle -- each depends on the other. Veld solves this because `url` and `port` for all `start_server` nodes are pre-computed before any node executes.
+
+```json
+{
+  "$schema": "https://veld.oss.life.li/schema/v1/veld.schema.json",
+  "schemaVersion": "1",
+  "name": "portal",
+  "url_template": "{service}.{branch ?? run}.portal.localhost",
+
+  "nodes": {
+    "backend": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "pnpm --filter @portal/api dev --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/health" },
+          "env": {
+            "CORS_ORIGIN": "${nodes.frontend.url}",
+            "ALLOWED_ORIGINS": "${nodes.frontend.url},${nodes.admin.url}"
+          }
+        }
+      }
+    },
+
+    "frontend": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "pnpm --filter @portal/web dev",
+          "health_check": { "type": "http", "path": "/" },
+          "env": {
+            "PORT": "${veld.port}",
+            "NEXT_PUBLIC_API_URL": "${nodes.backend.url}"
+          }
+        }
+      }
+    },
+
+    "admin": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "pnpm --filter @portal/admin dev",
+          "health_check": { "type": "http", "path": "/" },
+          "env": {
+            "PORT": "${veld.port}",
+            "NEXT_PUBLIC_API_URL": "${nodes.backend.url}"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**What happens:** Veld pre-computes URLs and ports for all three `start_server` nodes before starting anything. The backend receives `${nodes.frontend.url}` and `${nodes.admin.url}` as CORS origins even though neither frontend nor admin has started yet. No `depends_on` is needed between them -- all three start in parallel. This is only possible because the built-in `url` and `port` outputs are available before execution.
+
+Note: This pre-computation only applies to the built-in `url` and `port` outputs. Custom outputs (from `outputs` templates or `VELD_OUTPUT` lines) still require the producing node to have executed first, so they still need `depends_on`.
+
+---
+
+## 3. Multiple Databases (Postgres + Redis)
+
+**When to use:** Your backend needs both a relational database and a cache/queue. Both run as Docker containers.
+
+```json
+{
+  "$schema": "https://veld.oss.life.li/schema/v1/veld.schema.json",
+  "schemaVersion": "1",
+  "name": "taskboard",
+  "url_template": "{service}.{branch ?? run}.taskboard.localhost",
+
+  "nodes": {
+    "postgres": {
+      "variants": {
+        "docker": {
+          "type": "start_server",
+          "command": "docker run --rm --name veld-pg-${veld.run} -e POSTGRES_PASSWORD=veld -e POSTGRES_DB=taskboard -p ${veld.port}:5432 postgres:16",
+          "on_stop": "docker stop veld-pg-${veld.run}",
+          "health_check": {
+            "type": "command",
+            "command": "docker exec veld-pg-${veld.run} pg_isready -U postgres",
+            "timeout_seconds": 30,
+            "interval_ms": 2000
+          },
+          "outputs": {
+            "DATABASE_URL": "postgresql://postgres:veld@localhost:${veld.port}/taskboard"
+          }
+        }
+      }
+    },
+
+    "redis": {
+      "variants": {
+        "docker": {
+          "type": "start_server",
+          "command": "docker run --rm --name veld-redis-${veld.run} -p ${veld.port}:6379 redis:7-alpine",
+          "on_stop": "docker stop veld-redis-${veld.run}",
+          "health_check": {
+            "type": "command",
+            "command": "docker exec veld-redis-${veld.run} redis-cli ping",
+            "timeout_seconds": 15
+          },
+          "outputs": {
+            "REDIS_URL": "redis://localhost:${veld.port}/0"
+          }
+        }
+      }
+    },
+
+    "api": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "cargo run --bin taskboard-api -- --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/health", "timeout_seconds": 60 },
+          "depends_on": {
+            "postgres": "docker",
+            "redis": "docker"
+          },
+          "env": {
+            "DATABASE_URL": "${nodes.postgres.DATABASE_URL}",
+            "REDIS_URL": "${nodes.redis.REDIS_URL}"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**What happens:** Postgres and Redis start in parallel (they have no dependency on each other). The `api` node waits for both health checks to pass, then starts with both connection strings injected. The `command` health check type lets you use native readiness tools (`pg_isready`, `redis-cli ping`) instead of generic TCP port checks.
+
+---
+
+## 4. Local vs. Staging Backend with Variants
+
+**When to use:** Frontend developers want to run their UI locally against either a local backend or a shared staging backend. Variants let them switch with a single flag.
+
+```json
+{
+  "$schema": "https://veld.oss.life.li/schema/v1/veld.schema.json",
+  "schemaVersion": "1",
+  "name": "dashboard",
+  "url_template": "{service}.{branch ?? run}.dashboard.localhost",
+
+  "presets": {
+    "fullstack": ["frontend:local"],
+    "ui-only": ["frontend:staging"]
+  },
+
+  "nodes": {
+    "database": {
+      "variants": {
+        "docker": {
+          "type": "start_server",
+          "command": "docker run --rm --name veld-pg-${veld.run} -e POSTGRES_PASSWORD=veld -e POSTGRES_DB=dashboard -p ${veld.port}:5432 postgres:16",
+          "on_stop": "docker stop veld-pg-${veld.run}",
+          "health_check": { "type": "port", "timeout_seconds": 30 },
+          "outputs": {
+            "DATABASE_URL": "postgresql://postgres:veld@localhost:${veld.port}/dashboard"
+          }
+        }
+      }
+    },
+
+    "backend": {
+      "default_variant": "local",
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "pnpm --filter @dashboard/api dev --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/health" },
+          "depends_on": { "database": "docker" },
+          "env": {
+            "DATABASE_URL": "${nodes.database.DATABASE_URL}"
+          }
+        },
+        "staging": {
+          "type": "command",
+          "command": "echo 'VELD_OUTPUT BACKEND_URL=https://api.staging.dashboard.example.com'",
+          "outputs": ["BACKEND_URL"]
+        }
+      }
+    },
+
+    "frontend": {
+      "default_variant": "local",
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "pnpm --filter @dashboard/web dev",
+          "health_check": { "type": "http", "path": "/" },
+          "depends_on": { "backend": "local" },
+          "env": {
+            "PORT": "${veld.port}",
+            "NEXT_PUBLIC_API_URL": "${nodes.backend:local.url}"
+          }
+        },
+        "staging": {
+          "type": "start_server",
+          "command": "pnpm --filter @dashboard/web dev",
+          "health_check": { "type": "http", "path": "/" },
+          "depends_on": { "backend": "staging" },
+          "env": {
+            "PORT": "${veld.port}",
+            "NEXT_PUBLIC_API_URL": "${nodes.backend:staging.BACKEND_URL}"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**What happens:**
+
+- `veld start --preset fullstack` resolves `frontend:local` -> `backend:local` -> `database:docker`. The full stack runs locally.
+- `veld start --preset ui-only` resolves `frontend:staging` -> `backend:staging`. The staging variant is a `command` node that just emits the remote URL. No database starts. The frontend runs locally but talks to the staging API.
+
+Note the qualified form `${nodes.backend:local.url}` and `${nodes.backend:staging.BACKEND_URL}`. Because two variants of `backend` exist in the config, Veld requires disambiguation even though only one runs at a time per preset.
+
+---
+
+## 5. Database Cloning with Idempotency
+
+**When to use:** You clone a production or staging database into a local Postgres instance for development. The clone is expensive and should only run once unless the local copy is stale or missing.
+
+```json
+{
+  "$schema": "https://veld.oss.life.li/schema/v1/veld.schema.json",
+  "schemaVersion": "1",
+  "name": "analytics",
+  "url_template": "{service}.{branch ?? run}.analytics.localhost",
+
+  "nodes": {
+    "postgres": {
+      "variants": {
+        "docker": {
+          "type": "start_server",
+          "command": "docker run --rm --name veld-pg-${veld.run} -e POSTGRES_PASSWORD=veld -p ${veld.port}:5432 -v veld-pg-data-${veld.run}:/var/lib/postgresql/data postgres:16",
+          "on_stop": "docker stop veld-pg-${veld.run}",
+          "health_check": {
+            "type": "command",
+            "command": "docker exec veld-pg-${veld.run} pg_isready -U postgres",
+            "timeout_seconds": 30
+          },
+          "outputs": {
+            "DATABASE_URL": "postgresql://postgres:veld@localhost:${veld.port}/analytics"
+          }
+        }
+      }
+    },
+
+    "clone-db": {
+      "hidden": true,
+      "variants": {
+        "default": {
+          "type": "command",
+          "command": "pg_dump $SOURCE_DB_URL | psql ${nodes.postgres.DATABASE_URL}",
+          "verify": "psql ${nodes.postgres.DATABASE_URL} -c 'SELECT 1 FROM users LIMIT 1'",
+          "depends_on": { "postgres": "docker" },
+          "env": {
+            "SOURCE_DB_URL": "postgresql://readonly:secret@staging.analytics.example.com:5432/analytics"
+          },
+          "outputs": ["DATABASE_URL"],
+          "sensitive_outputs": ["DATABASE_URL"]
+        }
+      }
+    },
+
+    "api": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "pnpm --filter @analytics/api dev --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/health" },
+          "depends_on": { "clone-db": "default" },
+          "env": {
+            "DATABASE_URL": "${nodes.postgres.DATABASE_URL}"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**What happens:** The `clone-db` node depends on `postgres:docker`. Before running the expensive `pg_dump | psql` pipeline, Veld executes the `verify` command. If the `users` table already has data (`SELECT 1` succeeds), the clone is skipped entirely. On the first run, the clone executes. On subsequent runs, it is a no-op. The `hidden: true` flag keeps `clone-db` out of `veld nodes` output since it is an internal concern.
+
+---
+
+## 6. Microservices with Complex Dependency Graph
+
+**When to use:** Your system has multiple services with a non-trivial dependency graph. Some services depend on shared infrastructure; some depend on each other.
+
+```json
+{
+  "$schema": "https://veld.oss.life.li/schema/v1/veld.schema.json",
+  "schemaVersion": "1",
+  "name": "rideshare",
+  "url_template": "{service}.{branch ?? run}.rideshare.localhost",
+
+  "presets": {
+    "full": ["gateway:local"],
+    "riders-only": ["rider-service:local", "gateway:local"],
+    "drivers-only": ["driver-service:local", "gateway:local"]
+  },
+
+  "nodes": {
+    "postgres": {
+      "variants": {
+        "docker": {
+          "type": "start_server",
+          "command": "docker run --rm --name veld-pg-${veld.run} -e POSTGRES_PASSWORD=veld -p ${veld.port}:5432 postgres:16",
+          "on_stop": "docker stop veld-pg-${veld.run}",
+          "health_check": { "type": "port", "timeout_seconds": 30 },
+          "outputs": {
+            "DATABASE_URL": "postgresql://postgres:veld@localhost:${veld.port}/rideshare"
+          }
+        }
+      }
+    },
+
+    "redis": {
+      "variants": {
+        "docker": {
+          "type": "start_server",
+          "command": "docker run --rm --name veld-redis-${veld.run} -p ${veld.port}:6379 redis:7-alpine",
+          "on_stop": "docker stop veld-redis-${veld.run}",
+          "health_check": { "type": "port", "timeout_seconds": 15 },
+          "outputs": {
+            "REDIS_URL": "redis://localhost:${veld.port}/0"
+          }
+        }
+      }
+    },
+
+    "rider-service": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "cargo run --bin rider-service -- --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/health", "timeout_seconds": 60 },
+          "depends_on": { "postgres": "docker", "redis": "docker" },
+          "env": {
+            "DATABASE_URL": "${nodes.postgres.DATABASE_URL}",
+            "REDIS_URL": "${nodes.redis.REDIS_URL}",
+            "PRICING_SERVICE_URL": "${nodes.pricing-service.url}"
+          }
+        }
+      }
+    },
+
+    "driver-service": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "cargo run --bin driver-service -- --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/health", "timeout_seconds": 60 },
+          "depends_on": { "postgres": "docker", "redis": "docker" },
+          "env": {
+            "DATABASE_URL": "${nodes.postgres.DATABASE_URL}",
+            "REDIS_URL": "${nodes.redis.REDIS_URL}"
+          }
+        }
+      }
+    },
+
+    "pricing-service": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "cargo run --bin pricing-service -- --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/health", "timeout_seconds": 60 },
+          "depends_on": { "redis": "docker" },
+          "env": {
+            "REDIS_URL": "${nodes.redis.REDIS_URL}"
+          }
+        }
+      }
+    },
+
+    "notification-service": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "cargo run --bin notification-service -- --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/health", "timeout_seconds": 60 },
+          "depends_on": { "redis": "docker" },
+          "env": {
+            "REDIS_URL": "${nodes.redis.REDIS_URL}"
+          }
+        }
+      }
+    },
+
+    "gateway": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "cargo run --bin gateway -- --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/health" },
+          "depends_on": {
+            "rider-service": "local",
+            "driver-service": "local",
+            "pricing-service": "local",
+            "notification-service": "local"
+          },
+          "env": {
+            "RIDER_SERVICE_URL": "${nodes.rider-service.url}",
+            "DRIVER_SERVICE_URL": "${nodes.driver-service.url}",
+            "PRICING_SERVICE_URL": "${nodes.pricing-service.url}",
+            "NOTIFICATION_SERVICE_URL": "${nodes.notification-service.url}"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**What happens:** The dependency graph is resolved as a DAG:
+
+1. `postgres` and `redis` start in parallel (no dependencies).
+2. `pricing-service` and `notification-service` start in parallel once `redis` is healthy.
+3. `rider-service` and `driver-service` start in parallel once both `postgres` and `redis` are healthy.
+4. `gateway` starts last, after all four services are healthy.
+
+Notice that `rider-service` references `${nodes.pricing-service.url}` in its env without declaring a `depends_on` for it. This works because `url` is a pre-computed built-in output -- it is available before `pricing-service` starts. The `depends_on` on `postgres` and `redis` is still needed because those provide custom outputs (`DATABASE_URL`, `REDIS_URL`) that require execution.
+
+The presets let you run subsets: `--preset riders-only` starts only the rider service and gateway (plus their infrastructure dependencies).
+
+---
+
+## 7. Monorepo with Shared Setup Steps
+
+**When to use:** Multiple services share setup steps -- certificate generation, database migrations, seed data. These run once before any server starts.
+
+```json
+{
+  "$schema": "https://veld.oss.life.li/schema/v1/veld.schema.json",
+  "schemaVersion": "1",
+  "name": "enterprise-app",
+  "url_template": "{service}.{branch ?? run}.enterprise-app.localhost",
+
+  "nodes": {
+    "postgres": {
+      "variants": {
+        "docker": {
+          "type": "start_server",
+          "command": "docker run --rm --name veld-pg-${veld.run} -e POSTGRES_PASSWORD=veld -e POSTGRES_DB=enterprise -p ${veld.port}:5432 postgres:16",
+          "on_stop": "docker stop veld-pg-${veld.run}",
+          "health_check": {
+            "type": "command",
+            "command": "docker exec veld-pg-${veld.run} pg_isready -U postgres",
+            "timeout_seconds": 30
+          },
+          "outputs": {
+            "DATABASE_URL": "postgresql://postgres:veld@localhost:${veld.port}/enterprise"
+          }
+        }
+      }
+    },
+
+    "generate-certs": {
+      "hidden": true,
+      "variants": {
+        "default": {
+          "type": "command",
+          "command": "./scripts/generate-dev-certs.sh",
+          "verify": "test -f ./certs/dev.pem && test -f ./certs/dev-key.pem",
+          "outputs": ["CERT_PATH", "KEY_PATH"]
+        }
+      }
+    },
+
+    "migrate-db": {
+      "hidden": true,
+      "variants": {
+        "default": {
+          "type": "command",
+          "command": "pnpm --filter @enterprise/db migrate:dev",
+          "depends_on": { "postgres": "docker" },
+          "env": {
+            "DATABASE_URL": "${nodes.postgres.DATABASE_URL}"
+          },
+          "verify": "pnpm --filter @enterprise/db migrate:status --exit-code"
+        }
+      }
+    },
+
+    "seed-db": {
+      "hidden": true,
+      "variants": {
+        "default": {
+          "type": "command",
+          "command": "pnpm --filter @enterprise/db seed",
+          "depends_on": { "migrate-db": "default" },
+          "env": {
+            "DATABASE_URL": "${nodes.postgres.DATABASE_URL}"
+          },
+          "verify": "pnpm --filter @enterprise/db seed:check"
+        }
+      }
+    },
+
+    "backend": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "pnpm --filter @enterprise/api dev --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/health" },
+          "depends_on": {
+            "seed-db": "default",
+            "generate-certs": "default"
+          },
+          "env": {
+            "DATABASE_URL": "${nodes.postgres.DATABASE_URL}",
+            "TLS_CERT": "${nodes.generate-certs.CERT_PATH}",
+            "TLS_KEY": "${nodes.generate-certs.KEY_PATH}"
+          }
+        }
+      }
+    },
+
+    "frontend": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "pnpm --filter @enterprise/web dev",
+          "health_check": { "type": "http", "path": "/" },
+          "depends_on": { "backend": "local" },
+          "env": {
+            "PORT": "${veld.port}",
+            "NEXT_PUBLIC_API_URL": "${nodes.backend.url}"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**What happens:**
+
+1. `postgres:docker` and `generate-certs:default` start in parallel (independent).
+2. Once Postgres is ready, `migrate-db` runs (skipped if migrations are current, thanks to `verify`).
+3. Once migrations complete, `seed-db` runs (skipped if seed data exists).
+4. Once both `seed-db` and `generate-certs` finish, `backend:local` starts.
+5. Finally, `frontend:local` starts.
+
+The `verify` commands on the setup nodes make subsequent `veld start` calls fast -- if certs exist, migrations are current, and seed data is present, all three setup steps are skipped in milliseconds.
+
+---
+
+## 8. Docker Infrastructure with Synthetic Outputs
+
+**When to use:** You run Postgres, Redis, and Elasticsearch as Docker containers. Each needs to expose a connection string to downstream nodes. Since Docker containers cannot write `VELD_OUTPUT` to stdout in a way Veld captures, you use synthetic outputs.
+
+```json
+{
+  "$schema": "https://veld.oss.life.li/schema/v1/veld.schema.json",
+  "schemaVersion": "1",
+  "name": "search-platform",
+  "url_template": "{service}.{branch ?? run}.search-platform.localhost",
+
+  "nodes": {
+    "postgres": {
+      "variants": {
+        "docker": {
+          "type": "start_server",
+          "command": "docker run --rm --name veld-pg-${veld.run} -e POSTGRES_PASSWORD=veld -e POSTGRES_DB=search_platform -p ${veld.port}:5432 postgres:16",
+          "on_stop": "docker stop veld-pg-${veld.run}",
+          "health_check": { "type": "port", "timeout_seconds": 30 },
+          "outputs": {
+            "DATABASE_URL": "postgresql://postgres:veld@localhost:${veld.port}/search_platform",
+            "JDBC_URL": "jdbc:postgresql://localhost:${veld.port}/search_platform"
+          }
+        }
+      }
+    },
+
+    "redis": {
+      "variants": {
+        "docker": {
+          "type": "start_server",
+          "command": "docker run --rm --name veld-redis-${veld.run} -p ${veld.port}:6379 redis:7-alpine --appendonly yes",
+          "on_stop": "docker stop veld-redis-${veld.run}",
+          "health_check": { "type": "port", "timeout_seconds": 15 },
+          "outputs": {
+            "REDIS_URL": "redis://localhost:${veld.port}/0",
+            "REDIS_CACHE_URL": "redis://localhost:${veld.port}/1",
+            "REDIS_QUEUE_URL": "redis://localhost:${veld.port}/2"
+          }
+        }
+      }
+    },
+
+    "elasticsearch": {
+      "variants": {
+        "docker": {
+          "type": "start_server",
+          "command": "docker run --rm --name veld-es-${veld.run} -e discovery.type=single-node -e xpack.security.enabled=false -e ES_JAVA_OPTS='-Xms512m -Xmx512m' -p ${veld.port}:9200 elasticsearch:8.13.0",
+          "on_stop": "docker stop veld-es-${veld.run}",
+          "health_check": {
+            "type": "http",
+            "path": "/_cluster/health",
+            "timeout_seconds": 90,
+            "interval_ms": 3000
+          },
+          "outputs": {
+            "ELASTICSEARCH_URL": "http://localhost:${veld.port}"
+          }
+        }
+      }
+    },
+
+    "api": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "pnpm --filter @search-platform/api dev --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/health" },
+          "depends_on": {
+            "postgres": "docker",
+            "redis": "docker",
+            "elasticsearch": "docker"
+          },
+          "env": {
+            "DATABASE_URL": "${nodes.postgres.DATABASE_URL}",
+            "REDIS_URL": "${nodes.redis.REDIS_URL}",
+            "REDIS_CACHE_URL": "${nodes.redis.REDIS_CACHE_URL}",
+            "REDIS_QUEUE_URL": "${nodes.redis.REDIS_QUEUE_URL}",
+            "ELASTICSEARCH_URL": "${nodes.elasticsearch.ELASTICSEARCH_URL}"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**What happens:** All three infrastructure containers start in parallel. Synthetic outputs are template strings that are interpolated after port allocation -- no `VELD_OUTPUT` lines needed. The `api` node depends on all three and receives five connection strings. Note the Redis node exposes three different database numbers for different concerns (main, cache, queue).
+
+---
+
+## 9. Feature Branch Isolation
+
+**When to use:** You want every feature branch to get its own unique URLs so multiple developers (or multiple branches on one machine) never collide.
+
+```json
+{
+  "$schema": "https://veld.oss.life.li/schema/v1/veld.schema.json",
+  "schemaVersion": "1",
+  "name": "crm",
+  "url_template": "{service}.{branch ?? run}.crm.localhost",
+
+  "nodes": {
+    "database": {
+      "variants": {
+        "docker": {
+          "type": "start_server",
+          "command": "docker run --rm --name veld-pg-${veld.branch}-${veld.run} -e POSTGRES_PASSWORD=veld -e POSTGRES_DB=crm_${veld.branch} -p ${veld.port}:5432 -v veld-pg-${veld.branch}:/var/lib/postgresql/data postgres:16",
+          "on_stop": "docker stop veld-pg-${veld.branch}-${veld.run}",
+          "health_check": { "type": "port", "timeout_seconds": 30 },
+          "outputs": {
+            "DATABASE_URL": "postgresql://postgres:veld@localhost:${veld.port}/crm_${veld.branch}"
+          }
+        }
+      }
+    },
+
+    "backend": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "pnpm --filter @crm/api dev --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/health" },
+          "depends_on": { "database": "docker" },
+          "env": {
+            "DATABASE_URL": "${nodes.database.DATABASE_URL}"
+          }
+        }
+      }
+    },
+
+    "frontend": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "pnpm --filter @crm/web dev",
+          "health_check": { "type": "http", "path": "/" },
+          "depends_on": { "backend": "local" },
+          "env": {
+            "PORT": "${veld.port}",
+            "NEXT_PUBLIC_API_URL": "${nodes.backend.url}"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**What happens:** The `{branch ?? run}` in the URL template means:
+
+- On branch `feature/user-profiles`, the frontend URL becomes `https://frontend.feature-user-profiles.crm.localhost`.
+- On branch `fix/auth-bug`, it becomes `https://frontend.fix-auth-bug.crm.localhost`.
+- If not in a git repo, it falls back to the run name.
+
+Each branch also gets its own Docker volume (`veld-pg-${veld.branch}`) and database name, so branch data never collides. When you switch branches and run `veld start`, you get a completely isolated environment.
+
+---
+
+## 10. Multi-Developer / Team URL Isolation
+
+**When to use:** Multiple developers share a machine or a namespace (e.g., a shared Caddy proxy or a team `.localhost` domain) and need non-colliding URLs.
+
+```json
+{
+  "$schema": "https://veld.oss.life.li/schema/v1/veld.schema.json",
+  "schemaVersion": "1",
+  "name": "inventory",
+  "url_template": "{service}.{username}.{branch ?? run}.inventory.localhost",
+
+  "nodes": {
+    "backend": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "go run ./cmd/server --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/healthz" },
+          "env": {
+            "FRONTEND_URL": "${nodes.frontend.url}"
+          }
+        }
+      }
+    },
+
+    "frontend": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "pnpm --filter @inventory/web dev",
+          "health_check": { "type": "http", "path": "/" },
+          "env": {
+            "PORT": "${veld.port}",
+            "NEXT_PUBLIC_API_URL": "${nodes.backend.url}"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**What happens:** The `{username}` placeholder in the URL template means developer `alice` on branch `main` gets `https://frontend.alice.main.inventory.localhost`, while developer `bob` on the same branch gets `https://frontend.bob.main.inventory.localhost`. Ports are also independently allocated per run, so there is zero collision even when running simultaneously on the same host.
+
+---
+
+## 11. Sensitive Credentials
+
+**When to use:** A setup step produces credentials (database passwords, API keys, tokens) that should not appear in logs or be stored in plaintext.
+
+```json
+{
+  "$schema": "https://veld.oss.life.li/schema/v1/veld.schema.json",
+  "schemaVersion": "1",
+  "name": "fintech",
+  "url_template": "{service}.{branch ?? run}.fintech.localhost",
+
+  "nodes": {
+    "provision-db": {
+      "hidden": true,
+      "variants": {
+        "default": {
+          "type": "command",
+          "script": "./scripts/provision-dev-db.sh",
+          "verify": "./scripts/check-dev-db.sh",
+          "on_stop": "./scripts/teardown-dev-db.sh",
+          "outputs": ["DATABASE_URL", "DB_PASSWORD", "DB_READONLY_URL"],
+          "sensitive_outputs": ["DATABASE_URL", "DB_PASSWORD", "DB_READONLY_URL"]
+        }
+      }
+    },
+
+    "fetch-api-keys": {
+      "hidden": true,
+      "variants": {
+        "default": {
+          "type": "command",
+          "command": "vault read -format=json secret/dev/payment-gateway | jq -r '.data | to_entries[] | \"VELD_OUTPUT \\(.key)=\\(.value)\"'",
+          "outputs": ["STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET"],
+          "sensitive_outputs": ["STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET"]
+        }
+      }
+    },
+
+    "api": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "pnpm --filter @fintech/api dev --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/health" },
+          "depends_on": {
+            "provision-db": "default",
+            "fetch-api-keys": "default"
+          },
+          "env": {
+            "DATABASE_URL": "${nodes.provision-db.DATABASE_URL}",
+            "STRIPE_SECRET_KEY": "${nodes.fetch-api-keys.STRIPE_SECRET_KEY}",
+            "STRIPE_WEBHOOK_SECRET": "${nodes.fetch-api-keys.STRIPE_WEBHOOK_SECRET}"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**What happens:** The `provision-db` script creates a temporary database and emits connection strings. The `fetch-api-keys` step reads secrets from Vault. Both declare `sensitive_outputs`, which means:
+
+- All six output values are masked as `[REDACTED]` in terminal output, `veld logs`, and debug logs.
+- Values are encrypted at rest using a machine-local key.
+- The `veld graph` command never shows these values.
+
+The `api` node receives the secrets as environment variables at runtime.
+
+---
+
+## 12. Custom Apex Domains
+
+**When to use:** You want services at a real-looking domain (e.g., `*.myapp.dev`) instead of `.localhost`. This is useful for cookie scoping, CORS testing, or matching production domain structures.
+
+```json
+{
+  "$schema": "https://veld.oss.life.li/schema/v1/veld.schema.json",
+  "schemaVersion": "1",
+  "name": "saas-platform",
+  "url_template": "{service}.{branch ?? run}.saas-platform.test",
+
+  "nodes": {
+    "api": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "go run ./cmd/api --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/health" },
+          "env": {
+            "COOKIE_DOMAIN": ".saas-platform.test",
+            "CORS_ORIGINS": "${nodes.web.url},${nodes.admin.url}"
+          }
+        }
+      }
+    },
+
+    "web": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "pnpm --filter @saas/web dev",
+          "health_check": { "type": "http", "path": "/" },
+          "env": {
+            "PORT": "${veld.port}",
+            "NEXT_PUBLIC_API_URL": "${nodes.api.url}"
+          }
+        }
+      }
+    },
+
+    "admin": {
+      "url_template": "admin.{branch ?? run}.saas-platform.test",
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "pnpm --filter @saas/admin dev",
+          "health_check": { "type": "http", "path": "/" },
+          "env": {
+            "PORT": "${veld.port}",
+            "NEXT_PUBLIC_API_URL": "${nodes.api.url}"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**What happens:** Veld generates URLs like `https://api.feature-auth.saas-platform.test` and `https://admin.feature-auth.saas-platform.test`. Because `.test` is not `.localhost`, Veld manages DNS entries via `veld-helper` (writing exact host entries, never wildcards).
+
+**Requirement:** Custom apex domains require `veld setup privileged`. If you are in unprivileged mode, `veld start` will exit with an error explaining that non-`.localhost` domains need privileged setup for `/etc/hosts` access. The error message tells you exactly what to run.
+
+The `admin` node uses a node-level `url_template` override to produce a different URL shape than the project default — for example, `admin.saas-platform.test` instead of the default `{service}.{branch ?? run}.saas-platform.test` pattern.
+
+---
+
+## 13. Hybrid Local/Remote Services
+
+**When to use:** You are working on one or two services locally but want the rest of the stack to point at staging or production. Common when a system has 10+ microservices and you only need to modify one.
+
+```json
+{
+  "$schema": "https://veld.oss.life.li/schema/v1/veld.schema.json",
+  "schemaVersion": "1",
+  "name": "marketplace",
+  "url_template": "{service}.{branch ?? run}.marketplace.localhost",
+
+  "presets": {
+    "catalog-dev": ["catalog-service:local", "gateway:local"],
+    "payments-dev": ["payment-service:local", "gateway:local"],
+    "full-local": ["gateway:local-full"]
+  },
+
+  "nodes": {
+    "user-service": {
+      "default_variant": "staging",
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "cargo run --bin user-service -- --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/health", "timeout_seconds": 60 }
+        },
+        "staging": {
+          "type": "command",
+          "command": "echo 'VELD_OUTPUT SERVICE_URL=https://user-service.staging.marketplace.example.com'",
+          "outputs": ["SERVICE_URL"]
+        }
+      }
+    },
+
+    "catalog-service": {
+      "default_variant": "staging",
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "cargo run --bin catalog-service -- --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/health", "timeout_seconds": 60 }
+        },
+        "staging": {
+          "type": "command",
+          "command": "echo 'VELD_OUTPUT SERVICE_URL=https://catalog-service.staging.marketplace.example.com'",
+          "outputs": ["SERVICE_URL"]
+        }
+      }
+    },
+
+    "payment-service": {
+      "default_variant": "staging",
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "cargo run --bin payment-service -- --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/health", "timeout_seconds": 60 }
+        },
+        "staging": {
+          "type": "command",
+          "command": "echo 'VELD_OUTPUT SERVICE_URL=https://payment-service.staging.marketplace.example.com'",
+          "outputs": ["SERVICE_URL"]
+        }
+      }
+    },
+
+    "notification-service": {
+      "default_variant": "staging",
+      "variants": {
+        "staging": {
+          "type": "command",
+          "command": "echo 'VELD_OUTPUT SERVICE_URL=https://notification-service.staging.marketplace.example.com'",
+          "outputs": ["SERVICE_URL"]
+        }
+      }
+    },
+
+    "gateway": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "cargo run --bin gateway -- --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/health" },
+          "depends_on": {
+            "user-service": "staging",
+            "catalog-service": "local",
+            "payment-service": "staging",
+            "notification-service": "staging"
+          },
+          "env": {
+            "USER_SERVICE_URL": "${nodes.user-service:staging.SERVICE_URL}",
+            "CATALOG_SERVICE_URL": "${nodes.catalog-service:local.url}",
+            "PAYMENT_SERVICE_URL": "${nodes.payment-service:staging.SERVICE_URL}",
+            "NOTIFICATION_SERVICE_URL": "${nodes.notification-service:staging.SERVICE_URL}"
+          }
+        },
+        "local-full": {
+          "type": "start_server",
+          "command": "cargo run --bin gateway -- --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/health" },
+          "depends_on": {
+            "user-service": "local",
+            "catalog-service": "local",
+            "payment-service": "local",
+            "notification-service": "staging"
+          },
+          "env": {
+            "USER_SERVICE_URL": "${nodes.user-service:local.url}",
+            "CATALOG_SERVICE_URL": "${nodes.catalog-service:local.url}",
+            "PAYMENT_SERVICE_URL": "${nodes.payment-service:local.url}",
+            "NOTIFICATION_SERVICE_URL": "${nodes.notification-service:staging.SERVICE_URL}"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**What happens:** With `--preset catalog-dev`, the gateway runs locally and routes most traffic to staging services. Only `catalog-service` runs locally. The staging variants are lightweight `command` nodes that instantly emit the remote URL -- no servers start for those services. This gives you a fast feedback loop on the service you are changing while keeping the rest of the system real.
+
+Note the use of qualified references (`${nodes.catalog-service:local.url}` vs `${nodes.user-service:staging.SERVICE_URL}`) since multiple variants of the same node may be referenced across different gateway variants.
+
+---
+
+## 14. Build Step Before Server
+
+**When to use:** A service needs a compile or build step before it can be served. The build output is a static artifact (binary, bundle, etc.) that the server then uses.
+
+```json
+{
+  "$schema": "https://veld.oss.life.li/schema/v1/veld.schema.json",
+  "schemaVersion": "1",
+  "name": "docs-site",
+  "url_template": "{service}.{branch ?? run}.docs-site.localhost",
+
+  "nodes": {
+    "build-docs": {
+      "hidden": true,
+      "variants": {
+        "default": {
+          "type": "command",
+          "command": "pnpm --filter @docs-site/content build",
+          "verify": "test -d ./packages/content/dist && test ./packages/content/dist/index.html -nt ./packages/content/src/index.md"
+        }
+      }
+    },
+
+    "build-api": {
+      "hidden": true,
+      "variants": {
+        "default": {
+          "type": "command",
+          "command": "cargo build --release --bin docs-api",
+          "verify": "test -f ./target/release/docs-api && test ./target/release/docs-api -nt ./src/main.rs"
+        }
+      }
+    },
+
+    "api": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "./target/release/docs-api --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/health" },
+          "depends_on": { "build-api": "default" }
+        }
+      }
+    },
+
+    "docs": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "python3 -m http.server ${veld.port} --directory ./packages/content/dist",
+          "health_check": { "type": "http", "path": "/" },
+          "depends_on": { "build-docs": "default" }
+        }
+      }
+    }
+  }
+}
+```
+
+**What happens:** The `build-docs` and `build-api` command nodes run first (in parallel, since they are independent). The `verify` commands check whether the build artifacts are newer than the source files -- if so, the builds are skipped. Then `docs:local` serves the static files and `api:local` runs the compiled binary. On first run, both builds execute. On subsequent runs, they are skipped unless source files changed.
+
+---
+
+## 15. Worker Processes Alongside API Servers
+
+**When to use:** Your application has background workers (job processors, event consumers, schedulers) that run alongside the API server and share the same infrastructure.
+
+```json
+{
+  "$schema": "https://veld.oss.life.li/schema/v1/veld.schema.json",
+  "schemaVersion": "1",
+  "name": "jobrunner",
+  "url_template": "{service}.{branch ?? run}.jobrunner.localhost",
+
+  "presets": {
+    "full": ["api:local", "worker:local", "scheduler:local"],
+    "api-only": ["api:local"]
+  },
+
+  "nodes": {
+    "postgres": {
+      "variants": {
+        "docker": {
+          "type": "start_server",
+          "command": "docker run --rm --name veld-pg-${veld.run} -e POSTGRES_PASSWORD=veld -e POSTGRES_DB=jobrunner -p ${veld.port}:5432 postgres:16",
+          "on_stop": "docker stop veld-pg-${veld.run}",
+          "health_check": { "type": "port", "timeout_seconds": 30 },
+          "outputs": {
+            "DATABASE_URL": "postgresql://postgres:veld@localhost:${veld.port}/jobrunner"
+          }
+        }
+      }
+    },
+
+    "redis": {
+      "variants": {
+        "docker": {
+          "type": "start_server",
+          "command": "docker run --rm --name veld-redis-${veld.run} -p ${veld.port}:6379 redis:7-alpine",
+          "on_stop": "docker stop veld-redis-${veld.run}",
+          "health_check": { "type": "port", "timeout_seconds": 15 },
+          "outputs": {
+            "REDIS_URL": "redis://localhost:${veld.port}/0"
+          }
+        }
+      }
+    },
+
+    "api": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "pnpm --filter @jobrunner/api dev --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/health" },
+          "depends_on": {
+            "postgres": "docker",
+            "redis": "docker"
+          },
+          "env": {
+            "DATABASE_URL": "${nodes.postgres.DATABASE_URL}",
+            "REDIS_URL": "${nodes.redis.REDIS_URL}",
+            "WORKER_DASHBOARD_URL": "${nodes.worker.url}"
+          }
+        }
+      }
+    },
+
+    "worker": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "pnpm --filter @jobrunner/worker start --port ${veld.port} --concurrency 5",
+          "health_check": { "type": "http", "path": "/status" },
+          "depends_on": {
+            "postgres": "docker",
+            "redis": "docker"
+          },
+          "env": {
+            "DATABASE_URL": "${nodes.postgres.DATABASE_URL}",
+            "REDIS_URL": "${nodes.redis.REDIS_URL}",
+            "API_URL": "${nodes.api.url}"
+          }
+        }
+      }
+    },
+
+    "scheduler": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "pnpm --filter @jobrunner/scheduler start --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/health" },
+          "depends_on": {
+            "redis": "docker"
+          },
+          "env": {
+            "REDIS_URL": "${nodes.redis.REDIS_URL}",
+            "API_URL": "${nodes.api.url}"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**What happens:** With `--preset full`:
+
+1. Postgres and Redis start in parallel.
+2. Once both are healthy, `api`, `worker`, and `scheduler` can start. The `api` and `worker` nodes both depend on Postgres and Redis, so they start as soon as infrastructure is ready. The `scheduler` depends only on Redis.
+3. Note the cross-references: `api` references `${nodes.worker.url}` (for a worker dashboard link) and `worker` references `${nodes.api.url}` (for callback URLs). Neither has a `depends_on` on the other -- this works because `url` is pre-computed.
+
+With `--preset api-only`, only the API and its infrastructure dependencies start. No worker, no scheduler.
+
+All three application nodes are `start_server` with health check endpoints, so Veld monitors them and reports if any crashes.
+
+---
+
+## 16. Polyglot Monorepo (Mixed Languages)
+
+**When to use:** Your project has services written in different languages with different build tools and runtimes.
+
+```json
+{
+  "$schema": "https://veld.oss.life.li/schema/v1/veld.schema.json",
+  "schemaVersion": "1",
+  "name": "polyglot",
+  "url_template": "{service}.{branch ?? run}.polyglot.localhost",
+
+  "nodes": {
+    "postgres": {
+      "variants": {
+        "docker": {
+          "type": "start_server",
+          "command": "docker run --rm --name veld-pg-${veld.run} -e POSTGRES_PASSWORD=veld -e POSTGRES_DB=polyglot -p ${veld.port}:5432 postgres:16",
+          "on_stop": "docker stop veld-pg-${veld.run}",
+          "health_check": { "type": "port", "timeout_seconds": 30 },
+          "outputs": {
+            "DATABASE_URL": "postgresql://postgres:veld@localhost:${veld.port}/polyglot",
+            "JDBC_URL": "jdbc:postgresql://localhost:${veld.port}/polyglot"
+          }
+        }
+      }
+    },
+
+    "auth-service": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "cd services/auth && go run . --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/healthz" },
+          "depends_on": { "postgres": "docker" },
+          "env": {
+            "DATABASE_URL": "${nodes.postgres.DATABASE_URL}"
+          }
+        }
+      }
+    },
+
+    "billing-service": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "cd services/billing && ./gradlew bootRun --args='--server.port=${veld.port}'",
+          "health_check": {
+            "type": "http",
+            "path": "/actuator/health",
+            "timeout_seconds": 90,
+            "interval_ms": 3000
+          },
+          "depends_on": { "postgres": "docker" },
+          "env": {
+            "SPRING_DATASOURCE_URL": "${nodes.postgres.JDBC_URL}",
+            "SPRING_DATASOURCE_USERNAME": "postgres",
+            "SPRING_DATASOURCE_PASSWORD": "veld"
+          }
+        }
+      }
+    },
+
+    "recommendation-service": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "cd services/recommendations && uvicorn main:app --host 0.0.0.0 --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/health" },
+          "depends_on": { "postgres": "docker" },
+          "env": {
+            "DATABASE_URL": "${nodes.postgres.DATABASE_URL}"
+          }
+        }
+      }
+    },
+
+    "frontend": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "pnpm --filter @polyglot/web dev",
+          "health_check": { "type": "http", "path": "/" },
+          "depends_on": {
+            "auth-service": "local",
+            "billing-service": "local",
+            "recommendation-service": "local"
+          },
+          "env": {
+            "PORT": "${veld.port}",
+            "NEXT_PUBLIC_AUTH_URL": "${nodes.auth-service.url}",
+            "NEXT_PUBLIC_BILLING_URL": "${nodes.billing-service.url}",
+            "NEXT_PUBLIC_RECOMMENDATIONS_URL": "${nodes.recommendation-service.url}"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**What happens:** Veld does not care what language your services are written in. Go, Java/Kotlin (Spring Boot), Python (FastAPI/uvicorn), and Node.js all work the same way -- they receive `${veld.port}`, bind to it, and Veld health-checks them. Note the longer `timeout_seconds` and `interval_ms` for the Spring Boot service, since JVM startup is slower. Each service gets the same HTTPS URL treatment regardless of its runtime.
+
+---
+
+## 17. End-to-End Test Runner
+
+**When to use:** You want to run the full stack and then execute end-to-end tests against it. The test runner is a `command` node that depends on the entire stack being healthy.
+
+```json
+{
+  "$schema": "https://veld.oss.life.li/schema/v1/veld.schema.json",
+  "schemaVersion": "1",
+  "name": "e2e-suite",
+  "url_template": "{service}.{branch ?? run}.e2e-suite.localhost",
+
+  "presets": {
+    "dev": ["frontend:local"],
+    "test": ["e2e:default"]
+  },
+
+  "nodes": {
+    "postgres": {
+      "variants": {
+        "docker": {
+          "type": "start_server",
+          "command": "docker run --rm --name veld-pg-${veld.run} -e POSTGRES_PASSWORD=veld -e POSTGRES_DB=e2e -p ${veld.port}:5432 postgres:16",
+          "on_stop": "docker stop veld-pg-${veld.run}",
+          "health_check": { "type": "port", "timeout_seconds": 30 },
+          "outputs": {
+            "DATABASE_URL": "postgresql://postgres:veld@localhost:${veld.port}/e2e"
+          }
+        }
+      }
+    },
+
+    "seed-test-data": {
+      "hidden": true,
+      "variants": {
+        "default": {
+          "type": "command",
+          "command": "pnpm --filter @e2e-suite/db seed:test",
+          "depends_on": { "postgres": "docker" },
+          "env": {
+            "DATABASE_URL": "${nodes.postgres.DATABASE_URL}"
+          }
+        }
+      }
+    },
+
+    "backend": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "pnpm --filter @e2e-suite/api dev --port ${veld.port}",
+          "health_check": { "type": "http", "path": "/health" },
+          "depends_on": { "seed-test-data": "default" },
+          "env": {
+            "DATABASE_URL": "${nodes.postgres.DATABASE_URL}",
+            "NODE_ENV": "test"
+          }
+        }
+      }
+    },
+
+    "frontend": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "pnpm --filter @e2e-suite/web dev",
+          "health_check": { "type": "http", "path": "/" },
+          "depends_on": { "backend": "local" },
+          "env": {
+            "PORT": "${veld.port}",
+            "NEXT_PUBLIC_API_URL": "${nodes.backend.url}"
+          }
+        }
+      }
+    },
+
+    "e2e": {
+      "variants": {
+        "default": {
+          "type": "command",
+          "command": "pnpm --filter @e2e-suite/tests playwright test",
+          "depends_on": { "frontend": "local" },
+          "env": {
+            "BASE_URL": "${nodes.frontend.url}",
+            "API_URL": "${nodes.backend.url}"
+          },
+          "outputs": ["TEST_RESULTS_PATH"],
+          "strict_outputs": false
+        }
+      }
+    }
+  }
+}
+```
+
+**What happens:** With `--preset test`:
+
+1. Postgres starts.
+2. Test seed data is inserted.
+3. Backend starts with `NODE_ENV=test`.
+4. Frontend starts.
+5. Once the frontend is healthy, the `e2e` command node runs Playwright tests against the live stack.
+
+The `e2e` node is a `command` type, so it runs to completion and Veld reports its exit code. The `strict_outputs: false` flag means it will not fail if the test runner does not emit a `TEST_RESULTS_PATH` output.
+
+With `--preset dev`, only the frontend and its dependencies start (no test runner), giving you the same stack for manual development.


### PR DESCRIPTION
## Summary

- **Pre-compute ports and URLs** for all `start_server` nodes before any execution begins. `${nodes.X.url}` and `${nodes.X.port}` are now available to every node regardless of dependency order — frontend can reference backend's URL and vice versa without a cycle.
- **Port reservations** hold TCP listeners until the child process spawns, eliminating the TOCTOU race between concurrent `veld start` commands.
- **`${veld.url}`** exposed as a built-in variable for `start_server` nodes, available in `command`, `env`, and `outputs` templates.
- **Scenarios guide** (`docs/scenarios.md`) with 17 real-world configuration patterns including cross-referencing URLs, microservices, Docker infrastructure, feature branch isolation, and more.

## Test plan

- [x] All 27 existing tests pass
- [x] New `test_reservation_holds_port` test verifies port reservation mechanics
- [x] Port tests verified stable across 5 consecutive runs (no flakiness)
- [x] 3 review rounds completed — critical Linux port binding issue found and fixed
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)