### PR TITLE
fix: defer screenshot stream until after region selection

### DIFF
--- a/crates/veld-daemon/frontend/src/feedback-overlay.css
+++ b/crates/veld-daemon/frontend/src/feedback-overlay.css
@@ -935,10 +935,17 @@
   background: var(--vf-accent-hover);
 }
 
-/* Draw toolbar when inside a container (annotation mode) */
+/* Draw toolbar when inside screenshot annotation — render in flow below image */
 .veld-feedback-screenshot-preview .veld-feedback-draw-toolbar {
-  position: absolute; top: auto; bottom: -44px; left: 50%;
-  transform: translateX(-50%);
+  position: relative; top: auto; bottom: auto; left: auto;
+  transform: none;
+  margin: 8px auto 0;
+  opacity: 1;
+}
+@media (hover: hover) {
+  .veld-feedback-screenshot-preview .veld-feedback-draw-toolbar {
+    opacity: 1;
+  }
 }
 
 /* Annotate button in screenshot preview */

--- a/crates/veld-daemon/frontend/src/feedback-overlay/modes.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/modes.ts
@@ -4,7 +4,7 @@ import type { UIMode } from "./types";
 import { PREFIX } from "./constants";
 import { toast } from "./toast";
 import { closeActivePopover } from "./popover";
-import { stopCaptureStream, acquireCaptureStream } from "./screenshot";
+import { stopCaptureStream } from "./screenshot";
 import { ensureDrawScript, setupGlobalDrawCanvas, teardownGlobalDrawCanvas } from "./draw-mode";
 import { toggleToolbar } from "./toolbar";
 
@@ -39,16 +39,12 @@ export function setMode(mode: UIMode): void {
     refs.overlay.classList.add(PREFIX + "overlay-active");
   }
   if (mode === "screenshot") {
-    acquireCaptureStream().then(() => {
-      refs.overlay.classList.add(PREFIX + "overlay-active");
-      refs.overlay.classList.add(PREFIX + "overlay-crosshair");
-      window.focus();
-      toast("Draw a rectangle to capture a screenshot");
-    }).catch(() => {
-      toast("Screen capture denied", true);
-      dispatch({ type: "SET_MODE", mode: null });
-      refs.toolBtnScreenshot.classList.remove(PREFIX + "tool-active");
-    });
+    // No acquireCaptureStream — selection starts instantly without screen share dialog.
+    // Capture is deferred to after the user finishes drawing the selection rectangle.
+    refs.overlay.classList.add(PREFIX + "overlay-active");
+    refs.overlay.classList.add(PREFIX + "overlay-crosshair");
+    window.focus();
+    toast("Draw a rectangle to capture a screenshot");
   }
   if (mode === "draw") {
     if (getState().toolbarOpen) toggleToolbar();

--- a/crates/veld-daemon/frontend/src/feedback-overlay/screenshot.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/screenshot.ts
@@ -48,6 +48,9 @@ export function stopCaptureStream(): void {
 
 /**
  * Capture a screenshot of the selected viewport region.
+ * Acquires the capture stream on demand (after region selection) so the
+ * browser permission dialog doesn't appear until the user has drawn the
+ * selection rectangle.
  */
 export function captureScreenshot(
   viewX: number,
@@ -73,45 +76,51 @@ export function captureScreenshot(
     }
   });
 
-  // Exit screenshot mode (removes backdrop). Null the stream ref temporarily
-  // so setMode(null) doesn't stop it — we still need it for the grab.
-  const stream = getState().captureStream;
-  dispatch({ type: "SET_CAPTURE_STREAM", stream: null });
+  // Exit screenshot mode (removes backdrop).
   deps().setMode(null);
-  dispatch({ type: "SET_CAPTURE_STREAM", stream });
 
-  if (!stream) {
-    restoreVeldUI(hiddenEls);
-    showScreenshotThreadEditor(null, null, viewX, viewY, viewW, viewH);
-    return;
-  }
-
-  const track = stream.getVideoTracks()[0];
-
-  function grabCleanFrame(): void {
-    const grabber = new ImageCapture(track);
-    grabber
-      .grabFrame()
-      .then((bitmap: ImageBitmap) => {
-        stopCaptureStream();
-        restoreVeldUI(hiddenEls);
-        cropAndShowEditor(bitmap, viewX, viewY, viewW, viewH);
-      })
-      .catch(() => {
-        stopCaptureStream();
+  // Acquire the capture stream now (after region selection).
+  acquireCaptureStream()
+    .then(() => {
+      const stream = getState().captureStream;
+      if (!stream) {
         restoreVeldUI(hiddenEls);
         showScreenshotThreadEditor(null, null, viewX, viewY, viewW, viewH);
-      });
-  }
+        return;
+      }
 
-  // Wait for the UI to fully repaint before capturing: two rAF cycles
-  // to flush styles + composite, plus a small timeout as safety margin
-  // for slower compositors.
-  requestAnimationFrame(() => {
-    requestAnimationFrame(() => {
-      setTimeout(grabCleanFrame, 50);
+      const track = stream.getVideoTracks()[0];
+
+      function grabCleanFrame(): void {
+        const grabber = new ImageCapture(track);
+        grabber
+          .grabFrame()
+          .then((bitmap: ImageBitmap) => {
+            stopCaptureStream();
+            restoreVeldUI(hiddenEls);
+            cropAndShowEditor(bitmap, viewX, viewY, viewW, viewH);
+          })
+          .catch(() => {
+            stopCaptureStream();
+            restoreVeldUI(hiddenEls);
+            showScreenshotThreadEditor(null, null, viewX, viewY, viewW, viewH);
+          });
+      }
+
+      // Wait for the UI to fully repaint before capturing: two rAF cycles
+      // to flush styles + composite, plus a small timeout as safety margin
+      // for slower compositors.
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          setTimeout(grabCleanFrame, 50);
+        });
+      });
+    })
+    .catch(() => {
+      restoreVeldUI(hiddenEls);
+      toast("Screen capture denied", true);
+      showScreenshotThreadEditor(null, null, viewX, viewY, viewW, viewH);
     });
-  });
 }
 
 /** Restore visibility of veld UI elements hidden for a clean screenshot. */

