### PR TITLE
feat(feedback-overlay): radial goo arc menu for bubble + toolbar

### DIFF
--- a/crates/veld-daemon/frontend/src/feedback-overlay.css
+++ b/crates/veld-daemon/frontend/src/feedback-overlay.css
@@ -22,6 +22,7 @@
   --vf-text: #f1f5f9;
   --vf-text-muted: #94a3b8;
   --vf-border: #2a2a30;
+  --vf-goo-outline: rgba(255,255,255,.24);
   --vf-shadow: 0 4px 20px rgba(0,0,0,.4);
   --vf-radius: 10px;
   --vf-z: 999999;
@@ -42,6 +43,7 @@
     --vf-text: #1a1a2e;
     --vf-text-muted: #64748b;
     --vf-border: #d4d4d8;
+    --vf-goo-outline: rgba(0,0,0,.16);
     --vf-shadow: 0 4px 20px rgba(0,0,0,.1);
   }
 }
@@ -59,6 +61,7 @@
   --vf-text: #f1f5f9;
   --vf-text-muted: #94a3b8;
   --vf-border: #2a2a30;
+  --vf-goo-outline: rgba(255,255,255,.24);
   --vf-shadow: 0 4px 20px rgba(0,0,0,.4);
 }
 :host([data-theme="light"]) {
@@ -73,6 +76,7 @@
   --vf-text: #1a1a2e;
   --vf-text-muted: #64748b;
   --vf-border: #d4d4d8;
+  --vf-goo-outline: rgba(0,0,0,.16);
   --vf-shadow: 0 4px 20px rgba(0,0,0,.1);
 }
 
@@ -102,41 +106,127 @@
   opacity: 1; transform: translateX(-50%) translateY(0);
 }
 
-/* Toolbar container — fixed, draggable, anchor for radial buttons */
+/* ── Arc menu ─────────────────────────────────────────────────────────────
+   A floating bubble that expands into a radial arc of tool items with
+   metaball "goo" physics. The container is zero-size and positioned (left/top)
+   at the bubble center by the engine; everything inside is laid out relative
+   to that origin. Three layers:
+     goo-layer  — solid circles only, merged by the SVG goo filter
+     glow-layer — accent click-flash gradients
+     icon-layer — crisp icons, tooltip text, bubble cover + hit target
+   ------------------------------------------------------------------------- */
 .veld-feedback-toolbar-container {
   position: fixed;
   z-index: var(--vf-z);
   user-select: none;
-  /* FAB is centered at (20px, 20px) within this 40×40 container */
-  width: 40px; height: 40px;
+  width: 0; height: 0;
 }
 
-/* FAB */
+.veld-feedback-goo-layer,
+.veld-feedback-glow-layer,
+.veld-feedback-icon-layer {
+  position: absolute; top: 0; left: 0;
+  width: 0; height: 0;
+  pointer-events: none;
+}
+/* The metaball surface: blur + alpha-threshold merges nearby circles into
+   liquid necks. The four zero-blur drop-shadows paint a 1px contrast hairline
+   around the whole silhouette (so a dark shape reads on a dark page); the final
+   blurred shadow adds depth. */
+.veld-feedback-goo-layer {
+  filter:
+    url(#veld-feedback-goo)
+    drop-shadow(1px 0 0 var(--vf-goo-outline))
+    drop-shadow(-1px 0 0 var(--vf-goo-outline))
+    drop-shadow(0 1px 0 var(--vf-goo-outline))
+    drop-shadow(0 -1px 0 var(--vf-goo-outline))
+    drop-shadow(0 3px 12px rgba(0,0,0,.28));
+}
+
+/* Solid circles that the goo filter operates on (bubble + item blobs). */
+.veld-feedback-goo-blob {
+  position: absolute; top: 0; left: 0;
+  border-radius: 50%;
+  background: var(--vf-bg);
+  transform: translate(-50%, -50%);
+  will-change: transform, width, height;
+}
+.veld-feedback-goo-bubble { z-index: 1; }
+
+/* Tooltip pill — lives in the goo layer so it buds off the item blob.
+   Hidden by default; the engine reveals it (opacity + scale) on hover. Without
+   this the pill would flash full-size at idle before the rAF loop first
+   positions it. */
+.veld-feedback-goo-tooltip {
+  position: absolute; top: 0; left: 0;
+  height: 26px; min-width: 26px;
+  border-radius: 13px;
+  background: var(--vf-bg);
+  opacity: 0;
+  will-change: transform, opacity;
+}
+
+/* Accent halo behind an active item — a soft glow rather than a hard blob
+   tint, so the item still merges cleanly with its neighbours. */
+.veld-feedback-accent-glow {
+  position: absolute; top: 0; left: 0;
+  width: 58px; height: 58px; border-radius: 50%;
+  transform: translate(-50%, -50%);
+  background: radial-gradient(circle, color-mix(in srgb, var(--vf-accent) 60%, transparent) 0%, transparent 68%);
+  opacity: 0; pointer-events: none;
+  transition: opacity .25s ease;
+}
+
+/* Accent glow behind the bubble (flash on open/click). */
+.veld-feedback-bubble-glow {
+  position: absolute; top: 0; left: 0;
+  width: 84px; height: 84px; border-radius: 50%;
+  transform: translate(-50%, -50%);
+  background: radial-gradient(circle, color-mix(in srgb, var(--vf-accent) 45%, transparent) 0%, transparent 65%);
+  opacity: 0; pointer-events: none;
+  transition: opacity .5s ease-out;
+  z-index: 9;
+}
+
+/* Solid cover that masks the goo bubble so items emerge from behind it.
+   No border — the goo-layer hairline outlines the bubble silhouette. */
+.veld-feedback-bubble-cover {
+  position: absolute; top: 0; left: 0;
+  border-radius: 50%;
+  background: var(--vf-bg);
+  transform: translate(-50%, -50%);
+  z-index: 8;
+}
+
+/* Bubble hit target (drag + click) — transparent; the cover is the surface. */
 .veld-feedback-fab {
-  width: 40px; height: 40px; border-radius: 50%;
-  border: 1px solid var(--vf-border);
-  cursor: pointer; background: var(--vf-bg);
-  color: var(--vf-text); display: flex;
-  align-items: center; justify-content: center;
-  box-shadow: var(--vf-shadow); transition: background .2s, transform .15s;
-  position: relative; z-index: 2;
-  flex-shrink: 0;
+  position: absolute; top: 0; left: 0;
+  border-radius: 50%;
+  border: none; background: transparent;
+  color: var(--vf-text);
+  display: flex; align-items: center; justify-content: center;
+  transform: translate(-50%, -50%);
+  cursor: grab; pointer-events: auto;
+  z-index: 10;
 }
-.veld-feedback-fab:hover {
-  background: var(--vf-bg-card); transform: scale(1.07);
+.veld-feedback-fab:focus, .veld-feedback-fab:focus-visible { outline: none; }
+.veld-feedback-fab.veld-feedback-dragging { cursor: grabbing; }
+.veld-feedback-fab-icon {
+  display: flex; align-items: center; justify-content: center;
+  color: var(--vf-text);
+  transition: opacity .12s ease, transform .4s cubic-bezier(0.34, 1.56, 0.64, 1);
+  pointer-events: none;
 }
-.veld-feedback-fab svg {
-  width: 20px; height: 20px;
-}
+.veld-feedback-fab-icon svg { width: 20px; height: 20px; }
 .veld-feedback-fab-pulse {
   animation: veld-feedback-fab-glow 2s ease-in-out infinite;
 }
 @keyframes veld-feedback-fab-glow {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(196, 245, 106, 0.5); }
-  50% { box-shadow: 0 0 0 10px rgba(196, 245, 106, 0); }
+  0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--vf-accent) 50%, transparent); }
+  50% { box-shadow: 0 0 0 10px transparent; }
 }
 
-/* Badge */
+/* FAB unread badge. */
 .veld-feedback-badge {
   position: absolute; top: -4px; right: -4px;
   min-width: 16px; height: 16px; border-radius: 8px;
@@ -144,37 +234,39 @@
   font: 700 10px/1 var(--vf-font);
   display: flex; align-items: center; justify-content: center;
   padding: 0 4px; pointer-events: none;
+  z-index: 12;
 }
 .veld-feedback-badge-hidden { display: none; }
 
-/* Radial toolbar button — positioned absolutely around FAB, no border (arc backdrop provides container) */
+/* Item icon overlay — crisp, unfiltered, positioned/scaled by the engine. */
 .veld-feedback-tool-btn {
-  position: absolute;
-  width: 30px; height: 30px; border-radius: 50%;
-  border: none;
-  cursor: pointer; background: transparent;
-  color: var(--vf-text-muted); display: flex;
-  align-items: center; justify-content: center;
-  /* Centered on FAB: (40 - 30) / 2 = 5 */
-  top: 5px; left: 5px;
-  /* Start collapsed at FAB center */
-  transform: translate(0, 0) scale(0);
+  position: absolute; top: 0; left: 0;
+  width: 32px; height: 32px; border-radius: 50%;
+  border: none; background: transparent;
+  color: var(--vf-text); cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transform: translate(-50%, -50%) scale(0);
   opacity: 0; pointer-events: none;
-  transition: transform .2s ease, opacity .15s ease, background .15s, color .15s;
-  z-index: 1;
+  transition: color .15s;
+  z-index: 5;
 }
-.veld-feedback-tool-btn:hover {
-  background: rgba(255,255,255,.08); color: var(--vf-text);
+.veld-feedback-tool-btn:focus, .veld-feedback-tool-btn:focus-visible { outline: none; }
+.veld-feedback-tool-btn svg { width: 16px; height: 16px; }
+/* Active = accent-coloured icon (on the surface-coloured blob) + soft halo. */
+.veld-feedback-tool-btn.veld-feedback-tool-active { color: var(--vf-accent); }
+
+/* Listening dot — an empty tool item that shows a pulsing accent dot. */
+.veld-feedback-listening-dot::after {
+  content: ""; width: 10px; height: 10px; border-radius: 50%;
+  background: var(--vf-accent);
+  animation: veld-feedback-listen-pulse 1.6s ease-in-out infinite;
 }
-.veld-feedback-tool-btn.veld-feedback-tool-active {
-  background: var(--vf-accent); color: var(--vf-accent-text);
+@keyframes veld-feedback-listen-pulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(0.7); opacity: 0.55; }
 }
-.veld-feedback-tool-btn svg {
-  width: 15px; height: 15px;
-}
-.veld-feedback-tool-btn.veld-feedback-radial-open {
-  opacity: 1; pointer-events: auto;
-}
+
+/* Unread count on the Threads item (added live by badge.ts). */
 .veld-feedback-tool-badge {
   position: absolute;
   top: -2px; right: -2px;
@@ -186,6 +278,26 @@
   text-align: center;
   padding: 0 3px;
   pointer-events: none;
+}
+
+/* Goo tooltip text (crisp, above everything). */
+.veld-feedback-tt-text {
+  position: absolute; top: 0; left: 0;
+  transform: translate(-50%, -50%);
+  display: flex; align-items: center; gap: 6px;
+  white-space: nowrap; pointer-events: none;
+  color: var(--vf-text);
+  opacity: 0;
+  z-index: 25;
+}
+.veld-feedback-tt-label { font: 500 11.5px/1 var(--vf-font); letter-spacing: .2px; }
+.veld-feedback-tt-arrow { font-size: 12px; color: var(--vf-text-muted); margin-left: -2px; }
+.veld-feedback-tt-kbd { display: inline-flex; gap: 2px; }
+.veld-feedback-tt-kbd kbd {
+  font: 500 9.5px/1 var(--vf-font); letter-spacing: .3px;
+  padding: 2px 4px; border-radius: 3px;
+  color: var(--vf-text-muted);
+  background: color-mix(in srgb, var(--vf-text) 10%, transparent);
 }
 
 /* Feedback mode backdrop */

