### PR TITLE
feat: add `veld config` command

### DIFF
--- a/crates/veld/src/commands/config.rs
+++ b/crates/veld/src/commands/config.rs
@@ -1,0 +1,41 @@
+use crate::output;
+
+/// `veld config [--path]`
+///
+/// Print the resolved veld.json contents. With `--path`, print only the file path.
+pub async fn run(path_only: bool, json: bool) -> i32 {
+    let cwd = match std::env::current_dir() {
+        Ok(d) => d,
+        Err(e) => {
+            output::print_error(&format!("Failed to get current directory: {e}"), json);
+            return 1;
+        }
+    };
+
+    let config_path = match veld_core::config::discover_config(&cwd) {
+        Ok(p) => p,
+        Err(e) => {
+            output::print_error(&format!("{e}"), json);
+            return 1;
+        }
+    };
+
+    if path_only {
+        println!("{}", config_path.display());
+        return 0;
+    }
+
+    match std::fs::read_to_string(&config_path) {
+        Ok(contents) => {
+            print!("{contents}");
+            0
+        }
+        Err(e) => {
+            output::print_error(
+                &format!("Failed to read {}: {e}", config_path.display()),
+                json,
+            );
+            1
+        }
+    }
+}

--- a/crates/veld/src/commands/mod.rs
+++ b/crates/veld/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod config;
 pub mod doctor;
 pub mod feedback;
 pub mod gc;

--- a/crates/veld/src/main.rs
+++ b/crates/veld/src/main.rs
@@ -190,6 +190,17 @@ enum Command {
         json: bool,
     },
 
+    /// Print the project's veld.json configuration.
+    Config {
+        /// Print only the path to veld.json instead of its contents.
+        #[arg(long)]
+        path: bool,
+
+        /// Output as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Initialise a new veld.json in the current directory.
     Init,
 
@@ -364,6 +375,8 @@ async fn main() {
         Command::Nodes { json } => commands::nodes::run(json).await,
 
         Command::Presets { json } => commands::presets::run(json).await,
+
+        Command::Config { path, json } => commands::config::run(path, json).await,
 
         Command::Init => commands::init::run().await,
 

--- a/skills/veld/SKILL.md
+++ b/skills/veld/SKILL.md
@@ -5,7 +5,7 @@ description: >
   start/stop/restart environments, view logs or status, configure veld.json
   (add nodes, services, dependencies, presets, health checks, URL templates),
   get human feedback on UI changes, debug environment issues, or run any veld command.
-allowed-tools: Read, Edit, Bash(veld *), Bash(cat veld.json)
+allowed-tools: Read, Edit, Bash(veld *)
 metadata:
   author: prosperity-solutions
   version: "3.0.0"
@@ -18,7 +18,7 @@ Veld orchestrates local dev environments. It starts services from `veld.json`, w
 ## Live State
 
 ### Configuration
-!`cat veld.json 2>&1`
+!`veld config 2>&1`
 
 ### Nodes & presets
 !`veld nodes 2>&1`


### PR DESCRIPTION
## Summary
- Adds `veld config` CLI command that discovers and prints the project's `veld.json` using the existing config resolution (walks up from CWD)
- Fixes the agent skill's `cat veld.json` which broke when CWD wasn't the project root — now uses `veld config` instead
- Supports `--path` flag to print just the config file path

## Test plan
- [x] `veld config` prints veld.json from project root
- [x] `veld config` prints veld.json from a subdirectory
- [x] `veld config --path` prints the absolute path
- [x] `veld --help` shows the new command
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)