--- a/crates/veld-daemon/frontend/tests/zero-friction-screenshot.test.ts
+++ b/crates/veld-daemon/frontend/tests/zero-friction-screenshot.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+/**
+ * Regression tests for zero-friction screenshot mode.
+ *
+ * Two invariants:
+ * 1. Entering screenshot mode does NOT acquire a capture stream — the browser
+ *    permission dialog is deferred until after the user finishes drawing the
+ *    selection rectangle.
+ * 2. After the screenshot frame is grabbed, the capture stream is stopped
+ *    immediately (no lingering stream).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { initState } from "../src/feedback-overlay/state";
+import { refs } from "../src/feedback-overlay/refs";
+import { getState, dispatch } from "../src/feedback-overlay/store";
+import { registerDeps } from "../src/shared/registry";
+
+function setupDOM() {
+  const host = document.createElement("veld-feedback");
+  const shadow = host.attachShadow({ mode: "open" });
+  initState(shadow, host);
+
+  // Create minimal DOM refs
+  refs.toolbarContainer = document.createElement("div");
+  refs.toolbar = document.createElement("div");
+  refs.overlay = document.createElement("div");
+  refs.hoverOutline = document.createElement("div");
+  refs.componentTraceEl = document.createElement("div");
+  refs.panel = document.createElement("div");
+  refs.fab = document.createElement("div");
+  refs.toolBtnSelect = document.createElement("div");
+  refs.toolBtnScreenshot = document.createElement("div");
+  refs.toolBtnDraw = document.createElement("div");
+  refs.toolBtnPageComment = document.createElement("div");
+  refs.toolBtnComments = document.createElement("div");
+  refs.toolBtnHide = document.createElement("div");
+  refs.screenshotRect = document.createElement("div");
+}
+
+describe("Screenshot mode: deferred stream acquisition", () => {
+  beforeEach(() => {
+    setupDOM();
+  });
+
+  it("setMode('screenshot') does NOT acquire a capture stream", async () => {
+    // Wire up minimal deps so setMode works
+    const { setMode } = await import("../src/feedback-overlay/modes");
+    registerDeps({
+      setMode,
+      captureScreenshot: vi.fn(),
+      showCreatePopover: vi.fn(),
+      positionTooltip: vi.fn(),
+      ensureDrawScript: vi.fn().mockResolvedValue(undefined),
+    });
+
+    // Capture stream must be null before entering screenshot mode
+    expect(getState().captureStream).toBeNull();
+
+    // Enter screenshot mode
+    setMode("screenshot");
+
+    // Capture stream must STILL be null — no getDisplayMedia called
+    expect(getState().captureStream).toBeNull();
+
+    // But the overlay and crosshair should be active (selection is ready)
+    expect(refs.overlay.classList.contains("veld-feedback-overlay-active")).toBe(true);
+    expect(refs.overlay.classList.contains("veld-feedback-overlay-crosshair")).toBe(true);
+  });
+
+  it("capture stream is null after exiting screenshot mode without selection", async () => {
+    const { setMode } = await import("../src/feedback-overlay/modes");
+    registerDeps({
+      setMode,
+      captureScreenshot: vi.fn(),
+      showCreatePopover: vi.fn(),
+      positionTooltip: vi.fn(),
+      ensureDrawScript: vi.fn().mockResolvedValue(undefined),
+    });
+
+    setMode("screenshot");
+    setMode(null);
+
+    // No stream was ever acquired
+    expect(getState().captureStream).toBeNull();
+    // Overlay classes should be removed
+    expect(refs.overlay.classList.contains("veld-feedback-overlay-active")).toBe(false);
+    expect(refs.overlay.classList.contains("veld-feedback-overlay-crosshair")).toBe(false);
+  });
+});
+
+describe("Screenshot capture: stream lifecycle", () => {
+  beforeEach(() => {
+    setupDOM();
+  });
+
+  it("captureScreenshot acquires stream then stops it after grab", async () => {
+    const { setMode } = await import("../src/feedback-overlay/modes");
+    const screenshot = await import("../src/feedback-overlay/screenshot");
+
+    // Track whether stream tracks were stopped
+    const stopFn = vi.fn();
+    const mockTrack = {
+      addEventListener: vi.fn(),
+      stop: stopFn,
+      kind: "video",
+    };
+    const mockStream = {
+      getVideoTracks: () => [mockTrack],
+      getTracks: () => [mockTrack],
+    } as unknown as MediaStream;
+
+    // Mock getDisplayMedia to return our tracked stream
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: {
+        getDisplayMedia: vi.fn().mockResolvedValue(mockStream),
+      },
+      configurable: true,
+    });
+
+    // Mock ImageCapture — grabFrame returns a minimal bitmap
+    const mockBitmap = {
+      width: 800,
+      height: 600,
+      close: vi.fn(),
+    };
+    (globalThis as any).ImageCapture = class {
+      grabFrame() {
+        return Promise.resolve(mockBitmap);
+      }
+    };
+
+    registerDeps({
+      setMode,
+      captureScreenshot: screenshot.captureScreenshot,
+      showCreatePopover: vi.fn(),
+      positionTooltip: vi.fn(),
+      ensureDrawScript: vi.fn().mockResolvedValue(undefined),
+    });
+
+    // Enter screenshot mode — no stream acquired
+    setMode("screenshot");
+    expect(getState().captureStream).toBeNull();
+
+    // Simulate captureScreenshot (called after region selection)
+    screenshot.captureScreenshot(10, 10, 200, 150);
+
+    // Wait for the async acquireCaptureStream + grabFrame chain
+    // acquireCaptureStream is a promise chain, so flush microtasks
+    await vi.waitFor(() => {
+      expect(stopFn).toHaveBeenCalled();
+    }, { timeout: 2000 });
+
+    // Stream should be null in state after capture completes
+    expect(getState().captureStream).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- **Deferred stream acquisition**: Screenshot mode now enters instantly (crosshair + overlay) without triggering the browser's `getDisplayMedia` permission dialog. The stream is acquired only after the user finishes drawing the selection rectangle, then stopped immediately after the frame is grabbed.
- **Fixed annotation toolbar**: The draw toolbar in screenshot annotation mode was invisible — it was positioned outside its container (`bottom: -44px`) which has `overflow: hidden`, and the hover-opacity rule dimmed it to 0.25. Now renders in-flow below the image at full opacity.
- **Regression tests**: 3 new tests covering deferred stream acquisition and immediate stream cleanup after capture.

## Test plan
- [ ] Press Cmd+Shift+S — crosshair overlay should appear immediately with no permission dialog
- [ ] Draw a selection rectangle — permission dialog appears only now
- [ ] After granting permission, screenshot is captured and stream ends (no lingering share indicator)
- [ ] In the screenshot popover, click "Annotate" — draw toolbar should be visible below the image
- [ ] Verify draw tools (pen, select, pins, etc.) are clickable and functional
- [ ] `npm test` passes (289 tests, 23 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)