--- a/crates/veld-daemon/frontend/src/feedback-overlay/arc-menu.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/arc-menu.ts
@@ -1,0 +1,1187 @@
+// ---------------------------------------------------------------------------
+// Arc Menu — floating radial toolbar with metaball "goo" physics.
+//
+// A draggable bubble that expands into a partial radial arc of tool items.
+// Items render as metaball blobs (SVG goo filter) so they melt out of / back
+// into the bubble organically. Supports macOS-dock-style fisheye magnification,
+// momentum physics with edge bounce, per-edge viewport collision, goo-bridged
+// tooltips, and data-driven submenu transitions.
+//
+// Layering (all inside `container`, positioned relative to the bubble center):
+//   ┌ goo-layer  (filter: url(#goo)) — solid circles only; the filter merges
+//   │            neighbouring circles into liquid necks. Holds the goo bubble,
+//   │            per-item goo blobs, and goo tooltip pills. No text/icons here.
+//   ┌ glow-layer — per-item accent glows (click flash) + the bubble glow.
+//   └ icon-layer — crisp, unfiltered: the tool-button icon overlays, tooltip
+//                  text, the solid bubble cover (masks goo), and the bubble hit
+//                  target. Icons sit BELOW the cover so items visually emerge
+//                  from behind the bubble.
+//
+// This engine is deliberately framework-agnostic and owns no application state:
+// the host passes in an item model (each item carries its own persistent icon
+// element), and the engine calls back on select / move / open-change. The Veld
+// feedback overlay reuses its existing tool-button elements as icon overlays so
+// active-state classes, badges, and tooltips keep working unchanged.
+// ---------------------------------------------------------------------------
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+/** A single menu entry. `el` is a persistent, caller-owned icon overlay. */
+export interface ArcItem {
+  id: string;
+  /** Persistent icon element positioned/scaled by the engine each frame. */
+  el: HTMLElement;
+  /** Human label shown in the goo tooltip. */
+  label: string;
+  /** Optional keyboard hint chips, e.g. ["⌘", "⇧", "F"]. */
+  kbd?: string[];
+  /** Child menu — turns this item into a submenu opener. */
+  sub?: ArcItem[];
+  /** Leaf action. Ignored when `sub` is present. */
+  onSelect?: () => void;
+  /** Keep the menu open after selecting (in-place toggles: theme, shortcuts). */
+  stayOpen?: boolean;
+  /** Live active-state read — tints the item's goo blob with the accent color. */
+  isActive?: () => boolean;
+  /** Live visibility read — hidden items are omitted from the arc. */
+  isVisible?: () => boolean;
+}
+
+/** All physics / geometry knobs. Every value is tunable. */
+export interface ArcConfig {
+  BUBBLE_SZ: number; // base bubble diameter (px)
+  ARC_R: number; // bubble-center → item-center distance
+  ITEM_SZ: number; // base item diameter
+  FISH_RANGE: number; // angular range (rad) of fisheye influence
+  FISH_MAG: number; // max fisheye magnification (1 = none)
+  OPEN_MS: number; // open animation duration
+  CLOSE_MS: number; // close animation duration (retraction is lerp-driven)
+  DRAG_TH: number; // px before a press becomes a drag
+  SPAN_PI: number; // radians of arc span contributed per item
+  MIN_SPAN: number; // minimum total arc span (rad)
+  MAX_SPAN: number; // maximum total arc span (rad)
+  TT_GAP: number; // gap from item edge to tooltip pill
+  TT_PAD: number; // internal horizontal padding of the tooltip pill
+  TT_LERP: number; // tooltip scale animation speed
+  LERP: number; // main position/scale lerp speed
+  SUB_LERP: number; // retraction lerp during open/close/submenu transitions
+  FRICTION: number; // velocity decay per frame (0.9 heavy … 0.99 icy)
+  BOUNCE: number; // wall restitution (0 dead … 1 perfect)
+  MIN_VEL: number; // speed below which momentum stops
+  SNAP_VEL: number; // release speed needed to enter float mode
+  VP_PAD: number; // viewport edge padding
+  BADGE_SZ: number; // badge diameter (kept for host badge sizing parity)
+  gooBlur: number; // metaball blur radius (feGaussianBlur stdDeviation)
+  gooAlpha: number; // metaball alpha multiplier (feColorMatrix)
+  gooOffset: number; // metaball alpha offset (feColorMatrix)
+}
+
+export const DEFAULT_ARC_CONFIG: ArcConfig = {
+  BUBBLE_SZ: 40,
+  ARC_R: 64,
+  ITEM_SZ: 32,
+  FISH_RANGE: 0.4,
+  FISH_MAG: 1.65,
+  OPEN_MS: 600,
+  CLOSE_MS: 280,
+  DRAG_TH: 4,
+  SPAN_PI: 0.48,
+  MIN_SPAN: Math.PI * 0.4,
+  MAX_SPAN: Math.PI * 1.72,
+  TT_GAP: 2,
+  TT_PAD: 8,
+  TT_LERP: 0.15,
+  LERP: 0.1,
+  SUB_LERP: 0.1,
+  FRICTION: 0.95,
+  BOUNCE: 0.6,
+  MIN_VEL: 15,
+  SNAP_VEL: 60,
+  VP_PAD: 4,
+  BADGE_SZ: 14,
+  gooBlur: 6,
+  gooAlpha: 44,
+  gooOffset: -14,
+};
+
+export interface ArcCallbacks {
+  /** Bubble moved. `committed` is true on drag/float end (persist then). */
+  onMove?: (x: number, y: number, committed: boolean) => void;
+  /** Menu opened or closed. */
+  onOpenChange?: (open: boolean) => void;
+  /** Drag state changed (suppress tooltips, etc.). */
+  onDragChange?: (dragging: boolean) => void;
+  /** Should an outside click auto-close the menu? Defaults to always true. */
+  shouldCloseOnOutsideClick?: () => boolean;
+}
+
+export interface ArcMenuOptions {
+  /** Fixed, zero-size container translated to the bubble center. */
+  container: HTMLElement;
+  /** Tree scope hosting the goo <filter> (the shadow root). */
+  scope: ShadowRoot;
+  /** Persistent bubble hit target (drag + click). */
+  bubble: HTMLElement;
+  /** Icon wrapper inside the bubble (swapped between logo / close / back). */
+  bubbleIcon: HTMLElement;
+  /** Root menu provider — re-invoked on reflow so visibility stays live. */
+  items: () => ArcItem[];
+  /** Bubble icon SVGs for each state. */
+  icons: { logo: string; close: string; back: string };
+  /** Optional goo tooltip shown on bubble hover while the menu is closed. */
+  bubbleTooltip?: { label: string; kbd?: string[] };
+  /** CSS class prefix (e.g. "veld-feedback-"). */
+  prefix: string;
+  config?: Partial<ArcConfig>;
+  callbacks?: ArcCallbacks;
+}
+
+export interface ArcMenuHandle {
+  open(): void;
+  close(): void;
+  toggle(): void;
+  back(): void;
+  isOpen(): boolean;
+  depth(): number;
+  /** Re-evaluate visible items and relayout if open. */
+  reflow(): void;
+  setPosition(x: number, y: number, animate?: boolean): void;
+  getPosition(): { x: number; y: number };
+  /** Nudge inward so the current state fits the viewport. */
+  moveIntoView(animate?: boolean): void;
+  /** Clamp to the closed-state viewport bounds and persist. */
+  clampToViewport(): void;
+  destroy(): void;
+  /** Expose config for host-side sizing parity (read-only intent). */
+  readonly config: ArcConfig;
+}
+
+// ── math ────────────────────────────────────────────────────────────────
+const lerp = (a: number, b: number, t: number): number => a + (b - a) * t;
+const clamp = (v: number, lo: number, hi: number): number =>
+  Math.max(lo, Math.min(hi, v));
+const smoothstep = (t: number): number => t * t * (3 - 2 * t);
+const easeOutCubic = (t: number): number => 1 - Math.pow(1 - t, 3);
+const easeOutBack = (t: number): number => {
+  const c = 1.7;
+  const c3 = c + 1;
+  return 1 + c3 * Math.pow(t - 1, 3) + c * Math.pow(t - 1, 2);
+};
+/** Signed shortest angular difference from a to b, in (-π, π]. */
+const angDiff = (a: number, b: number): number =>
+  (((b - a) % (Math.PI * 2)) + Math.PI * 3) % (Math.PI * 2) - Math.PI;
+
+interface ItemViz {
+  sc: number; // current scale
+  ag: number; // current angle (rad)
+  r: number; // current radius from bubble center
+}
+
+export function createArcMenu(opts: ArcMenuOptions): ArcMenuHandle {
+  const C: ArcConfig = { ...DEFAULT_ARC_CONFIG, ...(opts.config || {}) };
+  const cb = opts.callbacks || {};
+  const P = opts.prefix;
+  const cls = (name: string) => P + name;
+
+  // ── layers ──────────────────────────────────────────────────────────
+  const container = opts.container;
+  const gooLayer = document.createElement("div");
+  gooLayer.className = cls("goo-layer");
+  const glowLayer = document.createElement("div");
+  glowLayer.className = cls("glow-layer");
+  const iconLayer = document.createElement("div");
+  iconLayer.className = cls("icon-layer");
+
+  const gooBubble = document.createElement("div");
+  gooBubble.className = cls("goo-blob") + " " + cls("goo-bubble");
+  gooLayer.appendChild(gooBubble);
+
+  const bubbleGlow = document.createElement("div");
+  bubbleGlow.className = cls("bubble-glow");
+  const bubbleCover = document.createElement("div");
+  bubbleCover.className = cls("bubble-cover");
+
+  // The caller-owned bubble hit target + icon live in the crisp icon layer,
+  // above the cover.
+  iconLayer.appendChild(bubbleGlow);
+  iconLayer.appendChild(bubbleCover);
+  iconLayer.appendChild(opts.bubble);
+
+  container.appendChild(gooLayer);
+  container.appendChild(glowLayer);
+  container.appendChild(iconLayer);
+
+  ensureGooFilter(opts.scope, P, C);
+
+  // ── bubble tooltip (persistent goo pill, shown on hover while closed) ──
+  let bubbleTT: HTMLElement | null = null;
+  let bubbleTTText: HTMLElement | null = null;
+  if (opts.bubbleTooltip) {
+    const t = document.createElement("div");
+    t.className = cls("tt-text");
+    let html = `<span class="${cls("tt-label")}">${escapeHtml(opts.bubbleTooltip.label)}</span>`;
+    const kbd = opts.bubbleTooltip.kbd;
+    if (kbd && kbd.length) {
+      html += `<span class="${cls("tt-kbd")}">` +
+        kbd.map((k) => `<kbd>${escapeHtml(k)}</kbd>`).join("") + "</span>";
+    }
+    t.innerHTML = html;
+    iconLayer.insertBefore(t, bubbleGlow);
+    bubbleTTText = t;
+
+    const pill = document.createElement("div");
+    pill.className = cls("goo-tooltip");
+    const w = t.offsetWidth + Math.max(C.TT_PAD, 12) * 2;
+    pill.style.width = w + "px";
+    pill.dataset.w = String(w);
+    gooLayer.appendChild(pill);
+    bubbleTT = pill;
+  }
+
+  // ── state ───────────────────────────────────────────────────────────
+  const S = {
+    x: 0,
+    y: 0,
+    vx: 0,
+    vy: 0,
+    dragging: false,
+    wasDrag: false,
+    pointerDown: false,
+    dragOff: { x: 0, y: 0 },
+    dragStart: { x: 0, y: 0 },
+    open: false,
+    openT: 0,
+    opening: false,
+    closing: false,
+    retracting: false,
+    animStart: 0,
+    floating: false,
+    hoveringBubble: false,
+    bubbleScale: 1,
+    bubbleTgtScale: 1,
+    bubbleTTScale: 0,
+    mouseAng: null as number | null,
+    mouseInZone: false,
+    // current level
+    menu: [] as ArcItem[],
+    stack: [] as ArcItem[][],
+    // pending level during a retraction transition
+    pending: null as ArcItem[] | null,
+    pendingStack: null as ArcItem[][] | null,
+    // per-item visualization + ephemeral decoration
+    cur: [] as ItemViz[],
+    tgt: [] as ItemViz[],
+    ttScales: [] as number[],
+    closeClear: true,
+  };
+
+  let gooBlobs: HTMLElement[] = [];
+  let gooTTs: HTMLElement[] = [];
+  let ttTexts: HTMLElement[] = [];
+  let glows: HTMLElement[] = [];
+  let hovIdx = -1;
+
+  const wiredItems = new WeakSet<ArcItem>();
+
+  // ── arc geometry ──────────────────────────────────────────────────────
+  // The arc always faces the viewport center, so dragging the bubble live-
+  // reorients the arc.
+  function arcCfg(n: number) {
+    const cx = window.innerWidth / 2;
+    const cy = window.innerHeight / 2;
+    const center = Math.atan2(cy - S.y, cx - S.x);
+    const span = clamp(n * C.SPAN_PI, C.MIN_SPAN, C.MAX_SPAN);
+    return { center, start: center - span / 2, span };
+  }
+  function baseAngles(start: number, span: number, n: number): number[] {
+    const out: number[] = [];
+    for (let i = 0; i < n; i++) out.push(start + ((i + 0.5) / n) * span);
+    return out;
+  }
+
+  // ── fisheye ────────────────────────────────────────────────────────────
+  // Items near the cursor inflate; the arc span is redistributed
+  // proportionally so total width stays constant (macOS dock on a curve).
+  function fisheye(
+    base: number[],
+    mouseAng: number | null,
+    start: number,
+    span: number,
+  ): { sc: number[]; ag: number[] } {
+    const n = base.length;
+    if (mouseAng === null || !S.mouseInZone || !n) {
+      return { sc: base.map(() => 1), ag: [...base] };
+    }
+    const sc = base.map((a) => {
+      const d = Math.abs(angDiff(a, mouseAng));
+      return 1 + (C.FISH_MAG - 1) * smoothstep(clamp(1 - d / C.FISH_RANGE, 0, 1));
+    });
+    const total = sc.reduce((a, b) => a + b, 0);
+    const unit = span / total;
+    let c = start;
+    const ag = sc.map((s) => {
+      const mid = c + (s * unit) / 2;
+      c += s * unit;
+      return mid;
+    });
+    return { sc, ag };
+  }
+
+  // ── viewport bounds (per-edge collision) ────────────────────────────────
+  // Extents are computed from actual item positions, so the bubble can hug an
+  // edge the arc doesn't face. Tooltips + fisheye are intentionally excluded.
+  function bounds() {
+    const pad = C.VP_PAD;
+    const br = (C.BUBBLE_SZ / 2) * (S.bubbleScale || 1);
+    let extL = br;
+    let extR = br;
+    let extT = br;
+    let extB = br;
+    if (S.open && !S.closing && S.cur.length > 0) {
+      for (let i = 0; i < S.cur.length; i++) {
+        const c = S.cur[i];
+        if (!c || c.r < 1) continue;
+        const ir = (C.ITEM_SZ * (c.sc || 1)) / 2;
+        const ix = Math.cos(c.ag) * c.r;
+        const iy = Math.sin(c.ag) * c.r;
+        extL = Math.max(extL, -ix + ir);
+        extR = Math.max(extR, ix + ir);
+        extT = Math.max(extT, -iy + ir);
+        extB = Math.max(extB, iy + ir);
+      }
+    }
+    return {
+      minX: extL + pad,
+      maxX: window.innerWidth - extR - pad,
+      minY: extT + pad,
+      maxY: window.innerHeight - extB - pad,
+    };
+  }
+
+  // ── build / destroy items ───────────────────────────────────────────────
+  function visible(menu: ArcItem[]): ArcItem[] {
+    return menu.filter((it) => (it.isVisible ? it.isVisible() : true));
+  }
+
+  function buildItems(menu: ArcItem[]): void {
+    destroyItems();
+    S.menu = menu;
+    const n = menu.length;
+    const arc = arcCfg(n);
+    const ba = baseAngles(arc.start, arc.span, n);
+    // Comfortable horizontal padding inside the tooltip pill.
+    const ttPad = Math.max(C.TT_PAD, 12);
+
+    menu.forEach((item, i) => {
+      wireItem(item);
+
+      // Goo blob — solid circle in the filtered layer.
+      const blob = document.createElement("div");
+      blob.className = cls("goo-blob");
+      blob.style.width = C.ITEM_SZ + "px";
+      blob.style.height = C.ITEM_SZ + "px";
+      gooLayer.appendChild(blob);
+      gooBlobs.push(blob);
+
+      // Accent glow — click flash, unfiltered.
+      const glow = document.createElement("div");
+      glow.className = cls("accent-glow");
+      glowLayer.appendChild(glow);
+      glows.push(glow);
+
+      // Icon overlay — the caller's persistent tool button, inserted BELOW the
+      // bubble cover so items emerge from behind the bubble.
+      item.el.classList.add(cls("tool-btn"));
+      iconLayer.insertBefore(item.el, bubbleGlow);
+
+      // Tooltip text (crisp). Built first so we can size the pill from its
+      // real rendered width — kbd chips are wider than a plain string, so
+      // measuring the actual element keeps text off the pill edges.
+      const tt = document.createElement("div");
+      tt.className = cls("tt-text");
+      let html = `<span class="${cls("tt-label")}">${escapeHtml(item.label)}</span>`;
+      if (item.sub) html += `<span class="${cls("tt-arrow")}">›</span>`;
+      if (item.kbd && item.kbd.length) {
+        html += `<span class="${cls("tt-kbd")}">`;
+        html += item.kbd.map((k) => `<kbd>${escapeHtml(k)}</kbd>`).join("");
+        html += "</span>";
+      }
+      tt.innerHTML = html;
+      iconLayer.insertBefore(tt, bubbleGlow);
+      ttTexts.push(tt);
+
+      // Goo tooltip pill (filtered) — merges with the blob at small scale.
+      const ttW = tt.offsetWidth + ttPad * 2;
+      const ttBlob = document.createElement("div");
+      ttBlob.className = cls("goo-tooltip");
+      ttBlob.style.width = ttW + "px";
+      ttBlob.dataset.w = String(ttW);
+      gooLayer.appendChild(ttBlob);
+      gooTTs.push(ttBlob);
+    });
+
+    S.cur = menu.map((_, i) => ({ sc: 0.01, ag: ba[i], r: 0 }));
+    S.tgt = menu.map((_, i) => ({ sc: 1, ag: ba[i], r: C.ARC_R }));
+    S.ttScales = menu.map(() => 0);
+  }
+
+  function destroyItems(): void {
+    gooBlobs.forEach((e) => e.remove());
+    gooTTs.forEach((e) => e.remove());
+    ttTexts.forEach((e) => e.remove());
+    glows.forEach((e) => e.remove());
+    // Detach (but keep) the caller-owned icon overlays.
+    S.menu.forEach((item) => {
+      item.el.classList.remove(cls("tool-btn"));
+      if (item.el.parentNode) item.el.parentNode.removeChild(item.el);
+      item.el.style.transform = "";
+      item.el.style.opacity = "";
+    });
+    gooBlobs = [];
+    gooTTs = [];
+    ttTexts = [];
+    glows = [];
+    S.cur = [];
+    S.tgt = [];
+    S.ttScales = [];
+    hovIdx = -1;
+  }
+
+  // ── per-frame positioning ────────────────────────────────────────────────
+  function posItems(progress: number): void {
+    const n = S.menu.length;
+    for (let i = 0; i < n; i++) {
+      const blob = gooBlobs[i];
+      const item = S.menu[i];
+      const glow = glows[i];
+      const ttBlob = gooTTs[i];
+      const tt = ttTexts[i];
+      const c = S.cur[i];
+      if (!blob || !item || !c) continue;
+
+      const itemT = clamp((progress * (n + 2) - i) / 2, 0, 1);
+      const appear = easeOutBack(clamp(itemT, 0, 1));
+
+      const r = c.r * appear;
+      const x = Math.cos(c.ag) * r;
+      const y = Math.sin(c.ag) * r;
+      const sz = C.ITEM_SZ * c.sc;
+
+      // Goo blob — always fully opaque and surface-colored so neighbouring
+      // blobs merge with no colour discontinuity at the necks.
+      blob.style.width = sz + "px";
+      blob.style.height = sz + "px";
+      blob.style.transform = `translate(calc(${x}px - 50%),calc(${y}px - 50%))`;
+
+      // Icon overlay — distance-based fade in, fisheye scale.
+      const active = item.isActive ? item.isActive() : false;
+      const separation = r / (C.ARC_R || 1);
+      const iconFade = clamp((separation - 0.5) * 3, 0, 1);
+      item.el.style.transform = `translate(calc(${x}px - 50%),calc(${y}px - 50%)) scale(${c.sc})`;
+      item.el.style.opacity = String(iconFade);
+      item.el.style.pointerEvents = iconFade > 0.6 ? "auto" : "none";
+
+      // Active state reads as a soft accent halo behind the icon (no hard
+      // colour edge on the blob), fading in/out via CSS.
+      if (glow) {
+        glow.style.transform = `translate(calc(${x}px - 50%),calc(${y}px - 50%))`;
+        glow.style.opacity = active ? String(iconFade * 0.95) : "0";
+      }
+
+      // Tooltip — horizontal pill scaling out from its attachment edge,
+      // clamped to the viewport.
+      if (ttBlob && tt) {
+        const ttW = parseFloat(ttBlob.dataset.w || "60");
+        const ttH = 26;
+        const outR = C.ARC_R + (C.ITEM_SZ * c.sc) / 2 + C.TT_GAP;
+        const ttX = Math.cos(c.ag) * outR * appear;
+        const ttY = Math.sin(c.ag) * outR * appear;
+        const ts = S.ttScales[i] || 0;
+        const ox = (1 - Math.cos(c.ag)) / 2;
+        const oy = (1 - Math.sin(c.ag)) / 2;
+        let pL = ttX - ox * ttW;
+        let pT = ttY - oy * ttH;
+
+        const vpPad = 6;
+        const vpL = S.x + pL;
+        const vpT = S.y + pT;
+        const vpR = vpL + ttW;
+        const vpB = vpT + ttH;
+        if (vpL < vpPad) pL += vpPad - vpL;
+        if (vpR > window.innerWidth - vpPad) pL -= vpR - (window.innerWidth - vpPad);
+        if (vpT < vpPad) pT += vpPad - vpT;
+        if (vpB > window.innerHeight - vpPad) pT -= vpB - (window.innerHeight - vpPad);
+
+        ttBlob.style.width = ttW + "px";
+        ttBlob.style.height = ttH + "px";
+        ttBlob.style.left = pL + "px";
+        ttBlob.style.top = pT + "px";
+        ttBlob.style.transformOrigin = `${ox * 100}% ${oy * 100}%`;
+        ttBlob.style.transform = `scale(${ts})`;
+        ttBlob.style.opacity = ts > 0.01 ? "1" : "0";
+
+        tt.style.left = pL + ttW * 0.5 + "px";
+        tt.style.top = pT + ttH * 0.5 + "px";
+        tt.style.opacity = ts > 0.5 ? String(clamp((ts - 0.5) * 2, 0, 1)) : "0";
+      }
+    }
+  }
+
+  function flashBubbleGlow(): void {
+    bubbleGlow.style.transition = "none";
+    bubbleGlow.style.opacity = "1";
+    requestAnimationFrame(() => {
+      bubbleGlow.style.transition = "opacity .6s ease-out";
+      bubbleGlow.style.opacity = "0";
+    });
+  }
+
+  // ── bubble icon ─────────────────────────────────────────────────────────
+  let iconTimer: ReturnType<typeof setTimeout> | null = null;
+  let currentIconKey = "";
+  function updateBubbleIcon(): void {
+    const key = S.stack.length > 0 ? "back" : S.open ? "close" : "logo";
+    if (key === currentIconKey) return;
+    currentIconKey = key;
+    const html =
+      key === "back" ? opts.icons.back : key === "close" ? opts.icons.close : opts.icons.logo;
+    if (iconTimer) clearTimeout(iconTimer);
+    opts.bubbleIcon.style.opacity = "0";
+    iconTimer = setTimeout(() => {
+      opts.bubbleIcon.innerHTML = html;
+      opts.bubbleIcon.style.opacity = "1";
+    }, 110);
+  }
+
+  // ── open / close / submenu ────────────────────────────────────────────────
+  function openMenu(): void {
+    if (closeTimer) { clearTimeout(closeTimer); closeTimer = null; }
+    if (S.open && !S.closing) return;
+    S.open = true;
+    S.opening = true;
+    S.closing = false;
+    S.openT = 0;
+    S.animStart = performance.now();
+    flashBubbleGlow();
+    buildItems(visible(opts.items()));
+    updateBubbleIcon();
+    cb.onOpenChange?.(true);
+    ensureLoop();
+  }
+
+  function closeMenu(clear = true): void {
+    if (closeTimer) { clearTimeout(closeTimer); closeTimer = null; }
+    // Re-entry guard: ignore if already closing (avoids double onOpenChange
+    // and restarted timing).
+    if (!S.open || S.closing) return;
+    S.closing = true;
+    S.opening = false;
+    S.retracting = false;
+    S.closeClear = clear;
+    S.animStart = performance.now();
+    hideAllTooltips();
+    updateBubbleIcon();
+    cb.onOpenChange?.(false);
+    ensureLoop();
+  }
+
+  // Submenu transitions are data-driven: stash the pending level, lerp items
+  // back to the bubble center, and only rebuild once the goo has absorbed them
+  // (maxR < 4). No setTimeout races.
+  function enterSub(item: ArcItem): void {
+    if (S.retracting || !item.sub) return;
+    hideAllTooltips();
+    S.pending = visible(item.sub);
+    S.pendingStack = [...S.stack, S.menu];
+    S.retracting = true;
+    S.opening = false;
+    updateBubbleIcon();
+    ensureLoop();
+  }
+  function goBack(): void {
+    if (!S.stack.length || S.retracting) return;
+    hideAllTooltips();
+    S.pending = S.stack[S.stack.length - 1];
+    S.pendingStack = S.stack.slice(0, -1);
+    S.retracting = true;
+    S.opening = false;
+    // Icon returns to logo/close only after rebuild; keep back arrow meanwhile.
+    ensureLoop();
+  }
+
+  function clickItem(i: number): void {
+    if (S.retracting || S.closing) return;
+    const item = S.menu[i];
+    if (!item) return;
+    hideAllTooltips();
+    hovIdx = -1;
+    if (item.sub) {
+      enterSub(item);
+      return;
+    }
+    flashBubbleGlow();
+    item.onSelect?.();
+    if (!item.stayOpen) {
+      // Track the timer so a fast close/re-open can't collapse the new menu.
+      if (closeTimer) clearTimeout(closeTimer);
+      closeTimer = setTimeout(() => {
+        closeTimer = null;
+        if (!destroyed) closeMenu();
+      }, C.CLOSE_MS);
+    }
+  }
+
+  // ── tooltips ──────────────────────────────────────────────────────────────
+  function hideAllTooltips(): void {
+    hovIdx = -1;
+    for (let i = 0; i < S.ttScales.length; i++) S.ttScales[i] = 0;
+  }
+
+  // ── main loop (gated: runs only while something is animating) ───────────────
+  let loopId: number | null = null;
+  let closeTimer: ReturnType<typeof setTimeout> | null = null;
+  let destroyed = false;
+  function needsFrame(): boolean {
+    return (
+      S.open ||
+      S.opening ||
+      S.closing ||
+      S.retracting ||
+      S.floating ||
+      S.hoveringBubble ||
+      S.bubbleTTScale > 0.01 ||
+      Math.abs(S.bubbleScale - S.bubbleTgtScale) > 0.001
+    );
+  }
+  function ensureLoop(): void {
+    if (destroyed) return;
+    if (loopId == null) {
+      S.animStart = S.animStart || performance.now();
+      loopId = requestAnimationFrame(tick);
+    }
+  }
+
+  function tick(): void {
+    loopId = null;
+    const now = performance.now();
+    const dt = now - S.animStart;
+    const n = S.cur.length;
+
+    // Bubble scale: hover target + a gentle breathing while engaged.
+    S.bubbleScale = lerp(S.bubbleScale, S.bubbleTgtScale, 0.15);
+    const engaged = S.open || S.hoveringBubble;
+    const breath = S.pointerDown || !engaged ? 0 : Math.sin(now / 2800 * Math.PI) * 0.015;
+    applyBubbleScale(S.bubbleScale + breath);
+
+    // Bubble goo tooltip: shown on hover while the menu is closed and idle.
+    if (bubbleTT) {
+      const showBTT =
+        S.hoveringBubble && !S.open && !S.opening && !S.closing &&
+        !S.retracting && !S.pointerDown;
+      S.bubbleTTScale = lerp(S.bubbleTTScale, showBTT ? 1 : 0, C.TT_LERP);
+      if (S.bubbleTTScale < 0.005) S.bubbleTTScale = 0;
+      positionBubbleTT();
+    }
+
+    if (S.opening) {
+      S.openT = clamp(dt / C.OPEN_MS, 0, 1);
+      if (S.openT >= 1) {
+        S.opening = false;
+        S.openT = 1;
+      }
+    }
+
+    if (S.closing) {
+      let maxR = 0;
+      for (let i = 0; i < n; i++) {
+        if (!S.cur[i]) continue;
+        S.cur[i].r = lerp(S.cur[i].r, 0, C.SUB_LERP);
+        S.cur[i].sc = lerp(S.cur[i].sc, 0.3, C.SUB_LERP);
+        if (S.cur[i].r > maxR) maxR = S.cur[i].r;
+      }
+      posItems(1);
+      if (maxR < 4) {
+        S.open = false;
+        S.closing = false;
+        S.openT = 0;
+        destroyItems();
+        if (S.closeClear) {
+          S.stack = [];
+        }
+        updateBubbleIcon();
+      }
+      if (needsFrame()) loopId = requestAnimationFrame(tick);
+      return;
+    }
+
+    if (S.retracting) {
+      let maxR = 0;
+      for (let i = 0; i < n; i++) {
+        if (!S.cur[i]) continue;
+        S.cur[i].r = lerp(S.cur[i].r, 0, C.SUB_LERP);
+        S.cur[i].sc = lerp(S.cur[i].sc, 0.3, C.SUB_LERP);
+        if (S.cur[i].r > maxR) maxR = S.cur[i].r;
+      }
+      posItems(1);
+      if (maxR < 4 && S.pending) {
+        S.retracting = false;
+        S.stack = S.pendingStack || [];
+        buildItems(S.pending);
+        S.pending = null;
+        S.pendingStack = null;
+        updateBubbleIcon();
+        S.opening = true;
+        S.openT = 0;
+        S.animStart = performance.now();
+      }
+      loopId = requestAnimationFrame(tick);
+      return;
+    }
+
+    if (!S.open) {
+      // Only bubble hover/scale animation remains.
+      if (needsFrame()) loopId = requestAnimationFrame(tick);
+      return;
+    }
+
+    const arc = arcCfg(n);
+    const ba = baseAngles(arc.start, arc.span, n);
+    const { sc, ag } = fisheye(ba, S.mouseAng, arc.start, arc.span);
+
+    for (let i = 0; i < n; i++) {
+      if (!S.tgt[i] || !S.cur[i]) continue;
+      S.tgt[i].sc = sc[i];
+      S.tgt[i].ag = ag[i];
+      S.tgt[i].r = C.ARC_R;
+      S.cur[i].sc = lerp(S.cur[i].sc, S.tgt[i].sc, C.LERP);
+      S.cur[i].ag = S.cur[i].ag + angDiff(S.cur[i].ag, S.tgt[i].ag) * C.LERP;
+      S.cur[i].r = lerp(S.cur[i].r, S.tgt[i].r, C.LERP);
+      const ttTgt = hovIdx === i ? 1 : 0;
+      S.ttScales[i] = lerp(S.ttScales[i] || 0, ttTgt, C.TT_LERP);
+      if (S.ttScales[i] < 0.005) S.ttScales[i] = 0;
+    }
+
+    posItems(easeOutCubic(S.openT));
+
+    // Live bounds correction: gently push the bubble inward while open so the
+    // arc never clips off-screen.
+    if (!S.dragging && !S.floating) {
+      const b = bounds();
+      let nx = S.x;
+      let ny = S.y;
+      let moved = false;
+      if (nx < b.minX) { nx = b.minX; moved = true; }
+      if (nx > b.maxX) { nx = b.maxX; moved = true; }
+      if (ny < b.minY) { ny = b.minY; moved = true; }
+      if (ny > b.maxY) { ny = b.maxY; moved = true; }
+      if (moved) {
+        S.x = lerp(S.x, nx, 0.18);
+        S.y = lerp(S.y, ny, 0.18);
+        applyContainer();
+        cb.onMove?.(S.x, S.y, false);
+      }
+    }
+
+    loopId = requestAnimationFrame(tick);
+  }
+
+  // ── DOM writes for bubble + container ───────────────────────────────────────
+  function applyBubbleScale(scale: number): void {
+    const sz = C.BUBBLE_SZ * scale;
+    gooBubble.style.width = sz + "px";
+    gooBubble.style.height = sz + "px";
+    bubbleCover.style.width = sz + "px";
+    bubbleCover.style.height = sz + "px";
+    opts.bubble.style.width = sz + "px";
+    opts.bubble.style.height = sz + "px";
+  }
+  function applyContainer(): void {
+    container.style.left = S.x + "px";
+    container.style.top = S.y + "px";
+  }
+
+  // Position the bubble's goo tooltip so it buds off the bubble toward the
+  // viewport center (open space), mirroring the item tooltips.
+  function positionBubbleTT(): void {
+    if (!bubbleTT || !bubbleTTText) return;
+    const ts = S.bubbleTTScale;
+    if (ts <= 0) {
+      bubbleTT.style.opacity = "0";
+      bubbleTTText.style.opacity = "0";
+      return;
+    }
+    const ttW = parseFloat(bubbleTT.dataset.w || "60");
+    const ttH = 26;
+    const br = (C.BUBBLE_SZ / 2) * (S.bubbleScale || 1);
+    const ang = Math.atan2(
+      window.innerHeight / 2 - S.y,
+      window.innerWidth / 2 - S.x,
+    );
+    const anchorR = br + C.TT_GAP;
+    const ttX = Math.cos(ang) * anchorR;
+    const ttY = Math.sin(ang) * anchorR;
+    const ox = (1 - Math.cos(ang)) / 2;
+    const oy = (1 - Math.sin(ang)) / 2;
+    let pL = ttX - ox * ttW;
+    let pT = ttY - oy * ttH;
+
+    const vpPad = 6;
+    const vpL = S.x + pL;
+    const vpT = S.y + pT;
+    const vpR = vpL + ttW;
+    const vpB = vpT + ttH;
+    if (vpL < vpPad) pL += vpPad - vpL;
+    if (vpR > window.innerWidth - vpPad) pL -= vpR - (window.innerWidth - vpPad);
+    if (vpT < vpPad) pT += vpPad - vpT;
+    if (vpB > window.innerHeight - vpPad) pT -= vpB - (window.innerHeight - vpPad);
+
+    bubbleTT.style.width = ttW + "px";
+    bubbleTT.style.height = ttH + "px";
+    bubbleTT.style.left = pL + "px";
+    bubbleTT.style.top = pT + "px";
+    bubbleTT.style.transformOrigin = `${ox * 100}% ${oy * 100}%`;
+    bubbleTT.style.transform = `scale(${ts})`;
+    bubbleTT.style.opacity = ts > 0.01 ? "1" : "0";
+    bubbleTTText.style.left = pL + ttW * 0.5 + "px";
+    bubbleTTText.style.top = pT + ttH * 0.5 + "px";
+    bubbleTTText.style.opacity = ts > 0.5 ? String(clamp((ts - 0.5) * 2, 0, 1)) : "0";
+  }
+
+  // ── mouse zone (fisheye activation) ───────────────────────────────────────
+  function updateZone(cx: number, cy: number): void {
+    if (!S.open || S.closing) {
+      S.mouseInZone = false;
+      return;
+    }
+    const dx = cx - S.x;
+    const dy = cy - S.y;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    const ang = Math.atan2(dy, dx);
+    const arc = arcCfg(S.menu.length);
+    S.mouseInZone =
+      dist > C.ARC_R - 35 &&
+      dist < C.ARC_R + 35 &&
+      Math.abs(angDiff(ang, arc.center)) < arc.span / 2 + 0.35;
+    S.mouseAng = ang;
+  }
+
+  // ── momentum physics ──────────────────────────────────────────────────────
+  const velHist: { x: number; y: number; t: number }[] = [];
+  const VH_SIZE = 6;
+  let physFrame: number | null = null;
+  let lastPhysT = 0;
+
+  function startFloat(): void {
+    if (velHist.length < 2) {
+      S.vx = 0;
+      S.vy = 0;
+      return;
+    }
+    const first = velHist[0];
+    const last = velHist[velHist.length - 1];
+    const dt = (last.t - first.t) / 1000;
+    if (dt <= 0) {
+      S.vx = 0;
+      S.vy = 0;
+      return;
+    }
+    S.vx = (last.x - first.x) / dt;
+    S.vy = (last.y - first.y) / dt;
+    const speed = Math.hypot(S.vx, S.vy);
+    if (speed < C.SNAP_VEL) {
+      S.vx = 0;
+      S.vy = 0;
+      S.floating = false;
+      cb.onMove?.(S.x, S.y, true);
+      return;
+    }
+    const maxV = 2500;
+    if (speed > maxV) {
+      S.vx = (S.vx / speed) * maxV;
+      S.vy = (S.vy / speed) * maxV;
+    }
+    S.floating = true;
+    lastPhysT = performance.now();
+    if (physFrame != null) cancelAnimationFrame(physFrame);
+    physFrame = requestAnimationFrame(physicsTick);
+  }
+
+  function physicsTick(): void {
+    const now = performance.now();
+    const dt = Math.min((now - lastPhysT) / 1000, 0.05);
+    lastPhysT = now;
+    const f = Math.pow(C.FRICTION, dt * 60);
+    S.vx *= f;
+    S.vy *= f;
+    S.x += S.vx * dt;
+    S.y += S.vy * dt;
+    const b = bounds();
+    if (S.x < b.minX) { S.x = b.minX; S.vx = -S.vx * C.BOUNCE; }
+    if (S.x > b.maxX) { S.x = b.maxX; S.vx = -S.vx * C.BOUNCE; }
+    if (S.y < b.minY) { S.y = b.minY; S.vy = -S.vy * C.BOUNCE; }
+    if (S.y > b.maxY) { S.y = b.maxY; S.vy = -S.vy * C.BOUNCE; }
+    applyContainer();
+    cb.onMove?.(S.x, S.y, false);
+    const speed = Math.hypot(S.vx, S.vy);
+    if (speed > C.MIN_VEL) {
+      physFrame = requestAnimationFrame(physicsTick);
+    } else {
+      S.vx = 0;
+      S.vy = 0;
+      S.floating = false;
+      physFrame = null;
+      cb.onMove?.(S.x, S.y, true);
+    }
+  }
+
+  // ── pointer wiring ─────────────────────────────────────────────────────────
+  function onBubblePointerDown(e: PointerEvent): void {
+    e.preventDefault();
+    if (S.floating) {
+      S.floating = false;
+      S.vx = 0;
+      S.vy = 0;
+      if (physFrame != null) cancelAnimationFrame(physFrame);
+      physFrame = null;
+    }
+    S.pointerDown = true;
+    S.dragging = false;
+    S.wasDrag = false;
+    S.dragStart.x = e.clientX;
+    S.dragStart.y = e.clientY;
+    S.dragOff.x = e.clientX - S.x;
+    S.dragOff.y = e.clientY - S.y;
+    try {
+      opts.bubble.setPointerCapture(e.pointerId);
+    } catch (_) { /* ignore */ }
+    S.bubbleTgtScale = 1.12;
+    velHist.length = 0;
+    velHist.push({ x: e.clientX, y: e.clientY, t: performance.now() });
+    ensureLoop();
+  }
+
+  function onWindowPointerMove(e: PointerEvent): void {
+    if (S.pointerDown) {
+      const dx = e.clientX - S.dragStart.x;
+      const dy = e.clientY - S.dragStart.y;
+      if (!S.wasDrag && Math.hypot(dx, dy) > C.DRAG_TH) {
+        S.wasDrag = true;
+        S.dragging = true;
+        opts.bubble.classList.add(cls("dragging"));
+        cb.onDragChange?.(true);
+      }
+      if (S.dragging) {
+        const b = bounds();
+        S.x = clamp(e.clientX - S.dragOff.x, b.minX, b.maxX);
+        S.y = clamp(e.clientY - S.dragOff.y, b.minY, b.maxY);
+        applyContainer();
+        cb.onMove?.(S.x, S.y, false);
+        velHist.push({ x: e.clientX, y: e.clientY, t: performance.now() });
+        if (velHist.length > VH_SIZE) velHist.shift();
+      }
+    }
+    updateZone(e.clientX, e.clientY);
+    if (!S.pointerDown) {
+      const dx = e.clientX - S.x;
+      const dy = e.clientY - S.y;
+      const onBubble = Math.hypot(dx, dy) < C.BUBBLE_SZ / 2 + 4;
+      if (onBubble && !S.hoveringBubble) {
+        S.hoveringBubble = true;
+        S.bubbleTgtScale = 1.1;
+        ensureLoop();
+      } else if (!onBubble && S.hoveringBubble) {
+        S.hoveringBubble = false;
+        S.bubbleTgtScale = 1;
+        ensureLoop();
+      }
+    }
+  }
+
+  function onWindowPointerUp(): void {
+    if (!S.pointerDown) return;
+    S.pointerDown = false;
+    S.dragging = false;
+    opts.bubble.classList.remove(cls("dragging"));
+    S.bubbleTgtScale = S.hoveringBubble ? 1.1 : 1;
+    if (!S.wasDrag) {
+      flashBubbleGlow();
+      if (S.open && !S.closing && !S.retracting) {
+        if (S.stack.length > 0) goBack();
+        else closeMenu();
+      } else if (!S.open && !S.opening) {
+        openMenu();
+      }
+    } else {
+      startFloat();
+    }
+    cb.onDragChange?.(false);
+  }
+
+  function onOutsidePointerDown(e: PointerEvent): void {
+    if (!S.open || S.closing) return;
+    if (cb.shouldCloseOnOutsideClick && !cb.shouldCloseOnOutsideClick()) return;
+    const path = e.composedPath();
+    if (path.indexOf(container) !== -1) return;
+    const dx = e.clientX - S.x;
+    const dy = e.clientY - S.y;
+    if (Math.hypot(dx, dy) > C.ARC_R + 55) closeMenu();
+  }
+
+  function wireItem(item: ArcItem): void {
+    if (wiredItems.has(item)) return;
+    wiredItems.add(item);
+    item.el.addEventListener("pointerenter", () => {
+      const idx = S.menu.indexOf(item);
+      if (idx >= 0) hovIdx = idx;
+    });
+    item.el.addEventListener("pointerleave", () => {
+      hovIdx = -1;
+    });
+    item.el.addEventListener("pointerdown", (e) => e.stopPropagation());
+    item.el.addEventListener("click", (e) => {
+      e.stopPropagation();
+      const idx = S.menu.indexOf(item);
+      if (idx >= 0) clickItem(idx);
+    });
+  }
+
+  // ── event registration ──────────────────────────────────────────────────
+  opts.bubble.addEventListener("pointerdown", onBubblePointerDown as EventListener);
+  window.addEventListener("pointermove", onWindowPointerMove as EventListener);
+  window.addEventListener("pointerup", onWindowPointerUp as EventListener);
+  window.addEventListener("pointerdown", onOutsidePointerDown as EventListener);
+
+  // ── init bubble geometry ───────────────────────────────────────────────
+  opts.bubbleIcon.innerHTML = opts.icons.logo;
+  currentIconKey = "logo";
+  applyBubbleScale(1);
+
+  // ── public handle ─────────────────────────────────────────────────────
+  return {
+    config: C,
+    open: openMenu,
+    close: () => closeMenu(),
+    toggle: () => {
+      if (S.open && !S.closing) closeMenu();
+      else openMenu();
+    },
+    back: goBack,
+    isOpen: () => S.open && !S.closing,
+    depth: () => S.stack.length,
+    reflow: () => {
+      if (!S.open || S.closing || S.retracting) return;
+      // Only the root level has visibility-conditional items (the listening
+      // dot). Recompute it and rebuild only when the visible set actually
+      // changed, so routine polls don't re-trigger the open animation.
+      const level = S.stack.length ? S.menu : visible(opts.items());
+      const sameSet =
+        level.length === S.menu.length &&
+        level.every((it, i) => it === S.menu[i]);
+      if (sameSet) return;
+      buildItems(level);
+      S.opening = true;
+      S.openT = 0;
+      S.animStart = performance.now();
+      ensureLoop();
+    },
+    setPosition: (x, y, animate = false) => {
+      // Only left/top may animate here; the base CSS transition (opacity +
+      // transform) is left intact so the hide/scale animation still works.
+      container.style.transition = animate ? "left .2s ease, top .2s ease" : "";
+      S.x = x;
+      S.y = y;
+      applyContainer();
+      if (animate) setTimeout(() => (container.style.transition = ""), 220);
+    },
+    getPosition: () => ({ x: S.x, y: S.y }),
+    moveIntoView: (animate = false) => {
+      const b = bounds();
+      const nx = clamp(S.x, b.minX, b.maxX);
+      const ny = clamp(S.y, b.minY, b.maxY);
+      if (nx !== S.x || ny !== S.y) {
+        container.style.transition = animate ? "left .2s ease, top .2s ease" : "";
+        S.x = nx;
+        S.y = ny;
+        applyContainer();
+        cb.onMove?.(S.x, S.y, true);
+        if (animate) setTimeout(() => (container.style.transition = ""), 220);
+      }
+    },
+    clampToViewport: () => {
+      const b = bounds();
+      const nx = clamp(S.x, b.minX, b.maxX);
+      const ny = clamp(S.y, b.minY, b.maxY);
+      if (nx !== S.x || ny !== S.y) {
+        S.x = nx;
+        S.y = ny;
+        applyContainer();
+        cb.onMove?.(S.x, S.y, true);
+      }
+    },
+    destroy: () => {
+      destroyed = true;
+      if (loopId != null) cancelAnimationFrame(loopId);
+      if (physFrame != null) cancelAnimationFrame(physFrame);
+      if (iconTimer) clearTimeout(iconTimer);
+      if (closeTimer) { clearTimeout(closeTimer); closeTimer = null; }
+      opts.bubble.removeEventListener("pointerdown", onBubblePointerDown as EventListener);
+      window.removeEventListener("pointermove", onWindowPointerMove as EventListener);
+      window.removeEventListener("pointerup", onWindowPointerUp as EventListener);
+      window.removeEventListener("pointerdown", onOutsidePointerDown as EventListener);
+      if (bubbleTT) bubbleTT.remove();
+      if (bubbleTTText) bubbleTTText.remove();
+      destroyItems();
+    },
+  };
+}
+
+// ── goo filter ──────────────────────────────────────────────────────────────
+// Two-step implicit surface: blur creates overlapping alpha fields, then a
+// color-matrix alpha threshold produces a sharp cutoff → thin organic necks
+// where circles are near, clean edges where they aren't. feComposite(atop)
+// re-composites the crisp original so circle edges stay pixel-clean.
+function ensureGooFilter(scope: ShadowRoot, prefix: string, C: ArcConfig): void {
+  const id = prefix + "goo";
+  if (scope.getElementById && scope.getElementById(id)) return;
+  const svg = document.createElementNS(SVG_NS, "svg");
+  svg.setAttribute("width", "0");
+  svg.setAttribute("height", "0");
+  svg.style.cssText = "position:absolute;width:0;height:0;overflow:hidden;";
+  const defs = document.createElementNS(SVG_NS, "defs");
+  const filter = document.createElementNS(SVG_NS, "filter");
+  filter.setAttribute("id", id);
+  filter.setAttribute("color-interpolation-filters", "sRGB");
+
+  const blur = document.createElementNS(SVG_NS, "feGaussianBlur");
+  blur.setAttribute("in", "SourceGraphic");
+  blur.setAttribute("stdDeviation", String(C.gooBlur));
+  blur.setAttribute("result", "blur");
+
+  const cmat = document.createElementNS(SVG_NS, "feColorMatrix");
+  cmat.setAttribute("in", "blur");
+  cmat.setAttribute("type", "matrix");
+  cmat.setAttribute(
+    "values",
+    `1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 ${C.gooAlpha} ${C.gooOffset}`,
+  );
+  cmat.setAttribute("result", "goo");
+
+  const comp = document.createElementNS(SVG_NS, "feComposite");
+  comp.setAttribute("in", "SourceGraphic");
+  comp.setAttribute("in2", "goo");
+  comp.setAttribute("operator", "atop");
+
+  filter.appendChild(blur);
+  filter.appendChild(cmat);
+  filter.appendChild(comp);
+  defs.appendChild(filter);
+  svg.appendChild(defs);
+  scope.appendChild(svg);
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}

