### PR TITLE
feat: secure output channel via $VELD_OUTPUT_FILE

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -361,7 +361,7 @@ If two selected end nodes transitively require the same dependency node with *di
 Runs a shell script or inline command to completion. Used for setup tasks — database cloning, seeding, exporting remote service URLs, etc.
 
 - Working directory defaults to `${veld.root}`
-- Declares outputs via `VELD_OUTPUT key=value` written to stdout
+- Declares outputs by writing `key=value` lines to `$VELD_OUTPUT_FILE` (preferred) or via `VELD_OUTPUT key=value` on stdout (legacy, discouraged)
 - Built-in outputs: `exit_code`
 - Optional `verify` command for idempotency of steps with external side effects:
   - Exit `0` → skip, previous result still valid
@@ -385,7 +385,7 @@ Starts and manages a long-lived process.
 }
 ```
 
-This is particularly useful for Docker infrastructure nodes where stdout cannot be used for `VELD_OUTPUT`.
+This is particularly useful for Docker infrastructure nodes where the process cannot write to `$VELD_OUTPUT_FILE`.
 
 - stdout/stderr streamed to the run's log store (see Logging)
 
@@ -835,7 +835,7 @@ All logic shared across binaries:
 - Node graph construction, topological sort, cycle detection, variant resolution
 - Variable reference validation and ambiguity detection at graph resolution time
 - Parallel execution engine (dependency-ordered startup, reverse-order teardown)
-- Bash runner (`VELD_OUTPUT` stdout parsing, `verify` execution)
+- Bash runner (`$VELD_OUTPUT_FILE` + legacy `VELD_OUTPUT` stdout parsing, `verify` execution)
 - Server launcher (process management, port allocation from managed range)
 - `outputs` interpolation for `start_server` (post-port-allocation)
 - Two-phase health check polling (port check + HTTPS URL check)

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ veld stop --name dev
 ### Step types
 
 - **`start_server`** — long-running process. Veld allocates a port (`${veld.port}`), starts the process, and runs health checks.
-- **`command`** — runs a command to completion. Can emit outputs via `VELD_OUTPUT key=value` on stdout. Optional `verify` command for idempotency.
+- **`command`** — runs a command to completion. Can emit outputs by writing `key=value` lines to `$VELD_OUTPUT_FILE` (preferred) or via `VELD_OUTPUT key=value` on stdout (legacy, discouraged). Optional `verify` command for idempotency.
 
 ### Health checks
 

--- a/crates/veld-core/src/config.rs
+++ b/crates/veld-core/src/config.rs
@@ -182,7 +182,7 @@ pub struct VariantConfig {
 #[derive(Debug, Clone, Serialize)]
 #[serde(untagged)]
 pub enum Outputs {
-    /// Declared output names for `command` steps (captured from VELD_OUTPUT).
+    /// Declared output names for `command` steps (captured from `$VELD_OUTPUT_FILE` or legacy `VELD_OUTPUT` stdout).
     Declared(Vec<String>),
     /// Synthetic output templates for `start_server` steps.
     Synthetic(HashMap<String, String>),

--- a/crates/veld-core/src/logging.rs
+++ b/crates/veld-core/src/logging.rs
@@ -59,6 +59,17 @@ pub fn debug_log_file(project_root: &Path, run_name: &str) -> PathBuf {
     log_dir(project_root, run_name).join("veld-debug.log")
 }
 
+/// Return a temporary output file path for a command node.
+///
+/// Scripts write `key=value` lines to this file instead of emitting
+/// `VELD_OUTPUT` on stdout, keeping sensitive values off the terminal.
+pub fn output_file(project_root: &Path, run_name: &str, node: &str, variant: &str) -> PathBuf {
+    project_root
+        .join(".veld")
+        .join("tmp")
+        .join(format!("{run_name}-{node}-{variant}.outputs"))
+}
+
 // ---------------------------------------------------------------------------
 // Log writer
 // ---------------------------------------------------------------------------

--- a/crates/veld-core/src/orchestrator.rs
+++ b/crates/veld-core/src/orchestrator.rs
@@ -859,7 +859,7 @@ impl Orchestrator {
             self.project_root.clone()
         });
 
-        match process::run_command(&resolved_cmd, &working_dir, &env).await {
+        match process::run_command(&resolved_cmd, &working_dir, &env, None).await {
             Ok(result) => {
                 if result.exit_code != 0 {
                     tracing::warn!(
@@ -1492,7 +1492,7 @@ async fn execute_command_isolated(
     // Verify step (idempotency).
     if let Some(ref verify_cmd) = variant_cfg.verify {
         let verify_resolved = crate::variables::interpolate(verify_cmd, var_ctx)?;
-        let verify_result = process::run_command(&verify_resolved, &working_dir, &env).await;
+        let verify_result = process::run_command(&verify_resolved, &working_dir, &env, None).await;
         if let Ok(ref out) = verify_result {
             if out.exit_code == 0 {
                 tracing::info!(
@@ -1517,7 +1517,10 @@ async fn execute_command_isolated(
             variant: sel.variant.clone(),
         },
     );
-    let result = process::run_command(&resolved_cmd, &working_dir, &env).await?;
+    let output_file =
+        logging::output_file(&ctx.project_root, &ctx.run_name, &sel.node, &sel.variant);
+    let result =
+        process::run_command(&resolved_cmd, &working_dir, &env, Some(&output_file)).await?;
 
     node_state
         .outputs

--- a/crates/veld-core/src/process.rs
+++ b/crates/veld-core/src/process.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
 use thiserror::Error;
@@ -24,6 +24,12 @@ pub enum ProcessError {
 
     #[error("failed to send signal to pid {pid}: {source}")]
     SignalFailed { pid: u32, source: std::io::Error },
+
+    #[error("failed to read output file {path}: {source}")]
+    OutputFileError {
+        path: PathBuf,
+        source: std::io::Error,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -240,28 +246,80 @@ async fn timestamp_pipe<R: tokio::io::AsyncRead + Unpin>(reader: R, log_path: &P
 // Run a command to completion, capturing VELD_OUTPUT lines
 // ---------------------------------------------------------------------------
 
-/// Run a command/script to completion. Parses `VELD_OUTPUT key=value`
-/// lines from stdout. Returns the collected outputs and exit code.
+/// Run a command/script to completion. Collects outputs from two channels:
+///
+/// 1. **File-based (preferred):** If `output_file` is `Some`, the file is
+///    created before spawning and `VELD_OUTPUT_FILE` is set in the child env.
+///    The script writes `key=value` lines to this file. After the process
+///    exits the file is read and deleted.
+///
+/// 2. **Stdout-based (legacy fallback):** `VELD_OUTPUT key=value` lines on
+///    stdout are still parsed for backward compatibility but this channel is
+///    discouraged because it exposes values in the terminal and logs.
+///
+/// When both channels produce the same key, the file-based value wins.
 pub async fn run_command(
     command: &str,
     working_dir: &Path,
     env: &HashMap<String, String>,
+    output_file: Option<&Path>,
 ) -> Result<CommandOutput, ProcessError> {
-    let mut child = Command::new("sh")
+    // Prepare the output file and augmented env.
+    let mut env = env.clone();
+    if let Some(path) = output_file {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| ProcessError::OutputFileError {
+                path: path.to_path_buf(),
+                source: e,
+            })?;
+        }
+        // Create (or truncate) the file with restrictive permissions (0600)
+        // since it may contain sensitive values like database passwords.
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o600)
+                .open(path)
+                .map_err(|e| ProcessError::OutputFileError {
+                    path: path.to_path_buf(),
+                    source: e,
+                })?;
+        }
+        env.insert(
+            "VELD_OUTPUT_FILE".to_owned(),
+            path.to_string_lossy().into_owned(),
+        );
+    }
+
+    let spawn_result = Command::new("sh")
         .arg("-c")
         .arg(command)
         .current_dir(working_dir)
-        .envs(env)
+        .envs(&env)
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(ProcessError::SpawnFailed)?;
+        .stderr(Stdio::inherit())
+        .spawn();
+
+    let mut child = match spawn_result {
+        Ok(child) => child,
+        Err(e) => {
+            // Clean up the output file on spawn failure.
+            if let Some(path) = output_file {
+                let _ = std::fs::remove_file(path);
+            }
+            return Err(ProcessError::SpawnFailed(e));
+        }
+    };
 
     let stdout = child.stdout.take().expect("stdout should be piped");
 
     let mut reader = BufReader::new(stdout).lines();
     let mut outputs = HashMap::new();
 
+    // Legacy stdout channel.
     while let Ok(Some(line)) = reader.next_line().await {
         if let Some(kv) = line.strip_prefix("VELD_OUTPUT ") {
             if let Some((key, value)) = kv.split_once('=') {
@@ -271,6 +329,44 @@ pub async fn run_command(
     }
 
     let status = child.wait().await.map_err(ProcessError::SpawnFailed)?;
+
+    // Read file-based outputs (overrides stdout for duplicate keys).
+    if let Some(path) = output_file {
+        match std::fs::read_to_string(path) {
+            Ok(contents) => {
+                for line in contents.lines() {
+                    let line = line.trim();
+                    if line.is_empty() {
+                        continue;
+                    }
+                    if let Some((key, value)) = line.split_once('=') {
+                        outputs.insert(key.trim().to_owned(), value.trim().to_owned());
+                    } else {
+                        tracing::warn!(
+                            line,
+                            "ignoring malformed line in output file (expected key=value)"
+                        );
+                    }
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                tracing::warn!(
+                    path = %path.display(),
+                    "output file was deleted by the script"
+                );
+            }
+            Err(e) => {
+                // Clean up before returning error.
+                let _ = std::fs::remove_file(path);
+                return Err(ProcessError::OutputFileError {
+                    path: path.to_path_buf(),
+                    source: e,
+                });
+            }
+        }
+        // Always clean up the temp file.
+        let _ = std::fs::remove_file(path);
+    }
 
     let exit_code = status.code().unwrap_or(-1);
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -253,14 +253,14 @@ Runs a shell command or script to completion. Used for setup tasks such as datab
 
 - The working directory defaults to `${veld.root}` (the directory containing `veld.json`)
 - Must specify either `command` or `script` (mutually exclusive)
-- Can declare outputs via `VELD_OUTPUT key=value` written to stdout
+- Can declare outputs by writing `key=value` lines to `$VELD_OUTPUT_FILE` (preferred) or via `VELD_OUTPUT key=value` on stdout (legacy, discouraged — exposes values in terminal/logs)
 - Built-in output: `exit_code`
 - Supports the `verify` field for idempotency
 
 ```json
 {
   "type": "command",
-  "command": "echo 'VELD_OUTPUT DATABASE_URL=postgresql://localhost:5432/mydb'",
+  "command": "echo 'DATABASE_URL=postgresql://localhost:5432/mydb' >> \"$VELD_OUTPUT_FILE\"",
   "outputs": ["DATABASE_URL"]
 }
 ```
@@ -399,7 +399,7 @@ Output declarations differ based on the variant type.
 
 #### For `command` variants: Array of strings
 
-Declares the output names that the script will emit via `VELD_OUTPUT` lines written to stdout. Your script prints `VELD_OUTPUT key=value` to stdout, and Veld captures the values.
+Declares the output names that the script will produce. Veld provides a `$VELD_OUTPUT_FILE` environment variable pointing to a temporary file — your script writes `key=value` lines there. This keeps sensitive values (database passwords, API keys) off stdout and out of terminal scrollback and log aggregators.
 
 ```json
 {
@@ -412,15 +412,17 @@ Declares the output names that the script will emit via `VELD_OUTPUT` lines writ
 Inside the script:
 ```bash
 #!/bin/bash
-echo "VELD_OUTPUT DATABASE_URL=postgresql://localhost:5432/mydb"
-echo "VELD_OUTPUT DB_NAME=mydb"
+echo "DATABASE_URL=postgresql://localhost:5432/mydb" >> "$VELD_OUTPUT_FILE"
+echo "DB_NAME=mydb" >> "$VELD_OUTPUT_FILE"
 ```
+
+> **Legacy fallback (discouraged):** For backward compatibility, Veld also parses `VELD_OUTPUT key=value` lines from stdout. This method is **discouraged** because it exposes output values in the terminal, log aggregators, and CI build output. Prefer `$VELD_OUTPUT_FILE` for all new scripts. If both channels emit the same key, the file-based value takes precedence.
 
 Every `command` variant also automatically provides the built-in output `exit_code`.
 
 #### For `start_server` variants: Object (key-value map)
 
-Defines synthetic outputs whose values are string templates interpolated after the port and URL are resolved. Templates support all `${veld.*}` and `${nodes.*}` variables. This is especially useful for Docker infrastructure nodes where stdout cannot be used for `VELD_OUTPUT`.
+Defines synthetic outputs whose values are string templates interpolated after the port and URL are resolved. Templates support all `${veld.*}` and `${nodes.*}` variables. This is especially useful for Docker infrastructure nodes where the process cannot write to `$VELD_OUTPUT_FILE`.
 
 ```json
 {
@@ -589,7 +591,7 @@ ${nodes.frontend.url}              # works even if frontend runs AFTER this node
 
 #### Execution-order outputs (available to downstream nodes only)
 
-Custom outputs — from synthetic output templates (`outputs` object) or `VELD_OUTPUT` lines in command nodes — are only available after the producing node has executed. These require a `depends_on` edge.
+Custom outputs — from synthetic output templates (`outputs` object) or `$VELD_OUTPUT_FILE` / `VELD_OUTPUT` lines in command nodes — are only available after the producing node has executed. These require a `depends_on` edge.
 
 ```
 ${nodes.database.DATABASE_URL}     # custom output from bash or outputs declaration
@@ -829,7 +831,7 @@ Below is a realistic `veld.json` for a monorepo with a database, backend API, fr
         },
         "staging": {
           "type": "command",
-          "command": "echo 'VELD_OUTPUT BACKEND_URL=https://api.staging.my-project.com'",
+          "command": "echo 'BACKEND_URL=https://api.staging.my-project.com' >> \"$VELD_OUTPUT_FILE\"",
           "outputs": ["BACKEND_URL"]
         }
       }

