### PR TITLE
fix(install): allow caddy binary in tarball validation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -102,7 +102,7 @@ TAR_CONTENTS="$(tar -tzf "${TMP_DIR}/${TARBALL}")"
 for entry in $TAR_CONTENTS; do
   entry="${entry#./}"
   case "$entry" in
-    veld|veld-helper|veld-daemon|"") ;;
+    veld|veld-helper|veld-daemon|caddy|"") ;;
     *) echo "Error: unexpected file in tarball: ${entry}"; exit 1 ;;
   esac
 done


### PR DESCRIPTION
## Summary
- The release tarball now includes a `caddy` binary (since the veld_inject module was added), but the install script's tarball validation only allowed `veld`, `veld-helper`, and `veld-daemon` — causing `v4.0.0` installs to fail with `Error: unexpected file in tarball: caddy`
- Adds `caddy` to the allowed file list (the install script already handled copying it at line 222)

## Test plan
- [ ] Run `curl -fsSL https://veld.oss.life.li/get | bash` after release and confirm install succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)