--- a/crates/veld-daemon/frontend/src/feedback-overlay/arc-menu.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/arc-menu.ts
@@ -183,6 +183,11 @@ export function createArcMenu(opts: ArcMenuOptions): ArcMenuHandle {
   const P = opts.prefix;
   const cls = (name: string) => P + name;
 
+  // All engine listeners share one AbortController so destroy() unbinds every
+  // window/bubble/item handler in one call (no leaks across re-init).
+  const ac = new AbortController();
+  const sig = ac.signal;
+
   // ── layers ──────────────────────────────────────────────────────────
   const container = opts.container;
   const gooLayer = document.createElement("div");
@@ -392,6 +397,7 @@ export function createArcMenu(opts: ArcMenuOptions): ArcMenuHandle {
       // Icon overlay — the caller's persistent tool button, inserted BELOW the
       // bubble cover so items emerge from behind the bubble.
       item.el.classList.add(cls("tool-btn"));
+      item.el.setAttribute("aria-label", item.label);
       iconLayer.insertBefore(item.el, bubbleGlow);
 
       // Tooltip text (crisp). Built first so we can size the pill from its
@@ -565,6 +571,7 @@ export function createArcMenu(opts: ArcMenuOptions): ArcMenuHandle {
     flashBubbleGlow();
     buildItems(visible(opts.items()));
     updateBubbleIcon();
+    opts.bubble.setAttribute("aria-expanded", "true");
     cb.onOpenChange?.(true);
     ensureLoop();
   }
@@ -581,6 +588,7 @@ export function createArcMenu(opts: ArcMenuOptions): ArcMenuHandle {
     S.animStart = performance.now();
     hideAllTooltips();
     updateBubbleIcon();
+    opts.bubble.setAttribute("aria-expanded", "false");
     cb.onOpenChange?.(false);
     ensureLoop();
   }
@@ -601,8 +609,12 @@ export function createArcMenu(opts: ArcMenuOptions): ArcMenuHandle {
   function goBack(): void {
     if (!S.stack.length || S.retracting) return;
     hideAllTooltips();
-    S.pending = S.stack[S.stack.length - 1];
     S.pendingStack = S.stack.slice(0, -1);
+    // Recompute visibility when returning to the root (the only level with a
+    // conditional item — the listening dot); use the snapshot for deeper levels.
+    S.pending = S.pendingStack.length
+      ? S.stack[S.stack.length - 1]
+      : visible(opts.items());
     S.retracting = true;
     S.opening = false;
     // Icon returns to logo/close only after rebuild; keep back arrow meanwhile.
@@ -1033,28 +1045,45 @@ export function createArcMenu(opts: ArcMenuOptions): ArcMenuHandle {
     item.el.addEventListener("pointerenter", () => {
       const idx = S.menu.indexOf(item);
       if (idx >= 0) hovIdx = idx;
-    });
+    }, { signal: sig });
     item.el.addEventListener("pointerleave", () => {
       hovIdx = -1;
-    });
-    item.el.addEventListener("pointerdown", (e) => e.stopPropagation());
+    }, { signal: sig });
+    item.el.addEventListener("pointerdown", (e) => e.stopPropagation(), { signal: sig });
     item.el.addEventListener("click", (e) => {
       e.stopPropagation();
       const idx = S.menu.indexOf(item);
       if (idx >= 0) clickItem(idx);
-    });
+    }, { signal: sig });
+  }
+
+  // Keyboard activation on the focused bubble (pointer path is separate).
+  function onBubbleKeyDown(e: KeyboardEvent): void {
+    if (e.key !== "Enter" && e.key !== " " && e.key !== "Spacebar") return;
+    e.preventDefault();
+    if (S.open && !S.closing && !S.retracting) {
+      if (S.stack.length > 0) goBack();
+      else closeMenu();
+    } else if (!S.open && !S.opening) {
+      openMenu();
+    }
   }
 
   // ── event registration ──────────────────────────────────────────────────