--- a/docs/scenarios.md
+++ b/docs/scenarios.md
@@ -150,7 +150,7 @@ For the full field reference, see [configuration.md](./configuration.md).
 
 **What happens:** Veld pre-computes URLs and ports for all three `start_server` nodes before starting anything. The backend receives `${nodes.frontend.url}` and `${nodes.admin.url}` as CORS origins even though neither frontend nor admin has started yet. No `depends_on` is needed between them -- all three start in parallel. This is only possible because the built-in `url` and `port` outputs are available before execution.
 
-Note: This pre-computation only applies to the built-in `url` and `port` outputs. Custom outputs (from `outputs` templates or `VELD_OUTPUT` lines) still require the producing node to have executed first, so they still need `depends_on`.
+Note: This pre-computation only applies to the built-in `url` and `port` outputs. Custom outputs (from `$VELD_OUTPUT_FILE` or `VELD_OUTPUT` lines) still require the producing node to have executed first, so they still need `depends_on`.
 
 ---
 
@@ -273,7 +273,7 @@ Note: This pre-computation only applies to the built-in `url` and `port` outputs
         },
         "staging": {
           "type": "command",
-          "command": "echo 'VELD_OUTPUT BACKEND_URL=https://api.staging.dashboard.example.com'",
+          "command": "echo 'BACKEND_URL=https://api.staging.dashboard.example.com' >> \"$VELD_OUTPUT_FILE\"",
           "outputs": ["BACKEND_URL"]
         }
       }
