### PR TITLE
fix: default toolbar position to bottom-left corner

### DIFF
--- a/crates/veld-daemon/assets/feedback-overlay.js
+++ b/crates/veld-daemon/assets/feedback-overlay.js
@@ -459,7 +459,7 @@
         return;
       }
     } catch (_) {}
-    positionFab(window.innerWidth - 20 - FAB_MARGIN, window.innerHeight - 20 - FAB_MARGIN, false);
+    positionFab(20 + FAB_MARGIN, window.innerHeight - 20 - FAB_MARGIN, false);
   }
 
   function clampFabToViewport() {


### PR DESCRIPTION
## Summary
- Change the default toolbar starting position from bottom-right to bottom-left
- Bottom-left feels more natural as a default position for the feedback overlay

## Test plan
- [ ] Verify toolbar appears in bottom-left on first load (no saved position)
- [ ] Verify saved positions still restore correctly
- [ ] Verify toolbar still snaps to viewport on resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)