-  opts.bubble.addEventListener("pointerdown", onBubblePointerDown as EventListener);
-  window.addEventListener("pointermove", onWindowPointerMove as EventListener);
-  window.addEventListener("pointerup", onWindowPointerUp as EventListener);
-  window.addEventListener("pointerdown", onOutsidePointerDown as EventListener);
+  // Window listeners use capture so a host page that stops propagation at
+  // document/body can't starve drag / outside-click-close.
+  opts.bubble.addEventListener("pointerdown", onBubblePointerDown as EventListener, { signal: sig });
+  opts.bubble.addEventListener("keydown", onBubbleKeyDown as EventListener, { signal: sig });
+  window.addEventListener("pointermove", onWindowPointerMove as EventListener, { capture: true, signal: sig });
+  window.addEventListener("pointerup", onWindowPointerUp as EventListener, { capture: true, signal: sig });
+  window.addEventListener("pointerdown", onOutsidePointerDown as EventListener, { capture: true, signal: sig });
 
   // ── init bubble geometry ───────────────────────────────────────────────
   opts.bubbleIcon.innerHTML = opts.icons.logo;
   currentIconKey = "logo";
   applyBubbleScale(1);
+  opts.bubble.setAttribute("aria-label", opts.bubbleTooltip?.label || "Feedback menu");
+  opts.bubble.setAttribute("aria-haspopup", "true");
 
   // ── public handle ─────────────────────────────────────────────────────
   return {
@@ -1124,10 +1153,7 @@ export function createArcMenu(opts: ArcMenuOptions): ArcMenuHandle {
       if (physFrame != null) cancelAnimationFrame(physFrame);
       if (iconTimer) clearTimeout(iconTimer);
       if (closeTimer) { clearTimeout(closeTimer); closeTimer = null; }
-      opts.bubble.removeEventListener("pointerdown", onBubblePointerDown as EventListener);
-      window.removeEventListener("pointermove", onWindowPointerMove as EventListener);
-      window.removeEventListener("pointerup", onWindowPointerUp as EventListener);
-      window.removeEventListener("pointerdown", onOutsidePointerDown as EventListener);
+      ac.abort(); // unbinds all window/bubble/item listeners at once
       if (bubbleTT) bubbleTT.remove();
       if (bubbleTTText) bubbleTTText.remove();
       destroyItems();
@@ -1180,7 +1206,7 @@ function ensureGooFilter(scope: ShadowRoot, prefix: string, C: ArcConfig): void 
 }
 
 function escapeHtml(s: string): string {
-  return s
+  return String(s ?? "")
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");

--- a/crates/veld-daemon/frontend/src/feedback-overlay/constants.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/constants.ts
@@ -5,7 +5,6 @@ export const KEY_MOD = IS_MAC ? "\u2318" : "Ctrl";
 export const KEY_SHIFT = IS_MAC ? "\u21E7" : "Shift";
 export const SUBMIT_HINT = " " + KEY_MOD + "\u21B5";
 export const FAB_MARGIN = 16;          // drag clamping — allow FAB near edges
-export const FAB_TOOLBAR_MARGIN = 50;  // when toolbar is open — enough for arc
 
 export const ICONS = {
   logo: '<svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M13.2 28L4 4H8.4L15.7 23.8H15.8L23.1 4H27.5L18.3 28H13.2Z" fill="currentColor"/><path d="M24.5 29C25.88 29 27 27.88 27 26.5C27 25.12 25.88 24 24.5 24C23.12 24 22 25.12 22 26.5C22 27.88 23.12 29 24.5 29Z" fill="#C4F56A"/></svg>',

--- a/crates/veld-daemon/frontend/src/feedback-overlay/constants.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/constants.ts
@@ -26,4 +26,5 @@ export const ICONS = {
   person: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>',
   dashboard: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>',
   panelSide: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="7 16 3 12 7 8"/><polyline points="17 16 21 12 17 8"/></svg>',
+  more: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="5" r="1.5" fill="currentColor" stroke="none"/><circle cx="12" cy="12" r="1.5" fill="currentColor" stroke="none"/><circle cx="12" cy="19" r="1.5" fill="currentColor" stroke="none"/></svg>',
 } as const;

--- a/crates/veld-daemon/frontend/src/feedback-overlay/dom.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/dom.ts
@@ -4,11 +4,11 @@ import { getState, dispatch } from "./store";
 import type { ThemeMode } from "./store";
 import { mkEl, appendGuarded } from "./helpers";
 import { PREFIX, ICONS, KEY_MOD, KEY_SHIFT } from "./constants";
-import { initTooltip, attachTooltip, tipHtml } from "./tooltip";
+import { initTooltip, attachTooltip } from "./tooltip";
 import { toast } from "./toast";
 import { initBackdropEvents } from "./backdrop";
-import { initDrag } from "./fab";
-import { toggleToolbar, makeToolBtn, toggleOverflow } from "./toolbar";
+import { initArc, makeToolBtn, handleToolAction } from "./toolbar";
+import type { ArcItem } from "./arc-menu";
 import { togglePanel, togglePanelSide, showThreadList, renderPanel, markAllRead } from "./panel";
 import { sendAllGood } from "./listening";
 
@@ -26,32 +26,52 @@ export function buildDOM(): void {
   refs.componentTraceEl = mkEl("div", "component-trace");
   appendGuarded(document.body, refs.componentTraceEl);
 
-  // Toolbar container (shadow DOM) — anchor for radial buttons
+  // Screenshot selection rectangle (light DOM) — drawn on the backdrop.
+  refs.screenshotRect = mkEl("div", "screenshot-rect");
+  appendGuarded(document.body, refs.screenshotRect);
+
+  // Float container (shadow DOM) — anchor for the arc-menu engine. Zero-size,
+  // translated to the bubble center; the engine builds its goo/glow/icon layers
+  // inside it.
   refs.toolbarContainer = mkEl("div", "toolbar-container");
   refs.toolbar = refs.toolbarContainer; // alias for compatibility
 
-  // --- Primary radial buttons ---
-  refs.toolBtnSelect = makeToolBtn("select-element", ICONS.crosshair, tipHtml("Select element", [KEY_MOD, KEY_SHIFT, "F"]));
-  refs.toolBtnScreenshot = makeToolBtn("screenshot", ICONS.screenshot, tipHtml("Screenshot", [KEY_MOD, KEY_SHIFT, "S"]));
-  refs.toolBtnDraw = makeToolBtn("draw", ICONS.draw, tipHtml("Draw", [KEY_MOD, KEY_SHIFT, "D"]));
-  refs.toolBtnPageComment = makeToolBtn("page-comment", ICONS.pageComment, tipHtml("Page comment", [KEY_MOD, KEY_SHIFT, "P"]));
-  refs.toolBtnComments = makeToolBtn("show-comments", ICONS.chat, tipHtml("Threads", [KEY_MOD, KEY_SHIFT, "C"]));
+  // --- Primary tool icons (reused by the engine as crisp icon overlays) ---
+  refs.toolBtnSelect = makeToolBtn("select-element", ICONS.crosshair);
+  refs.toolBtnScreenshot = makeToolBtn("screenshot", ICONS.screenshot);
+  refs.toolBtnDraw = makeToolBtn("draw", ICONS.draw);
+  refs.toolBtnPageComment = makeToolBtn("page-comment", ICONS.pageComment);
+  refs.toolBtnComments = makeToolBtn("show-comments", ICONS.chat);
 
-  // Listening dot — also a radial button, conditionally visible
+  // Listening dot — conditionally-visible tool.
   refs.listeningModule = mkEl("button", "tool-btn listening-dot");
-  attachTooltip(refs.listeningModule, "All Good");
-  refs.listeningModule.addEventListener("click", function (e) { e.stopPropagation(); sendAllGood(); });
 
-  // Three-dot overflow toggle
-  refs.moreBtn = mkEl("button", "tool-btn");
-  refs.moreBtn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="5" r="1.5" fill="currentColor" stroke="none"/><circle cx="12" cy="12" r="1.5" fill="currentColor" stroke="none"/><circle cx="12" cy="19" r="1.5" fill="currentColor" stroke="none"/></svg>';
-  attachTooltip(refs.moreBtn, tipHtml("More options", []));
-  refs.moreBtn.addEventListener("click", function (e) {
-    e.stopPropagation();
-    toggleOverflow();
-  });
+  // Three-dot overflow — opens the secondary tools as a submenu.
+  refs.moreBtn = makeToolBtn("more", ICONS.more);
 
-  // Register primary buttons in display order
+  // --- Overflow (secondary) tools ---
+  const toolBtnShortcuts = makeToolBtn("shortcuts", ICONS.keyboard);
+  const THEME_ICONS: Record<ThemeMode, string> = {
+    auto: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>',
+    dark: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>',
+    light: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>'
+  };
+  const THEME_LABELS: Record<ThemeMode, string> = { auto: "Auto (contrast)", dark: "Dark", light: "Light" };
+  const THEME_ORDER: ThemeMode[] = ["auto", "dark", "light"];
+  const toolBtnTheme = makeToolBtn("theme", THEME_ICONS[getState().theme]);
+  const toolBtnDashboard = makeToolBtn("dashboard", ICONS.dashboard);
+  refs.toolBtnHide = makeToolBtn("hide", ICONS.eyeOff);
+
+  // Reflect the current theme on the icon + host, and persist it.
+  function applyTheme(): void {
+    const theme = getState().theme;
+    toolBtnTheme.innerHTML = THEME_ICONS[theme];
+    refs.hostEl.setAttribute("data-theme", theme);
+    document.documentElement.setAttribute("data-veld-theme", theme === "auto" ? "" : theme);
+    try { localStorage.setItem("veld-theme", theme); } catch (_) { /* ignore */ }
+  }
+
+  // Keep the ref arrays populated (legacy compat / debugging).
   refs.radialButtons = [
     refs.toolBtnSelect,
     refs.toolBtnScreenshot,
@@ -61,79 +81,119 @@ export function buildDOM(): void {
     refs.listeningModule,
     refs.moreBtn,
   ];
-
-  // Append all primary buttons to the container
-  refs.radialButtons.forEach(function (btn) {
-    refs.toolbarContainer.appendChild(btn);
-  });
-
-  // --- Overflow (secondary) radial buttons ---
-  const toolBtnShortcuts = mkEl("button", "tool-btn");
-  toolBtnShortcuts.innerHTML = ICONS.keyboard;
-  attachTooltip(toolBtnShortcuts, tipHtml("Disable shortcuts", []));
-  toolBtnShortcuts.addEventListener("click", function (e) {
-    e.stopPropagation();
-    dispatch({ type: "SET_SHORTCUTS_DISABLED", disabled: !getState().shortcutsDisabled });
-    toolBtnShortcuts.classList.toggle(PREFIX + "tool-active", getState().shortcutsDisabled);
-    toast(getState().shortcutsDisabled ? "Shortcuts disabled" : "Shortcuts enabled");
-  });
-
-  const THEME_ICONS: Record<ThemeMode, string> = {
-    auto: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>',
-    dark: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>',
-    light: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>'
-  };
-  const THEME_LABELS: Record<ThemeMode, string> = { auto: "Auto (contrast)", dark: "Dark", light: "Light" };
-  const THEME_ORDER: ThemeMode[] = ["auto", "dark", "light"];
-  const toolBtnTheme = mkEl("button", "tool-btn");
-  toolBtnTheme.innerHTML = THEME_ICONS[getState().theme];
-  attachTooltip(toolBtnTheme, tipHtml(THEME_LABELS[getState().theme], []));
-  toolBtnTheme.addEventListener("click", function (e) {
-    e.stopPropagation();
-    const idx = (THEME_ORDER.indexOf(getState().theme) + 1) % THEME_ORDER.length;
-    dispatch({ type: "SET_THEME", theme: THEME_ORDER[idx] });
-    toolBtnTheme.innerHTML = THEME_ICONS[getState().theme];
-    refs.hostEl.setAttribute("data-theme", getState().theme);
-    document.documentElement.setAttribute("data-veld-theme", getState().theme === "auto" ? "" : getState().theme);
-    toast("Theme: " + THEME_LABELS[getState().theme]);
-  });
-
-  const toolBtnDashboard = mkEl("button", "tool-btn");
-  toolBtnDashboard.innerHTML = ICONS.dashboard;
-  attachTooltip(toolBtnDashboard, tipHtml("Management UI", []));
-  toolBtnDashboard.addEventListener("click", function (e) {
-    e.stopPropagation();
-    window.open("https://veld.localhost:" + window.location.port, "_blank");
-  });
-
-  refs.toolBtnHide = makeToolBtn("hide", ICONS.eyeOff, tipHtml("Hide", [KEY_MOD, KEY_SHIFT, "."]));
-
   refs.overflowButtons = [toolBtnShortcuts, toolBtnTheme, toolBtnDashboard, refs.toolBtnHide];
-  refs.overflowButtons.forEach(function (btn) {
-    refs.toolbarContainer.appendChild(btn);
-  });
+  refs.toolbarOverflow = refs.toolbarContainer; // test compat
 
-  // Keep toolbarOverflow ref for test compat (points to container, overflow state tracked in store)
-  refs.toolbarOverflow = refs.toolbarContainer;
+  // --- Item model ---------------------------------------------------------
+  const overflowItems: ArcItem[] = [
+    {
+      id: "shortcuts",
+      el: toolBtnShortcuts,
+      label: "Shortcuts",
+      stayOpen: true,
+      isActive: () => getState().shortcutsDisabled,
+      onSelect: () => {
+        dispatch({ type: "SET_SHORTCUTS_DISABLED", disabled: !getState().shortcutsDisabled });
+        toolBtnShortcuts.classList.toggle(PREFIX + "tool-active", getState().shortcutsDisabled);
+        toast(getState().shortcutsDisabled ? "Shortcuts disabled" : "Shortcuts enabled");
+      },
+    },
+    {
+      id: "theme",
+      el: toolBtnTheme,
+      label: "Theme",
+      stayOpen: true,
+      onSelect: () => {
+        const idx = (THEME_ORDER.indexOf(getState().theme) + 1) % THEME_ORDER.length;
+        dispatch({ type: "SET_THEME", theme: THEME_ORDER[idx] });
+        applyTheme();
+        toast("Theme: " + THEME_LABELS[getState().theme]);
+      },
+    },
+    {
+      id: "dashboard",
+      el: toolBtnDashboard,
+      label: "Management UI",
+      onSelect: () => window.open("https://veld.localhost:" + window.location.port, "_blank"),
+    },
+    {
+      id: "hide",
+      el: refs.toolBtnHide,
+      label: "Hide",
+      kbd: [KEY_MOD, KEY_SHIFT, "."],
+      onSelect: () => handleToolAction("hide"),
+    },
+  ];
 
-  // Screenshot rect (light DOM)
-  refs.screenshotRect = mkEl("div", "screenshot-rect");
-  appendGuarded(document.body, refs.screenshotRect);
+  const rootItems: ArcItem[] = [
+    {
+      id: "select-element",
+      el: refs.toolBtnSelect,
+      label: "Select element",
+      kbd: [KEY_MOD, KEY_SHIFT, "F"],
+      stayOpen: true,
+      isActive: () => getState().activeMode === "select-element",
+      onSelect: () => handleToolAction("select-element"),
+    },
+    {
+      id: "screenshot",
+      el: refs.toolBtnScreenshot,
+      label: "Screenshot",
+      kbd: [KEY_MOD, KEY_SHIFT, "S"],
+      isActive: () => getState().activeMode === "screenshot",
+      onSelect: () => handleToolAction("screenshot"),
+    },
+    {
+      id: "draw",
+      el: refs.toolBtnDraw,
+      label: "Draw",
+      kbd: [KEY_MOD, KEY_SHIFT, "D"],
+      isActive: () => getState().activeMode === "draw",
+      onSelect: () => handleToolAction("draw"),
+    },
+    {
+      id: "page-comment",
+      el: refs.toolBtnPageComment,
+      label: "Page comment",
+      kbd: [KEY_MOD, KEY_SHIFT, "P"],
+      onSelect: () => handleToolAction("page-comment"),
+    },
+    {
+      id: "show-comments",
+      el: refs.toolBtnComments,
+      label: "Threads",
+      kbd: [KEY_MOD, KEY_SHIFT, "C"],
+      onSelect: () => handleToolAction("show-comments"),
+    },
+    {
+      id: "listening",
+      el: refs.listeningModule,
+      label: "All good",
+      isVisible: () => getState().agentListening,
+      onSelect: () => sendAllGood(),
+    },
+    {
+      id: "more",
+      el: refs.moreBtn,
+      label: "More",
+      sub: overflowItems,
+    },
+  ];
 
-  // FAB
+  // --- Bubble -------------------------------------------------------------
   refs.fab = mkEl("button", "fab");
-  attachTooltip(refs.fab, tipHtml("Veld Feedback", [KEY_MOD, KEY_SHIFT, "V"]));
-  refs.fab.innerHTML = ICONS.logo;
+  const fabIcon = mkEl("div", "fab-icon");
+  refs.fab.appendChild(fabIcon);
   refs.fabBadge = mkEl("span", "badge badge-hidden");
   refs.fab.appendChild(refs.fabBadge);
-  refs.fab.addEventListener("click", function () {
-    if (getState().fabWasDragged) { dispatch({ type: "SET_FAB_DRAGGED", dragged: false }); return; }
-    toggleToolbar();
-  });
-  refs.toolbarContainer.appendChild(refs.fab);
 
   refs.shadow.appendChild(refs.toolbarContainer);
-  initDrag();
+
+  // Boot the arc-menu engine (it moves the bubble into its icon layer).
+  initArc(fabIcon, rootItems, { label: "Veld Feedback", kbd: [KEY_MOD, KEY_SHIFT, "V"] });
+
+  // Apply the restored theme (icon + host attributes).
+  applyTheme();
 
   // Panel (shadow DOM)
   refs.panel = mkEl("div", "panel");

--- a/crates/veld-daemon/frontend/src/feedback-overlay/fab.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/fab.ts
@@ -50,12 +50,3 @@ export function clampFabToViewport(): void {
     saveFabPos(cx, cy);
   }
 }
-
-/**
- * When the menu opens near an edge, the engine's live bounds-correction nudges
- * the bubble inward on its own. This remains as an explicit trigger for callers
- * that open the menu programmatically.
- */
-export function nudgeFabForToolbar(): void {
-  getArc()?.moveIntoView(true);
-}

--- a/crates/veld-daemon/frontend/src/feedback-overlay/fab.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/fab.ts
@@ -1,74 +1,23 @@
-import { refs } from "./refs";
+// FAB (bubble) positioning + persistence.
+//
+// Drag, momentum, bounce, and live viewport collision are all owned by the
+// arc-menu engine now. This module keeps the position API the rest of the
+// overlay relies on (restore/clamp on init, nudge for the arc) and mirrors the
+// bubble center into the store + sessionStorage.
 import { getState, dispatch } from "./store";
-import { PREFIX, FAB_MARGIN, FAB_TOOLBAR_MARGIN } from "./constants";
-import { suppressTooltip } from "./tooltip";
-import { positionRadialButtons } from "./toolbar";
+import { FAB_MARGIN } from "./constants";
+import { getArc } from "./toolbar";
 
-export function initDrag(): void {
-  let startX = 0;
-  let startY = 0;
-  let origX = 0;
-  let origY = 0;
-  let dragging = false;
-  let moved = false;
-
-  refs.fab.addEventListener("mousedown", function (e: MouseEvent) {
-    if (e.button !== 0) return;
-    dragging = true;
-    moved = false;
-    startX = e.clientX;
-    startY = e.clientY;
-    origX = getState().fabCX;
-    origY = getState().fabCY;
-    e.preventDefault();
-  });
-
-  document.addEventListener("mousemove", function (e: MouseEvent) {
-    if (!dragging) return;
-    const dx = e.clientX - startX;
-    const dy = e.clientY - startY;
-    if (!moved && Math.abs(dx) < 4 && Math.abs(dy) < 4) return;
-    if (!moved) suppressTooltip(true);
-    moved = true;
-    let nx = origX + dx;
-    let ny = origY + dy;
-    nx = Math.max(
-      20 + FAB_MARGIN,
-      Math.min(window.innerWidth - 20 - FAB_MARGIN, nx),
-    );
-    ny = Math.max(
-      20 + FAB_MARGIN,
-      Math.min(window.innerHeight - 20 - FAB_MARGIN, ny),
-    );
-    positionFab(nx, ny, false);
-    positionRadialButtons();
-  });
-
-  document.addEventListener("mouseup", function () {
-    if (!dragging) return;
-    dragging = false;
-    if (moved) {
-      dispatch({ type: "SET_FAB_DRAGGED", dragged: true });
-      setTimeout(function () {
-        dispatch({ type: "SET_FAB_DRAGGED", dragged: false });
-        suppressTooltip(false);
-      }, 300);
-      saveFabPos(getState().fabCX, getState().fabCY);
-    }
-  });
-}
-
+/** Move the bubble center to (cx, cy). Updates the engine + store. */
 export function positionFab(cx: number, cy: number, animate: boolean): void {
   dispatch({ type: "SET_FAB_POS", cx, cy });
-  refs.toolbarContainer.style.transition = animate ? "all .2s ease" : "none";
-  refs.toolbarContainer.style.top = cy - 20 + "px";
-  refs.toolbarContainer.style.left = cx - 20 + "px";
+  getArc()?.setPosition(cx, cy, animate);
 }
 
 export function saveFabPos(x: number, y: number): void {
   try {
-    sessionStorage.setItem("veld-fab-pos", JSON.stringify({ x: x, y: y }));
-  } catch (_) {}
+    sessionStorage.setItem("veld-fab-pos", JSON.stringify({ x, y }));
+  } catch (_) { /* ignore */ }
 }
 
 export function restoreFabPos(): void {
@@ -79,60 +28,34 @@ export function restoreFabPos(): void {
       positionFab(pos.x, pos.y, false);
       return;
     }
-  } catch (_) {}
-  positionFab(
-    20 + FAB_MARGIN,
-    window.innerHeight - 20 - FAB_MARGIN,
-    false,
-  );
+  } catch (_) { /* ignore */ }
+  positionFab(20 + FAB_MARGIN, window.innerHeight - 20 - FAB_MARGIN, false);
 }
 
+/** Clamp the bubble into the viewport (called on init + resize). */
 export function clampFabToViewport(): void {
-  let cx = getState().fabCX;
-  let cy = getState().fabCY;
-  let clamped = false;
+  const arc = getArc();
+  if (arc) {
+    arc.clampToViewport();
+    return;
+  }
+  // Fallback (no engine): simple viewport clamp against the store position.
   const maxX = window.innerWidth - 20 - FAB_MARGIN;
   const maxY = window.innerHeight - 20 - FAB_MARGIN;
   const minXY = 20 + FAB_MARGIN;
-  if (cx > maxX) {
-    cx = maxX;
-    clamped = true;
-  }
-  if (cx < minXY) {
-    cx = minXY;
-    clamped = true;
-  }
-  if (cy > maxY) {
-    cy = maxY;
-    clamped = true;
-  }
-  if (cy < minXY) {
-    cy = minXY;
-    clamped = true;
-  }
-  if (clamped) {
+  const cx = Math.max(minXY, Math.min(maxX, getState().fabCX));
+  const cy = Math.max(minXY, Math.min(maxY, getState().fabCY));
+  if (cx !== getState().fabCX || cy !== getState().fabCY) {
     positionFab(cx, cy, false);
     saveFabPos(cx, cy);
   }
 }
 
 /**
- * If the FAB is too close to an edge for the toolbar arc,
- * smoothly animate it inward to the toolbar-safe margin.
+ * When the menu opens near an edge, the engine's live bounds-correction nudges
+ * the bubble inward on its own. This remains as an explicit trigger for callers
+ * that open the menu programmatically.
  */
 export function nudgeFabForToolbar(): void {
-  let cx = getState().fabCX;
-  let cy = getState().fabCY;
-  let nudged = false;
-  const maxX = window.innerWidth - 20 - FAB_TOOLBAR_MARGIN;
-  const maxY = window.innerHeight - 20 - FAB_TOOLBAR_MARGIN;
-  const minXY = 20 + FAB_TOOLBAR_MARGIN;
-  if (cx > maxX) { cx = maxX; nudged = true; }
-  if (cx < minXY) { cx = minXY; nudged = true; }
-  if (cy > maxY) { cy = maxY; nudged = true; }
-  if (cy < minXY) { cy = minXY; nudged = true; }
-  if (nudged) {
-    positionFab(cx, cy, true); // animate: true
-    saveFabPos(cx, cy);
-  }
+  getArc()?.moveIntoView(true);
 }

--- a/crates/veld-daemon/frontend/src/feedback-overlay/modes.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/modes.ts
@@ -6,7 +6,7 @@ import { toast } from "./toast";
 import { closeActivePopover } from "./popover";
 import { stopCaptureStream } from "./screenshot";
 import { ensureDrawScript, setupGlobalDrawCanvas, teardownGlobalDrawCanvas } from "./draw-mode";
-import { toggleToolbar } from "./toolbar";
+import { closeToolbar } from "./toolbar";
 
 export function setMode(mode: UIMode): void {
   // Tear down previous mode
@@ -56,19 +56,18 @@ export function setMode(mode: UIMode): void {
   if (mode === "screenshot") {
     // No acquireCaptureStream — selection starts instantly without screen share dialog.
     // Capture is deferred to after the user finishes drawing the selection rectangle.
+    // Close the menu so the arc doesn't float over the capture region.
+    closeToolbar();
     refs.overlay.classList.add(PREFIX + "overlay-active");
     refs.overlay.classList.add(PREFIX + "overlay-crosshair");
     window.focus();
     toast("Draw a rectangle to capture a screenshot");
   }
   if (mode === "draw") {
-    // Close the radial toolbar visually but DON'T call toggleToolbar() —
-    // it calls setMode(null) which clobbers activeMode before the async
-    // setupGlobalDrawCanvas() runs.
-    if (getState().toolbarOpen) {
-      dispatch({ type: "SET_TOOLBAR_OPEN", open: false });
-      dispatch({ type: "SET_OVERFLOW_OPEN", open: false });
-    }
+    // Close the arc menu (the engine is the sole authority for open state).
+    // Safe to call here: SET_MODE was already dispatched above, so the engine's
+    // onOpenChange guard (only clears select-element) won't clobber draw mode.
+    closeToolbar();
     // No acquireCaptureStream — draw starts instantly without screen share dialog.
     // Capture is deferred to Done (for compositing) or blur tool (for pixelation).
     ensureDrawScript().then(() => {

--- a/crates/veld-daemon/frontend/src/feedback-overlay/store.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/store.ts
@@ -150,6 +150,15 @@ import { createStore, type Store as StoreInterface } from "../shared/create-stor
 
 let instance: StoreInterface<Store, Action>;
 
+/** Restore the persisted toolbar theme, defaulting to auto (contrast). */
+function readStoredTheme(): ThemeMode {
+  try {
+    const t = localStorage.getItem("veld-theme");
+    if (t === "dark" || t === "light" || t === "auto") return t;
+  } catch (_) { /* ignore */ }
+  return "auto";
+}
+
 function createInitial(): Store {
   return {
     threads: [],
@@ -167,7 +176,7 @@ function createInitial(): Store {
     overflowOpen: false,
     hidden: false,
     shortcutsDisabled: false,
-    theme: "auto",
+    theme: readStoredTheme(),
     expandedThreadId: null,
     pins: {},
     captureStream: null,

--- a/crates/veld-daemon/frontend/src/feedback-overlay/store.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/store.ts
@@ -35,7 +35,6 @@ export interface Store {
   // FAB positioning
   fabCX: number;
   fabCY: number;
-  fabWasDragged: boolean;
 
   // Misc
   rafPending: boolean;
@@ -69,7 +68,6 @@ export type Action =
   | { type: "REMOVE_PIN"; threadId: string }
   | { type: "CLEAR_PINS" }
   | { type: "SET_FAB_POS"; cx: number; cy: number }
-  | { type: "SET_FAB_DRAGGED"; dragged: boolean }
   | { type: "SET_RAF_PENDING"; pending: boolean }
   | { type: "SET_LAST_EVENT_SEQ"; seq: number }
   | { type: "SET_LAST_PATHNAME"; path: string }
@@ -133,8 +131,6 @@ function reduce(s: Store, action: Action): Store {
       return { ...s, pins: {} };
     case "SET_FAB_POS":
       return { ...s, fabCX: action.cx, fabCY: action.cy };
-    case "SET_FAB_DRAGGED":
-      return { ...s, fabWasDragged: action.dragged };
     case "SET_RAF_PENDING":
       return { ...s, rafPending: action.pending };
     case "SET_LAST_EVENT_SEQ":
@@ -159,6 +155,15 @@ function readStoredTheme(): ThemeMode {
   return "auto";
 }
 
+/** Restore panel side. Wrapped: merely accessing localStorage throws in
+ *  sandboxed / cross-origin iframes, which would abort overlay boot. */
+function readPanelSide(): "left" | "right" {
+  try {
+    if (localStorage.getItem("veld-panel-side") === "left") return "left";
+  } catch (_) { /* ignore */ }
+  return "right";
+}
+
 function createInitial(): Store {
   return {
     threads: [],
@@ -166,7 +171,7 @@ function createInitial(): Store {
     lastSeenAt: {},
     agentListening: false,
     panelOpen: false,
-    panelSide: (typeof localStorage !== "undefined" && localStorage.getItem("veld-panel-side")) === "left" ? "left" : "right",
+    panelSide: readPanelSide(),
     panelTab: "active",
     activePopover: null,
     activeMode: null,
@@ -186,7 +191,6 @@ function createInitial(): Store {
     prevOverflow: null,
     fabCX: 0,
     fabCY: 0,
-    fabWasDragged: false,
     rafPending: false,
     lastPathname: typeof window !== "undefined" ? window.location.pathname : "/",
   };

--- a/crates/veld-daemon/frontend/src/feedback-overlay/toolbar.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/toolbar.ts
@@ -1,34 +1,33 @@
+// Toolbar — thin adapter between the Veld feedback overlay and the arc-menu
+// engine. It owns the engine instance, translates engine callbacks into store
+// dispatches, and preserves the public API that other modules + tests depend on
+// (toggleToolbar, positionRadialButtons, makeToolBtn).
 import { refs } from "./refs";
 import { getState, dispatch } from "./store";
 import { mkEl } from "./helpers";
-import { PREFIX } from "./constants";
-import { attachTooltip } from "./tooltip";
+import { PREFIX, ICONS } from "./constants";
 import { updateBadge } from "./badge";
 import { deps } from "../shared/registry";
-import { nudgeFabForToolbar } from "./fab";
+import { saveFabPos } from "./fab";
+import { createArcMenu, type ArcItem, type ArcMenuHandle } from "./arc-menu";
 
-const RADIUS = 48;           // center-to-center distance from FAB
-const ARC_SPAN = Math.PI;    // 180° arc
-const ARC_THICKNESS = 32;    // arc backdrop thickness
-const SVG_NS = "http://www.w3.org/2000/svg";
+let arc: ArcMenuHandle | null = null;
 
-// Arc backdrop SVG elements (created lazily)
-let arcSvg: SVGSVGElement | null = null;
-let arcPathEl: SVGPathElement | null = null;
+/** The live engine handle (null before buildDOM / in unit tests). */
+export function getArc(): ArcMenuHandle | null {
+  return arc;
+}
 
-export function makeToolBtn(action: string, iconSvg: string, title: string): HTMLElement {
+/** Create a bare icon button. Label/kbd/action are carried by the ArcItem. */
+export function makeToolBtn(action: string, iconSvg: string): HTMLElement {
   const btn = mkEl("button", "tool-btn");
   (btn as HTMLElement & { dataset: DOMStringMap }).dataset.action = action;
   btn.innerHTML = iconSvg;
-  attachTooltip(btn, title);
-  btn.addEventListener("click", (e: Event) => {
-    e.stopPropagation();
-    handleToolAction(action);
-  });
   return btn;
 }
 
-function handleToolAction(action: string): void {
+/** Perform a standard tool action (modes / panel / page-comment / hide). */
+export function handleToolAction(action: string): void {
   if (action === "select-element") {
     deps().setMode(getState().activeMode === "select-element" ? null : "select-element");
   } else if (action === "screenshot") {
@@ -44,163 +43,67 @@ function handleToolAction(action: string): void {
   }
 }
 
-/** Compute the base angle for the arc: points from FAB toward viewport center. */
-function computeBaseAngle(): number {
-  const cx = getState().fabCX / window.innerWidth;
-  const cy = getState().fabCY / window.innerHeight;
-  return Math.atan2(0.5 - cy, 0.5 - cx);
-}
-
 /**
- * Get the currently active button set.
- * When overflow is open, show overflow buttons + the ⋯ toggle.
- * Otherwise, show primary buttons (filtering hidden listening dot).
+ * Instantiate the arc-menu engine. Called once from buildDOM with the bubble's
+ * icon element and the assembled root item model.
  */
-function getActiveButtons(): HTMLElement[] {
-  if (getState().overflowOpen) {
-    // Overflow page: overflow buttons + the ⋯ toggle (to switch back)
-    return [...refs.overflowButtons, refs.moreBtn];
-  }
-  // Primary page: primary tools, conditional listening, ⋯ toggle
-  return refs.radialButtons.filter(function (btn) {
-    if (btn === refs.listeningModule && !getState().agentListening) return false;
-    return true;
-  });
-}
-
-/** Build an SVG arc (ring segment) path string with rounded endcaps. */
-function arcPath(
-  centerX: number, centerY: number,
-  radius: number, thickness: number,
-  startAngle: number, endAngle: number,
-): string {
-  const rOuter = radius + thickness / 2;
-  const rInner = radius - thickness / 2;
-  const capR = (rOuter - rInner) / 2;
-  const pad = capR * 0.35 / radius;
-  const a1 = startAngle - pad;
-  const a2 = endAngle + pad;
-  const largeArc = Math.abs(a2 - a1) > Math.PI ? 1 : 0;
-
-  const ox1 = centerX + Math.cos(a1) * rOuter;
-  const oy1 = centerY + Math.sin(a1) * rOuter;
-  const ox2 = centerX + Math.cos(a2) * rOuter;
-  const oy2 = centerY + Math.sin(a2) * rOuter;
-  const ix2 = centerX + Math.cos(a2) * rInner;
-  const iy2 = centerY + Math.sin(a2) * rInner;
-  const ix1 = centerX + Math.cos(a1) * rInner;
-  const iy1 = centerY + Math.sin(a1) * rInner;
-
-  return [
-    "M", ox1, oy1,
-    "A", rOuter, rOuter, 0, largeArc, 1, ox2, oy2,
-    "A", capR, capR, 0, 0, 1, ix2, iy2,
-    "A", rInner, rInner, 0, largeArc, 0, ix1, iy1,
-    "A", capR, capR, 0, 0, 1, ox1, oy1,
-    "Z"
-  ].join(" ");
-}
-
-/** Ensure the arc SVG exists, create lazily. */
-function ensureArc(): { svg: SVGSVGElement; path: SVGPathElement } {
-  if (!arcSvg) {
-    arcSvg = document.createElementNS(SVG_NS, "svg");
-    arcSvg.style.cssText = "position:absolute;top:0;left:0;pointer-events:none;overflow:visible;width:40px;height:40px;z-index:0;";
-    arcPathEl = document.createElementNS(SVG_NS, "path");
-    arcPathEl.setAttribute("fill", "var(--vf-bg)");
-    arcPathEl.setAttribute("stroke", "var(--vf-border)");
-    arcPathEl.setAttribute("stroke-width", "1");
-    arcPathEl.style.filter = "drop-shadow(0 2px 8px rgba(0,0,0,.25))";
-    arcPathEl.style.transition = "d .2s ease";
-    arcSvg.appendChild(arcPathEl);
-    refs.toolbarContainer.insertBefore(arcSvg, refs.toolbarContainer.firstChild);
-  }
-  return { svg: arcSvg, path: arcPathEl! };
-}
-
-/** Hide all buttons (both primary and overflow). */
-function hideAllButtons(): void {
-  const all = [...refs.radialButtons, ...refs.overflowButtons];
-  all.forEach(function (btn) {
-    btn.classList.remove(PREFIX + "radial-open");
-    btn.style.transform = "translate(0, 0) scale(0)";
+export function initArc(
+  bubbleIcon: HTMLElement,
+  rootItems: ArcItem[],
+  bubbleTooltip?: { label: string; kbd?: string[] },
+): void {
+  arc = createArcMenu({
+    container: refs.toolbarContainer,
+    scope: refs.shadow,
+    bubble: refs.fab,
+    bubbleIcon,
+    prefix: PREFIX,
+    items: () => rootItems,
+    icons: {
+      logo: ICONS.logo,
+      close: ICONS.cancel,
+      back: ICONS.back,
+    },
+    bubbleTooltip,
+    callbacks: {
+      onMove: (x, y, committed) => {
+        dispatch({ type: "SET_FAB_POS", cx: x, cy: y });
+        if (committed) saveFabPos(x, y);
+      },
+      onOpenChange: (open) => {
+        dispatch({ type: "SET_TOOLBAR_OPEN", open });
+        dispatch({ type: "SET_OVERFLOW_OPEN", open: false });
+        // Closing the menu exits the menu-coupled inspection mode, but leaves
+        // full-screen takeovers (screenshot / draw) running.
+        if (!open && getState().activeMode === "select-element") {
+          deps().setMode(null);
+        }
+        updateBadge();
+      },
+      shouldCloseOnOutsideClick: () => !getState().activeMode,
+    },
   });
 }
 
 /**
- * Position the active button set around the FAB.
- * Called on open, during drag, on overflow toggle, and on window resize.
+ * Toggle the menu open/closed.
+ *
+ * With the engine present (production) the engine drives open state and fires
+ * onOpenChange to update the store. Without an engine (unit tests) we mutate
+ * the store directly so the documented state semantics still hold.
  */
-export function positionRadialButtons(): void {
-  if (!getState().toolbarOpen) return;
-  const baseAngle = computeBaseAngle();
-  const active = getActiveButtons();
-  const count = active.length;
-  if (count === 0) return;
-
-  const startAngle = baseAngle - ARC_SPAN / 2;
-  const step = count > 1 ? ARC_SPAN / (count - 1) : 0;
-  const cx = 20, cy = 20;
-
-  for (let i = 0; i < count; i++) {
-    const angle = startAngle + step * i;
-    const x = Math.cos(angle) * RADIUS;
-    const y = Math.sin(angle) * RADIUS;
-    active[i].style.transform = "translate(" + Math.round(x) + "px, " + Math.round(y) + "px) scale(1)";
-  }
-
-  // Update arc backdrop
-  const { path } = ensureArc();
-  const endAngle = startAngle + step * (count - 1);
-  path.setAttribute("d", arcPath(cx, cy, RADIUS, ARC_THICKNESS, startAngle, endAngle));
-}
-
-/** Toggle between primary and overflow button sets in the same arc. */
-export function toggleOverflow(): void {
-  const nowOpen = !getState().overflowOpen;
-  dispatch({ type: "SET_OVERFLOW_OPEN", open: nowOpen });
-
-  // Hide the old set, show the new set
-  hideAllButtons();
-  positionRadialButtons();
-  const active = getActiveButtons();
-  active.forEach(function (btn, i) {
-    setTimeout(function () {
-      btn.classList.add(PREFIX + "radial-open");
-    }, i * 30);
-  });
-}
-
 export function toggleToolbar(): void {
-  dispatch({ type: "SET_TOOLBAR_OPEN", open: !getState().toolbarOpen });
-
-  if (getState().toolbarOpen) {
-    nudgeFabForToolbar();
-    positionRadialButtons();
-    if (arcSvg) arcSvg.style.opacity = "1";
-    const active = getActiveButtons();
-    active.forEach(function (btn, i) {
-      setTimeout(function () {
-        btn.classList.add(PREFIX + "radial-open");
-      }, i * 30);
-    });
-  } else {
-    deps().setMode(null);
-    dispatch({ type: "SET_OVERFLOW_OPEN", open: false });
-    const active = getActiveButtons();
-    const total = active.length;
-    active.forEach(function (btn, i) {
-      setTimeout(function () {
-        btn.classList.remove(PREFIX + "radial-open");
-        btn.style.transform = "translate(0, 0) scale(0)";
-      }, (total - 1 - i) * 30);
-    });
-    // Also hide any buttons from the other set
-    hideAllButtons();
-    setTimeout(function () {
-      if (arcSvg) arcSvg.style.opacity = "0";
-    }, total * 30);
+  if (arc) {
+    arc.toggle();
+    return;
   }
-
+  const open = !getState().toolbarOpen;
+  dispatch({ type: "SET_TOOLBAR_OPEN", open });
+  if (!open) dispatch({ type: "SET_OVERFLOW_OPEN", open: false });
   updateBadge();
+}
+
+/** Re-sync the arc when the visible item set changes (e.g. listening dot). */
+export function positionRadialButtons(): void {
+  arc?.reflow();
 }

--- a/crates/veld-daemon/frontend/src/feedback-overlay/toolbar.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/toolbar.ts
@@ -52,6 +52,7 @@ export function initArc(
   rootItems: ArcItem[],
   bubbleTooltip?: { label: string; kbd?: string[] },
 ): void {
+  arc?.destroy(); // unbind a prior engine's listeners before replacing it
   arc = createArcMenu({
     container: refs.toolbarContainer,
     scope: refs.shadow,
@@ -106,4 +107,20 @@ export function toggleToolbar(): void {
 /** Re-sync the arc when the visible item set changes (e.g. listening dot). */
 export function positionRadialButtons(): void {
   arc?.reflow();
+}
+
+/**
+ * Close the menu. Used by mode entry (draw / screenshot) and hide, which need
+ * the engine — the sole authority for open state — to actually collapse.
+ * Falls back to store-only in unit tests where no engine exists.
+ */
+export function closeToolbar(): void {
+  if (arc) {
+    arc.close(); // engine fires onOpenChange → store + badge update
+    return;
+  }
+  // No engine (unit tests): keep the store consistent. Badge sync is the
+  // engine's job in production, so we don't touch refs here.
+  dispatch({ type: "SET_TOOLBAR_OPEN", open: false });
+  dispatch({ type: "SET_OVERFLOW_OPEN", open: false });
 }

--- a/crates/veld-daemon/frontend/src/feedback-overlay/visibility.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/visibility.ts
@@ -2,6 +2,7 @@ import { refs } from "./refs";
 import { getState, dispatch } from "./store";
 import { PREFIX } from "./constants";
 import { deps } from "../shared/registry";
+import { closeToolbar } from "./toolbar";
 
 export function hideOverlay(): void {
   dispatch({ type: "SET_HIDDEN", hidden: true });
@@ -14,6 +15,7 @@ export function hideOverlay(): void {
   refs.hoverOutline.style.display = "none";
   refs.componentTraceEl.style.display = "none";
   deps().setMode(null);
+  closeToolbar(); // collapse the arc so it doesn't tick behind the hidden overlay
   if (getState().panelOpen) deps().togglePanel();
 }
 

--- a/crates/veld-daemon/frontend/tests/build-dom.test.ts
+++ b/crates/veld-daemon/frontend/tests/build-dom.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import { initState } from "../src/feedback-overlay/state";
+import { refs } from "../src/feedback-overlay/refs";
+import { registerDeps } from "../src/shared/registry";
+import { buildDOM } from "../src/feedback-overlay/dom";
+import { makeFakeDeps } from "./test-helpers";
+
+/**
+ * Smoke test for the real buildDOM() (as opposed to the mock refs used
+ * elsewhere). Guards against dropping a DOM element during refactors — a
+ * missing ref (e.g. screenshotRect) surfaces as a null-deref at runtime, not
+ * in the mock-based unit tests.
+ */
+describe("buildDOM", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    const host = document.createElement("veld-feedback");
+    const shadow = host.attachShadow({ mode: "open" });
+    document.body.appendChild(host);
+    initState(shadow, host);
+    registerDeps(makeFakeDeps());
+  });
+
+  it("initializes every DOM ref", () => {
+    buildDOM();
+    const required = [
+      "toolbarContainer", "fab", "fabBadge", "toolbar", "toolBtnSelect",
+      "toolBtnScreenshot", "toolBtnDraw", "toolBtnPageComment", "toolBtnComments",
+      "toolBtnHide", "toolbarOverflow", "listeningModule", "moreBtn", "overlay",
+      "hoverOutline", "componentTraceEl", "screenshotRect", "panel", "panelBody",
+      "panelHeadTitle", "panelBackBtn", "markReadBtn", "segBtnActive",
+      "segBtnResolved", "tooltip",
+    ] as const;
+    for (const key of required) {
+      expect(refs[key], `refs.${key} should be initialized`).toBeTruthy();
+    }
+    expect(refs.radialButtons.length).toBeGreaterThan(0);
+    expect(refs.overflowButtons.length).toBeGreaterThan(0);
+  });
+
+  it("screenshot mode teardown does not throw", async () => {
+    buildDOM();
+    const { setMode } = await import("../src/feedback-overlay/modes");
+    setMode("screenshot");
+    // Teardown touches refs.screenshotRect — must exist.
+    expect(() => setMode(null)).not.toThrow();
+  });
+});

--- a/crates/veld-daemon/frontend/tests/mode-close.test.ts
+++ b/crates/veld-daemon/frontend/tests/mode-close.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { initState } from "../src/feedback-overlay/state";
+import { registerDeps } from "../src/shared/registry";
+import { buildDOM } from "../src/feedback-overlay/dom";
+import { getArc } from "../src/feedback-overlay/toolbar";
+import { setMode } from "../src/feedback-overlay/modes";
+import { hideOverlay } from "../src/feedback-overlay/visibility";
+import { getState } from "../src/feedback-overlay/store";
+import { makeFakeDeps } from "./test-helpers";
+
+/**
+ * Regression: the arc engine is the sole authority for open state. Entering a
+ * full-screen mode (screenshot / draw) or hiding the overlay must actually
+ * CLOSE the engine — not just flip a store bool — otherwise the menu stays
+ * visually open (and the rAF loop runs forever) over the draw canvas / behind
+ * the hidden overlay. See closeToolbar() wiring in modes.ts / visibility.ts.
+ */
+describe("mode entry / hide closes the arc engine", () => {
+  beforeEach(() => {
+    // jsdom has no rAF loop; make it a no-op scheduler so open() doesn't throw.
+    vi.stubGlobal("requestAnimationFrame", () => 1 as unknown as number);
+    vi.stubGlobal("cancelAnimationFrame", () => {});
+    document.body.innerHTML = "";
+    const host = document.createElement("veld-feedback");
+    const shadow = host.attachShadow({ mode: "open" });
+    document.body.appendChild(host);
+    initState(shadow, host);
+    registerDeps(makeFakeDeps());
+    buildDOM();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("screenshot mode entry closes the open menu", () => {
+    getArc()!.open();
+    expect(getArc()!.isOpen()).toBe(true);
+    setMode("screenshot");
+    expect(getArc()!.isOpen()).toBe(false);
+    expect(getState().toolbarOpen).toBe(false);
+  });
+
+  it("hideOverlay closes the open menu", () => {
+    getArc()!.open();
+    expect(getArc()!.isOpen()).toBe(true);
+    hideOverlay();
+    expect(getArc()!.isOpen()).toBe(false);
+    expect(getState().toolbarOpen).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Rebuilds the feedback overlay's floating bubble + radial toolbar as a metaball **"goo" arc menu**, ported from the `floating-arc-menu` prototype.

- Draggable bubble that expands into a partial radial arc of tools with liquid merge/emerge animations
- macOS-dock **fisheye** magnification on hover
- **Momentum** drag with edge **bounce** + per-edge **viewport collision** (bubble hugs edges the arc doesn't face)
- Goo-bridged **tooltips** for both the bubble and each item
- Data-driven **submenu** retraction — overflow tools are now a submenu of the ⋯ item
- Soft accent **halo** for active modes (no hard blob edge)
- 1px per-theme **contrast hairline** around the goo silhouette (dark UI reads on dark pages)
- Toolbar **theme persists** to `localStorage`

## How

- New engine `crates/veld-daemon/frontend/src/feedback-overlay/arc-menu.ts` — framework-agnostic, shadow-DOM aware, **gated rAF** (idle = no CPU), configurable physics/geometry. Reuses the existing tool-button elements as crisp icon overlays, so active-state classes, badges, and modes keep working unchanged.
- `toolbar.ts` / `fab.ts` are now thin adapters over the engine, preserving the public API other modules + tests depend on.

## Testing

- `vitest`: 398 passing (adds a `buildDOM` smoke test guarding against dropped DOM refs — the class of regression that briefly broke screenshot mode during development)
- `tsc --noEmit`: clean
- `node build.mjs`: clean
- Visually verified via headless Chrome across states (closed / open / fisheye / submenu / active / tooltips) in both themes

## Notes

Internal overlay UI — no config/CLI/schema surface changes, so the docs checklist doesn't apply. The `floating-arc-menu.html` prototype is intentionally left untracked.