@@ -651,7 +651,7 @@ The `verify` commands on the setup nodes make subsequent `veld start` calls fast
 
 ## 8. Docker Infrastructure with Synthetic Outputs
 
-**When to use:** You run Postgres, Redis, and Elasticsearch as Docker containers. Each needs to expose a connection string to downstream nodes. Since Docker containers cannot write `VELD_OUTPUT` to stdout in a way Veld captures, you use synthetic outputs.
+**When to use:** You run Postgres, Redis, and Elasticsearch as Docker containers. Each needs to expose a connection string to downstream nodes. Since Docker containers cannot write to `$VELD_OUTPUT_FILE` in a way Veld captures, you use synthetic outputs.
 
 ```json
 {
@@ -736,7 +736,7 @@ The `verify` commands on the setup nodes make subsequent `veld start` calls fast
 }
 ```
 
-**What happens:** All three infrastructure containers start in parallel. Synthetic outputs are template strings that are interpolated after port allocation -- no `VELD_OUTPUT` lines needed. The `api` node depends on all three and receives five connection strings. Note the Redis node exposes three different database numbers for different concerns (main, cache, queue).
+**What happens:** All three infrastructure containers start in parallel. Synthetic outputs are template strings that are interpolated after port allocation -- no `$VELD_OUTPUT_FILE` writes needed. The `api` node depends on all three and receives five connection strings. Note the Redis node exposes three different database numbers for different concerns (main, cache, queue).
 
 ---
 
