### PR TITLE
docs: add client-side log collection to all documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,32 @@ This starts a local HTTP server for the `website/` directory with an HTTPS URL l
 
 Veld ships consumer-facing skills in `skills/` for the [npx skills](https://github.com/vercel-labs/skills) ecosystem. Users install with `npx skills add prosperity-solutions/veld`. Skills are auto-discovered from `skills/*/SKILL.md`.
 
+## PR Workflow
+
+Follow this workflow for every feature or fix:
+
+1. **Implement** — Make the code changes.
+2. **Docs audit** — Before considering the work done, check the [documentation checklist](#documentation-checklist) below.
+3. **Self-review rounds** — Use sub-agents to review the diff. Iterate (review → fix → review → fix) until no issues remain.
+4. **Push to draft PR** — Push the branch and open a draft PR on GitHub.
+5. **Wait for CI** — All checks must be green. Never assume checks are missing just because they haven't started yet.
+6. **Ask before merging** — Ask the maintainer for explicit approval before merging. Only merge with admin bypass if the maintainer explicitly says so upfront at task start.
+
+## Documentation Checklist
+
+When a change introduces new config fields, CLI flags, subcommands, or user-visible behavior, update **all** of the following:
+
+| File | What to update |
+|------|----------------|
+| `README.md` | Features list, CLI reference table, Configuration section |
+| `docs/configuration.md` | Config field reference (top-level table, field section, variant table) |
+| `skills/veld-config/SKILL.md` | Agent-facing config reference |
+| `skills/veld-usage/SKILL.md` | Agent-facing CLI reference |
+| `schema/v1/veld.schema.json` | JSON Schema (usually updated in code, but verify) |
+| `website/llms-full.txt` | LLM-facing docs (if applicable, see `website/AGENTS.md`) |
+
+If the change is purely internal (refactor, bugfix with no new surface area), this checklist does not apply.
+
 ## Key Conventions
 
 - Domain: `veld.oss.life.li` (not `veld.dev`)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ No port numbers. No manual wiring. Just clean, stable, human-readable URLs.
 - **Variable interpolation** — `${veld.port}`, `${nodes.backend.url}`, git branch, etc.
 - **Structured output** — all commands support `--json` for scripting and CI
 - **Browser dashboard** — management UI at `https://veld.localhost` with service health, logs, search, stop/restart
+- **Client-side logs** — captures browser `console.log/warn/error`, exceptions, and promise rejections; view with `veld logs --source client`
 
 ## Install
 
@@ -131,7 +132,7 @@ veld stop --name dev
 | `veld restart [--name <n>]` | Restart an environment |
 | `veld status [--name <n>] [--json]` | Show run status |
 | `veld urls [--name <n>] [--json]` | Show URLs for a run |
-| `veld logs [--name <n>] [--node <n>] [--lines <n>]` | View logs |
+| `veld logs [--name <n>] [--node <n>] [--lines <n>] [--source <s>]` | View logs (source: `all`, `server`, `client`) |
 | `veld graph [NODE:VARIANT...]` | Print dependency graph |
 | `veld nodes` | List all nodes and variants |
 | `veld presets` | List presets |
@@ -174,6 +175,18 @@ veld stop --name dev
 
 Fallback operator: `{branch ?? run}` uses the first non-empty value.
 
+### Client-side log levels
+
+Veld automatically captures browser `console.log`, `console.warn`, `console.error`, unhandled exceptions, and promise rejections from `start_server` nodes. Configure which levels to capture with `client_log_levels` at the project, node, or variant level (most specific wins):
+
+```json
+"client_log_levels": ["log", "warn", "error"]
+```
+
+Valid levels: `"log"`, `"warn"`, `"error"`, `"info"`, `"debug"`. Default: `["log", "warn", "error"]`. Unhandled exceptions are always captured regardless of this setting.
+
+View client logs with `veld logs --source client` or filter by source in the management UI.
+
 ### Variable interpolation
 
 Commands, env values, and output templates support `${veld.port}`, `${veld.url}`, `${veld.run}`, `${veld.root}`, `${nodes.backend.url}`, `${nodes.backend.port}`, etc.
@@ -209,7 +222,7 @@ Caddy handles HTTPS termination and reverse proxying. Its internal CA is trusted
 Veld includes a browser-based dashboard at `https://veld.localhost` (or `https://veld.localhost:18443` in unprivileged mode). It shows all environments with:
 
 - **Services tab** — nodes with health status indicators, URLs with copy/open, variant, PID
-- **Logs tab** — terminal viewer with search + highlighting, context lines (grep -C), auto-scroll, node filter
+- **Logs tab** — terminal viewer with search + highlighting, context lines (grep -C), auto-scroll, node filter, source filter (server/client/all)
 - **Stop/Restart** — control environments directly from the browser
 
 Open it with `veld ui` or visit the URL directly.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,9 +36,12 @@ All relative paths in the configuration resolve relative to the directory contai
 | `$schema`        | string | No       | JSON Schema URL for editor autocompletion         |
 | `schemaVersion`  | string | Yes      | Must be `"1"` for the current version             |
 | `name`           | string | Yes      | Human-readable project name                       |
-| `url_template`   | string | No       | URL template for services (see [URL Templates])   |
-| `presets`        | object | No       | Named shortcuts for node:variant selections       |
-| `nodes`          | object | Yes      | The dependency graph nodes                        |
+| `url_template`      | string | No       | URL template for services (see [URL Templates])   |
+| `presets`           | object | No       | Named shortcuts for node:variant selections       |
+| `client_log_levels` | array  | No       | Browser log levels to capture (see [Client-Side Log Levels]) |
+| `nodes`             | object | Yes      | The dependency graph nodes                        |
+
+[Client-Side Log Levels]: #client-side-log-levels
 
 [URL Templates]: #url-templates
 
@@ -73,6 +76,38 @@ Defines how Veld generates HTTPS URLs for your services. See the full [URL Templ
 ```
 
 **Default:** `{service}.{run}.{project}.localhost`
+
+### `client_log_levels`
+
+Controls which browser console levels Veld captures from `start_server` nodes. Veld injects a small script into proxied HTML responses that hooks `console.log`, `console.warn`, `console.error`, `console.info`, and `console.debug`, plus `window.onerror` and `onunhandledrejection`. Captured logs are sent to the Veld daemon and appear in `veld logs` and the management UI alongside server logs.
+
+```json
+"client_log_levels": ["log", "warn", "error"]
+```
+
+**Valid values:** `"log"`, `"warn"`, `"error"`, `"info"`, `"debug"`
+
+**Default:** `["log", "warn", "error"]`
+
+Unhandled exceptions and promise rejections are always captured regardless of this setting.
+
+The setting cascades: variant-level overrides node-level overrides project-level. Set it to an empty array to capture only unhandled exceptions.
+
+```json
+{
+  "client_log_levels": ["warn", "error"],
+  "nodes": {
+    "frontend": {
+      "client_log_levels": ["log", "warn", "error", "info"],
+      "variants": {
+        "local": {
+          "client_log_levels": ["debug", "log", "warn", "error", "info"]
+        }
+      }
+    }
+  }
+}
+```
 
 ---
 
@@ -119,6 +154,17 @@ When set to `true`, the node is excluded from `veld nodes` output. Hidden nodes 
 }
 ```
 
+### `client_log_levels` (node-level)
+
+Overrides the project-level `client_log_levels` for all variants of this node. See [Client-Side Log Levels](#client-side-log-levels) for details.
+
+```json
+"frontend": {
+  "client_log_levels": ["log", "warn", "error", "info"],
+  "variants": { ... }
+}
+```
+
 ### `url_template` (node-level)
 
 Overrides the project-level `url_template` for all variants of this node. See [URL Template Cascade](#url-template-cascade) for resolution order.
@@ -155,6 +201,7 @@ A variant defines how a node behaves in a given context. The same node might be 
 | `url_template`      | string           | No       | `start_server` | URL template override for this variant                |
 | `on_stop`           | string           | No       | All            | Teardown command run when the environment is stopped  |
 | `verify`            | string           | No       | `command` only    | Idempotency verification command                      |
+| `client_log_levels` | array of strings | No       | `start_server` | Browser log levels override for this variant          |
 
 ### `type`
 

--- a/skills/veld-config/SKILL.md
+++ b/skills/veld-config/SKILL.md
@@ -32,6 +32,7 @@ Always include the `$schema` field for editor autocompletion:
 | `name` | string | Yes | Project name (alphanumeric, dots, hyphens, underscores) |
 | `url_template` | string | No | Default: `{service}.{run}.{project}.localhost` |
 | `presets` | object | No | Named shortcuts for node:variant selections |
+| `client_log_levels` | array | No | Browser log levels to capture: `["log", "warn", "error"]` (default). Valid: `"log"`, `"warn"`, `"error"`, `"info"`, `"debug"`. Exceptions always captured. |
 | `nodes` | object | Yes | At least one node required |
 
 ## Node Types
@@ -265,6 +266,16 @@ Use `command` type with `verify` — the verify script runs first, and if it exi
 
 ### Wiring environment variables between nodes
 Use `${nodes.<node>.<output>}` in the `env` block of dependent nodes. Veld resolves these after dependencies complete.
+
+### Client-side log levels
+
+Captures browser console output from `start_server` nodes. Cascades: variant > node > project.
+
+```json
+"client_log_levels": ["log", "warn", "error", "info", "debug"]
+```
+
+Set at project, node, or variant level. Unhandled exceptions are always captured.
 
 ## Common Mistakes
 

--- a/skills/veld-usage/SKILL.md
+++ b/skills/veld-usage/SKILL.md
@@ -101,6 +101,8 @@ veld logs --name dev --lines 200              # More lines
 veld logs --name dev --since 5m               # Last 5 minutes
 veld logs --name dev --follow                 # Stream (like tail -f)
 veld logs --name dev --node backend --follow  # Stream single node
+veld logs --name dev --source client          # Client-side (browser) logs only
+veld logs --name dev --source server          # Server logs only (default: all)
 veld logs --name dev --json                   # NDJSON format
 ```
 

--- a/website/llms-full.txt
+++ b/website/llms-full.txt
@@ -121,7 +121,7 @@ veld stop --name dev
 | `veld restart [--name <n>]` | Restart an environment |
 | `veld status [--name <n>] [--json]` | Show run status |
 | `veld urls [--name <n>] [--json]` | Show URLs for a run |
-| `veld logs [--name <n>] [--node <n>] [--lines <n>] [-f]` | View logs (`-f` to follow) |
+| `veld logs [--name <n>] [--node <n>] [--lines <n>] [-f] [--source <s>]` | View logs (`-f` to follow, source: `all`/`server`/`client`) |
 | `veld graph [NODE:VARIANT...]` | Print dependency graph |
 | `veld nodes` | List all nodes and variants |
 | `veld presets` | List presets |
@@ -180,6 +180,32 @@ This makes veld uniquely suited for agentic workflows where AI agents build UI a
 
 ---
 
+## Client-Side Log Collection
+
+Veld automatically captures browser console output from `start_server` nodes. A small script is injected into proxied HTML responses that hooks `console.log`, `console.warn`, `console.error`, `console.info`, and `console.debug`, plus `window.onerror` and `onunhandledrejection`.
+
+Captured logs appear alongside server logs in `veld logs` and the management UI. Filter by source:
+
+```sh
+veld logs --source client          # Browser logs only
+veld logs --source server          # Server logs only
+veld logs --source all             # Both (default)
+```
+
+### Configuration
+
+Control which levels to capture with `client_log_levels` at the project, node, or variant level (most specific wins):
+
+```json
+"client_log_levels": ["log", "warn", "error", "info", "debug"]
+```
+
+Valid levels: `"log"`, `"warn"`, `"error"`, `"info"`, `"debug"`. Default: `["log", "warn", "error"]`. Unhandled exceptions and promise rejections are always captured regardless of this setting.
+
+The management UI also provides source filter controls (All / Server / Client) in the Logs tab.
+
+---
+
 ## Configuration Reference
 
 ### Top-Level Structure
@@ -191,6 +217,7 @@ This makes veld uniquely suited for agentic workflows where AI agents build UI a
 | `name` | string | Yes | Project name (used in URLs) |
 | `url_template` | string | No | URL template for services |
 | `presets` | object | No | Named shortcuts for node:variant selections |
+| `client_log_levels` | array | No | Browser log levels to capture (default: `["log", "warn", "error"]`) |
 | `nodes` | object | Yes | The dependency graph nodes |
 
 ### Step Types
@@ -361,6 +388,7 @@ Usage: `veld start --preset fullstack --name my-feature`
 | `on_stop` | string | All | Teardown command on `veld stop` |
 | `verify` | string | `command` only | Idempotency check (exit 0 = skip) |
 | `sensitive_outputs` | array | All | Output keys to mask and encrypt |
+| `client_log_levels` | array | `start_server` | Browser log levels override (variant > node > project) |
 | `hidden` (node-level) | boolean | All | Hide from `veld nodes` output |
 
 ---


### PR DESCRIPTION
## Summary

- Documents `client_log_levels` config field (project/node/variant cascade) in README, docs/configuration.md, skills/veld-config, and llms-full.txt
- Documents `--source all|server|client` flag on `veld logs` in README, skills/veld-usage, and llms-full.txt
- Adds "Client-side logs" to the README features list and management UI description
- Adds **PR Workflow** and **Documentation Checklist** sections to AGENTS.md so future features include a docs audit pass by default

## Context

PR #71 shipped the full client-side log collection system but didn't update any documentation, skills, or LLM references. This PR fills that gap and adds guardrails to prevent it from happening again.

## Test plan

- [ ] Verify all internal markdown links resolve correctly
- [ ] Verify `client_log_levels` documentation matches schema/v1/veld.schema.json
- [ ] Verify `--source` flag documentation matches CLI implementation
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)