### PR TITLE
fix(helper): self-removing bootstrap script avoids React hydration mismatch

### DIFF
--- a/crates/veld-core/src/feedback.rs
+++ b/crates/veld-core/src/feedback.rs
@@ -307,7 +307,7 @@ impl FeedbackStore {
                 }
             }
         }
-        threads.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        threads.sort_by_key(|a| a.created_at);
         Ok(threads)
     }
 

--- a/crates/veld-helper/src/caddy.rs
+++ b/crates/veld-helper/src/caddy.rs
@@ -546,7 +546,9 @@ fn build_bootstrap_script(fb: &FeedbackConfig<'_>) -> String {
     // execution, so removal here runs before hydration. Side effects (console
     // interception, error listeners, and the requestIdleCallback-deferred
     // asset loads) survive removal because they're attached to window/console.
-    js.push_str("var s=document.currentScript;if(s&&s.parentNode)s.parentNode.removeChild(s);})();");
+    js.push_str(
+        "var s=document.currentScript;if(s&&s.parentNode)s.parentNode.removeChild(s);})();",
+    );
 
     format!("<script>{js}</script>")
 }

--- a/crates/veld-helper/src/caddy.rs
+++ b/crates/veld-helper/src/caddy.rs
@@ -535,7 +535,18 @@ fn build_bootstrap_script(fb: &FeedbackConfig<'_>) -> String {
         js.push_str("E('script',{'src':'/__veld__/feedback/script.js'});");
     }
 
-    js.push_str("});})();");
+    js.push_str("});");
+
+    // Self-remove the bootstrap <script> tag from the DOM before React (or any
+    // other hydration-checking framework) walks the live DOM. The browser's
+    // HTML5 parser relocates a stray <script> between <!DOCTYPE> and <html>
+    // into <head>; Next.js app-router hydrates from the <html> root and would
+    // see an extra child not present in the React tree, causing a hydration
+    // mismatch. `document.currentScript` is set during synchronous script
+    // execution, so removal here runs before hydration. Side effects (console
+    // interception, error listeners, and the requestIdleCallback-deferred
+    // asset loads) survive removal because they're attached to window/console.
+    js.push_str("var s=document.currentScript;if(s&&s.parentNode)s.parentNode.removeChild(s);})();");
 
     format!("<script>{js}</script>")
 }
@@ -959,6 +970,29 @@ mod tests {
         // Guard prevents double execution.
         assert!(script.contains("if(window.__veld_cl)return"));
         assert!(script.contains("window.__veld_cl=1"));
+    }
+
+    /// The bootstrap script must remove its own <script> tag from the DOM
+    /// after running, to prevent React hydration mismatches in Next.js
+    /// app-router and similar frameworks that hydrate from the <html> root.
+    #[test]
+    fn test_bootstrap_script_self_removes() {
+        let configs = [
+            make_fb(true, true, "log,warn,error"), // both
+            make_fb(true, false, "log"),           // overlay only
+            make_fb(false, true, "log"),           // logs only
+        ];
+        for fb in &configs {
+            let script = build_bootstrap_script(fb);
+            assert!(
+                script.contains("document.currentScript"),
+                "script must reference document.currentScript for self-removal"
+            );
+            assert!(
+                script.contains("removeChild"),
+                "script must call removeChild to detach itself from the DOM"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Bootstrap `<script>` injected by `veld_inject` lands between `<!DOCTYPE>` and `<html>`. HTML5 parser relocates it into `<head>`. Next.js app-router hydrates from the `<html>` root and reports a hydration mismatch because the script is not in the React tree.
- Fix: the bootstrap IIFE removes its own `<script>` tag via `document.currentScript.parentNode.removeChild(...)` before returning. Runs synchronously during script execution, before React hydration walks the live DOM.
- Side effects survive removal: console interception + error listeners attach to `window`/`console`; the dynamically-loaded `client-log.js` and `feedback/script.js` are scheduled via `requestIdleCallback` and use `document.head.appendChild`, independent of the bootstrap tag's presence.

## Why this is safe

- `document.currentScript` is non-null during synchronous inline script execution.
- The `__veld_cl` dedup guard sits on `window`, not the DOM, so re-injection on the same page is still a no-op.
- Removal is null-guarded: `if(s&&s.parentNode)`.
- No effect on non-React apps — they don't care that an inline script tag disappeared after running.

## Workaround removed

Previously users had to use `next/script` with `strategy="beforeInteractive"` to dodge the mismatch. No longer needed.

## Test plan

- [x] `cargo test -p veld-helper caddy::tests::test_bootstrap` — 13 passed (includes new `test_bootstrap_script_self_removes` covering all 3 feature combos)
- [x] `cargo build -p veld-helper` clean
- [ ] Manual smoke: run veld in front of a Next.js app-router project, confirm no hydration mismatch warning in console and overlay/client-log still load