### PR TITLE
fix: sort preset names alphabetically in veld start selector

### DIFF
--- a/crates/veld/src/commands/start.rs
+++ b/crates/veld/src/commands/start.rs
@@ -450,11 +450,12 @@ async fn follow_logs_until_interrupt(
 
 /// Handle the case where no selections or preset were given.
 fn handle_no_selections(config: &VeldConfig) -> Option<Vec<NodeSelection>> {
-    let preset_names: Vec<String> = config
+    let mut preset_names: Vec<String> = config
         .presets
         .as_ref()
         .map(|p| p.keys().cloned().collect())
         .unwrap_or_default();
+    preset_names.sort();
 
     if is_tty() && !preset_names.is_empty() {
         match interactive_preset_selector(&preset_names) {


### PR DESCRIPTION
## Summary
- Sort preset names alphabetically in the `veld start` interactive selector
- `HashMap` iteration order is non-deterministic in Rust, causing presets to appear in a different order on each run — making it easy to pick the wrong one by number
- Aligns with `veld presets`, which already sorts alphabetically

## Test plan
- [ ] Run `veld start` in a project with multiple presets — verify order is alphabetical and stable across runs
- [ ] Run `veld presets` — verify order matches `veld start`

🤖 Generated with [Claude Code](https://claude.com/claude-code)