### PR TITLE
fix(feedback): hide side panel drop shadow when panel is closed

### DIFF
--- a/crates/veld-daemon/frontend/src/feedback-overlay.css
+++ b/crates/veld-daemon/frontend/src/feedback-overlay.css
@@ -339,20 +339,19 @@
   width: 380px; max-width: 90vw;
   background: var(--vf-bg); color: var(--vf-text);
   z-index: var(--vf-z);
-  box-shadow: -4px 0 30px rgba(0,0,0,.5);
+  box-shadow: 0 0 0 rgba(0,0,0,0);
   display: flex; flex-direction: column;
   font: 13px/1.5 var(--vf-font);
-  transform: translateX(100%); transition: transform .25s ease;
+  transform: translateX(100%); transition: transform .25s ease, box-shadow .25s ease;
   border-left: 1px solid var(--vf-border);
 }
-.veld-feedback-panel-open { transform: translateX(0); }
+.veld-feedback-panel-open { transform: translateX(0); box-shadow: -4px 0 30px rgba(0,0,0,.5); }
 .veld-feedback-panel-left {
   right: auto; left: 0;
   transform: translateX(-100%);
   border-left: none; border-right: 1px solid var(--vf-border);
-  box-shadow: 4px 0 30px rgba(0,0,0,.5);
 }
-.veld-feedback-panel-left.veld-feedback-panel-open { transform: translateX(0); }
+.veld-feedback-panel-left.veld-feedback-panel-open { transform: translateX(0); box-shadow: 4px 0 30px rgba(0,0,0,.5); }
 
 .veld-feedback-panel-head {
   padding: 14px 18px; font-size: 14px; font-weight: 600;


### PR DESCRIPTION
## Problem

The injected feedback side panel is hidden by translating it offscreen (`transform: translateX(±100%)`), but its `box-shadow` bled back into the viewport — leaving a persistent shadow edge along the screen border even when the panel was closed.

## Fix

- Move the `box-shadow` onto the `.veld-feedback-panel-open` state only (both right and left variants), so it appears solely when the panel is visible.
- Add `box-shadow` to the panel's `transition` so it fades in/out together with the slide.
- Keep a transparent zero-spread `box-shadow: 0 0 0 rgba(0,0,0,0)` as the base state — required as an animatable baseline (`none` cannot transition to a shadow value).

## Scope

Internal CSS-only bugfix to the feedback overlay. No new config fields, CLI flags, or user-visible surface area — documentation checklist does not apply.

## Test

- `npm run build` in `crates/veld-daemon/frontend` succeeds (CSS bundles into the overlay JS via esbuild, embedded at cargo build).
- Sub-agent review of the diff: cascade/specificity, directional shadows (left/right), and transition baseline all verified correct.