@@ -885,7 +885,7 @@ Each branch also gets its own Docker volume (`veld-pg-${veld.branch}`) and datab
       "variants": {
         "default": {
           "type": "command",
-          "command": "vault read -format=json secret/dev/payment-gateway | jq -r '.data | to_entries[] | \"VELD_OUTPUT \\(.key)=\\(.value)\"'",
+          "command": "vault read -format=json secret/dev/payment-gateway | jq -r '.data | to_entries[] | \"\\(.key)=\\(.value)\"' >> \"$VELD_OUTPUT_FILE\"",
           "outputs": ["STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET"],
           "sensitive_outputs": ["STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET"]
         }
@@ -1018,7 +1018,7 @@ The `admin` node uses a node-level `url_template` override to produce a differen
         },
         "staging": {
           "type": "command",
-          "command": "echo 'VELD_OUTPUT SERVICE_URL=https://user-service.staging.marketplace.example.com'",
+          "command": "echo 'SERVICE_URL=https://user-service.staging.marketplace.example.com' >> \"$VELD_OUTPUT_FILE\"",
           "outputs": ["SERVICE_URL"]
         }
       }
@@ -1034,7 +1034,7 @@ The `admin` node uses a node-level `url_template` override to produce a differen
         },
         "staging": {
           "type": "command",
-          "command": "echo 'VELD_OUTPUT SERVICE_URL=https://catalog-service.staging.marketplace.example.com'",
+          "command": "echo 'SERVICE_URL=https://catalog-service.staging.marketplace.example.com' >> \"$VELD_OUTPUT_FILE\"",
           "outputs": ["SERVICE_URL"]
         }
       }
