### PR TITLE
fix: release breaking-change (!) commits via conventionalcommits preset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
           extra_plugins: |
             @semantic-release/exec
             @semantic-release/git
+            conventional-changelog-conventionalcommits
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -167,6 +168,7 @@ jobs:
           extra_plugins: |
             @semantic-release/exec
             @semantic-release/git
+            conventional-changelog-conventionalcommits
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,8 +1,8 @@
 {
   "branches": ["main"],
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    ["@semantic-release/commit-analyzer", { "preset": "conventionalcommits" }],
+    ["@semantic-release/release-notes-generator", { "preset": "conventionalcommits" }],
     ["@semantic-release/exec", {
       "prepareCmd": "sed -i'' -e 's/Requires veld v[0-9][0-9.]*/Requires veld v${nextRelease.version}/' -e 's/version: \"[0-9][0-9.]*\"/version: \"${nextRelease.version}\"/' skills/veld/SKILL.md && sed -i'' -e \"s/^version = \\\"[^\\\"]*\\\"/version = \\\"${nextRelease.version}\\\"/\" Cargo.toml"
     }],


### PR DESCRIPTION
## Why

The #127 merge (`feat(feedback)!: …`) didn't release — the run showed *"The commit should not trigger a release."*

`@semantic-release/commit-analyzer` had no `preset`, so it defaulted to **angular**, whose header pattern `type(scope): subject` rejects the `!` breaking marker. So `feat(feedback)!:` wasn't parsed as a `feat` at all → no release → `build`/`release`/`publish` skipped (they gate on `new_release_published == 'true'`).

## Fix

- `commit-analyzer` + `release-notes-generator` → **conventionalcommits** preset (honors `!`).
- Add `conventional-changelog-conventionalcommits` to the action's `extra_plugins` (plan + release jobs).

## Effect

Merging re-analyzes commits since v7.3.0; the pending `feat!` resolves to the **major** bump (v8.0.0), and future `!` commits release correctly. The "Plan Release" check on this PR should now show the computed version.