### PR TITLE
fix: use login shell in Hammerspoon spoon so veld is found on PATH

### DIFF
--- a/integrations/hammerspoon/Veld.spoon/init.lua
+++ b/integrations/hammerspoon/Veld.spoon/init.lua
@@ -20,11 +20,22 @@ obj.homepage = "https://github.com/prosperity-solutions/veld"
 
 --- Veld.veldBin
 --- Variable
---- Path to the veld binary (default: "/usr/local/bin/veld").
-obj.veldBin = "/usr/local/bin/veld"
+--- Path to the veld binary (default: "veld", resolved via the user's login shell PATH).
+obj.veldBin = "veld"
 
 -- Internal state
 local menubar = nil
+
+-- ============================================================
+-- Shell helper
+-- ============================================================
+
+--- Run a command through the user's login shell so that PATH from
+--- .zshrc / .bashrc / .profile is available.
+local function loginShellExecute(cmd)
+    local shell = os.getenv("SHELL") or "/bin/zsh"
+    return hs.execute(string.format("%s -l -c %q", shell, cmd))
+end
 
 -- ============================================================
 -- Data
@@ -32,8 +43,9 @@ local menubar = nil
 
 --- Fetch all active environments via `veld list --json`.
 local function fetchEnvironments(veldBin)
-    local cmd = string.format("%s list --json 2>/dev/null", veldBin)
-    local output, status = hs.execute(cmd)
+    local output, status = loginShellExecute(
+        string.format("%s list --json 2>/dev/null", veldBin)
+    )
 
     if not status or not output or output == "" then
         return {}
@@ -104,7 +116,8 @@ local function stopRun(veldBin, projectRoot, runName)
         "cd %q && %s stop --name %q 2>&1",
         projectRoot, veldBin, runName
     )
-    hs.task.new("/bin/sh", function(exitCode, stdOut, stdErr)
+    local shell = os.getenv("SHELL") or "/bin/zsh"
+    hs.task.new(shell, function(exitCode, stdOut, stdErr)
         if exitCode == 0 then
             hs.notify.new({
                 title = "Veld",
@@ -119,7 +132,7 @@ local function stopRun(veldBin, projectRoot, runName)
                 withdrawAfter = 5,
             }):send()
         end
-    end, { "-c", cmd }):start()
+    end, { "-l", "-c", cmd }):start()
 end
 
 -- ============================================================


### PR DESCRIPTION
## Summary
- The Hammerspoon menubar spoon hardcoded `/usr/local/bin/veld`, but veld now installs to `~/.local/bin/`. Since `hs.execute` runs in a minimal shell without the user's PATH, `veld list --json` silently failed — always showing "No active environments".
- All shell commands now run through `$SHELL -l -c "..."` so the user's full PATH is available.
- Default `veldBin` changed from `/usr/local/bin/veld` to just `"veld"`, resolved by the login shell.

## Test plan
- [ ] Install the updated Spoon, reload Hammerspoon config, verify active environments appear in the menubar
- [ ] Verify "Stop" action still works from the menubar submenu
- [ ] Verify the spoon works when veld is installed at `~/.local/bin/veld` (default) and `/usr/local/bin/veld` (legacy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)