@@ -1050,7 +1050,7 @@ The `admin` node uses a node-level `url_template` override to produce a differen
         },
         "staging": {
           "type": "command",
-          "command": "echo 'VELD_OUTPUT SERVICE_URL=https://payment-service.staging.marketplace.example.com'",
+          "command": "echo 'SERVICE_URL=https://payment-service.staging.marketplace.example.com' >> \"$VELD_OUTPUT_FILE\"",
           "outputs": ["SERVICE_URL"]
         }
       }
@@ -1061,7 +1061,7 @@ The `admin` node uses a node-level `url_template` override to produce a differen
       "variants": {
         "staging": {
           "type": "command",
-          "command": "echo 'VELD_OUTPUT SERVICE_URL=https://notification-service.staging.marketplace.example.com'",
+          "command": "echo 'SERVICE_URL=https://notification-service.staging.marketplace.example.com' >> \"$VELD_OUTPUT_FILE\"",
           "outputs": ["SERVICE_URL"]
         }
       }

--- a/schema/v1/veld.schema.json
+++ b/schema/v1/veld.schema.json
@@ -139,7 +139,7 @@
           }
         },
         "outputs": {
-          "description": "Output declarations. For command steps: an array of output names captured from VELD_OUTPUT. For start_server steps: an object mapping output names to template strings.",
+          "description": "Output declarations. For command steps: an array of output names captured from $VELD_OUTPUT_FILE (preferred) or VELD_OUTPUT stdout lines (legacy). For start_server steps: an object mapping output names to template strings.",
           "oneOf": [
             {
               "type": "array",
@@ -167,7 +167,7 @@
         "strict_outputs": {
           "type": "boolean",
           "default": true,
-          "description": "When true (default), fail if the command produces VELD_OUTPUT keys not declared in \"outputs\". Set to false to silently ignore undeclared outputs."
+          "description": "When true (default), fail if the command produces output keys (via $VELD_OUTPUT_FILE or stdout) not declared in \"outputs\". Set to false to silently ignore undeclared outputs."
         },
         "verify": {
           "type": "string",

--- a/skills/veld-config/SKILL.md
+++ b/skills/veld-config/SKILL.md
@@ -77,7 +77,7 @@ For setup steps, migrations, data seeding. Can emit outputs via stdout.
 }
 ```
 
-The script emits outputs by printing `VELD_OUTPUT key=value` lines to stdout.
+The script emits outputs by writing `key=value` lines to `$VELD_OUTPUT_FILE` (preferred). The legacy method of printing `VELD_OUTPUT key=value` to stdout is still supported but discouraged as it exposes values in the terminal.
 
 ## Health Checks
 

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -33,7 +33,7 @@ The website has **two audiences** — humans and LLMs. When you change content, 
 ### Correctness constraints
 
 - `command` type steps do NOT get `${veld.port}` allocated — only `start_server` does.
-- `start_server` outputs are objects (synthetic templates); `command` outputs are arrays (captured from VELD_OUTPUT).
+- `start_server` outputs are objects (synthetic templates); `command` outputs are arrays (captured from `$VELD_OUTPUT_FILE` or legacy `VELD_OUTPUT` stdout).
 - The domain is `veld.oss.life.li`, not `veld.dev`.
 - URL templates use `{variable}` (single braces); commands/env use `${variable}`.
 - The install URL is `https://veld.oss.life.li/get` (nginx redirects to GitHub).

--- a/website/llms-full.txt
+++ b/website/llms-full.txt
@@ -256,7 +256,7 @@ Starts and manages a long-lived process. Veld allocates a port, injects it as `$
 Runs a shell command or script to completion. Used for setup tasks.
 
 - Must specify either `command` or `script` (mutually exclusive)
-- Can emit outputs via `VELD_OUTPUT key=value` on stdout
+- Can emit outputs by writing `key=value` lines to `$VELD_OUTPUT_FILE` (preferred) or via `VELD_OUTPUT key=value` on stdout (legacy, discouraged)
 - Declares outputs as an array of strings
 - Built-in output: `exit_code`
 - Supports `verify` for idempotency
@@ -312,7 +312,7 @@ For `start_server` variants — object (synthetic templates):
 }
 ```
 
-For `command` variants — array (captured from VELD_OUTPUT):
+For `command` variants — array (captured from `$VELD_OUTPUT_FILE` or legacy `VELD_OUTPUT` stdout):
 ```json
 "outputs": ["DATABASE_URL", "DB_NAME"]
 ```


### PR DESCRIPTION
## Summary

- Adds `$VELD_OUTPUT_FILE` env var for command nodes — scripts write `key=value` lines to this temp file instead of emitting `VELD_OUTPUT` on stdout, keeping sensitive values (DB passwords, API keys) off the terminal and log aggregators
- Output file created with 0600 permissions, cleaned up after read (including on spawn failure)
- Old stdout-based `VELD_OUTPUT` parsing preserved as backward-compatible fallback, marked as **discouraged** across all documentation
- File-based outputs take precedence over stdout for duplicate keys

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes (11/11)
- [ ] Manual test: command node writes to `$VELD_OUTPUT_FILE`, downstream node receives the value
- [ ] Manual test: legacy `VELD_OUTPUT` stdout still works
- [ ] Manual test: output file is cleaned up after run
- [ ] CI checks pass

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)