### PR TITLE
fix: bypass replace_response for WebSocket and SSE connections

### DIFF
--- a/crates/veld-helper/src/caddy.rs
+++ b/crates/veld-helper/src/caddy.rs
@@ -521,7 +521,10 @@ mod tests {
         let subroutes = route["handle"][0]["routes"].as_array().unwrap();
         assert_eq!(subroutes.len(), 1);
         assert_eq!(subroutes[0]["handle"][0]["handler"], "reverse_proxy");
-        assert!(subroutes[0]["match"].is_null(), "catch-all route has no matcher");
+        assert!(
+            subroutes[0]["match"].is_null(),
+            "catch-all route has no matcher"
+        );
     }
 
     #[test]
@@ -823,10 +826,7 @@ mod tests {
 
         // --- WebSocket / HTTP upgrade bypass ---
         let ws_route = &subroutes[1];
-        assert_eq!(
-            ws_route["match"][0]["header"]["Connection"][0],
-            "*Upgrade*"
-        );
+        assert_eq!(ws_route["match"][0]["header"]["Connection"][0], "*Upgrade*");
         let ws_handlers = ws_route["handle"].as_array().unwrap();
         assert_eq!(ws_handlers.len(), 1);
         assert_eq!(ws_handlers[0]["handler"], "reverse_proxy");


### PR DESCRIPTION
## Summary

- Caddy's `replace_response` handler wraps the `ResponseWriter`, which breaks `http.Hijacker` (WebSocket upgrades) and `http.Flusher` (SSE streaming) — causing HMR failures for dev servers proxied through veld with feedback injection active
- Add two bypass subroutes that route WebSocket (`Connection: *Upgrade*`) and SSE (`Accept: text/event-stream`) requests directly to a plain `reverse_proxy`, skipping `replace_response`
- Only affects routes with feedback injection enabled; plain proxy routes already handle all protocols natively

## Test plan

- [x] All 8 caddy unit tests pass (including new `test_streaming_bypass_routes_structure`)
- [x] Full workspace test suite passes (74 tests, 0 failures)
- [ ] Manual: run a Next.js app through veld with feedback injection — HMR WebSocket should connect
- [ ] Manual: run a Vite/Remix app through veld — SSE-based HMR should stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)