### PR TITLE
fix(helper): self-heal Caddy and stop updates from resetting privileged setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4135,7 +4135,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "veld"
-version = "7.2.0"
+version = "8.0.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4155,7 +4155,7 @@ dependencies = [
 
 [[package]]
 name = "veld-core"
-version = "7.2.0"
+version = "8.0.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -4177,7 +4177,7 @@ dependencies = [
 
 [[package]]
 name = "veld-daemon"
-version = "7.2.0"
+version = "8.0.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4199,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "veld-helper"
-version = "7.2.0"
+version = "8.0.0"
 dependencies = [
  "anyhow",
  "nix",

--- a/crates/veld-core/src/helper.rs
+++ b/crates/veld-core/src/helper.rs
@@ -1,9 +1,16 @@
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
+
+/// Overall timeout for a single request/response round-trip with the helper.
+/// The helper bounds its own Caddy admin calls at ~10s, so this leaves margin
+/// for a slow-but-working helper while still guaranteeing a caller (e.g. the
+/// daemon's GC task) can never block forever on a wedged helper after sleep.
+const SEND_TIMEOUT: Duration = Duration::from_secs(15);
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -163,8 +170,20 @@ impl HelperClient {
         Self::new(&default_socket_path())
     }
 
-    /// Send a command and receive the response.
+    /// Send a command and receive the response, bounded by [`SEND_TIMEOUT`] so
+    /// a dead/wedged helper cannot hang the caller indefinitely.
     async fn send(&self, command: &HelperCommand) -> Result<HelperResponse, HelperError> {
+        match tokio::time::timeout(SEND_TIMEOUT, self.send_inner(command)).await {
+            Ok(result) => result,
+            Err(_) => Err(HelperError::ReadFailed(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "veld-helper did not respond within timeout",
+            ))),
+        }
+    }
+
+    /// Inner request/response round-trip without the timeout wrapper.
+    async fn send_inner(&self, command: &HelperCommand) -> Result<HelperResponse, HelperError> {
         let mut stream = UnixStream::connect(&self.socket_path).await.map_err(|e| {
             HelperError::ConnectionFailed {
                 path: self.socket_path.clone(),
@@ -283,6 +302,14 @@ impl HelperClient {
         })
     }
 
+    /// Connect to the helper at a specific socket path, verifying it is
+    /// responsive with a bounded status check. Public wrapper over
+    /// [`Self::try_connect`] for callers that know which socket a managed
+    /// helper should be on (e.g. mode-aware connection in `ensure_helper`).
+    pub async fn connect_to(socket_path: &Path) -> Result<Self, HelperError> {
+        Self::try_connect(socket_path).await
+    }
+
     /// Try to connect and verify the helper is responsive (status check).
     async fn try_connect(socket_path: &Path) -> Result<Self, HelperError> {
         let client = Self::new(socket_path);
@@ -309,5 +336,17 @@ impl HelperClient {
             .and_then(|d| d.get("https_port"))
             .and_then(|v| v.as_u64())
             .unwrap_or(443) as u16)
+    }
+
+    /// Query the running helper's version string from its status response.
+    /// Older helpers that predate this field return `None`.
+    pub async fn version(&self) -> Result<Option<String>, HelperError> {
+        let resp = self.status().await?;
+        Ok(resp
+            .data
+            .as_ref()
+            .and_then(|d| d.get("version"))
+            .and_then(|v| v.as_str())
+            .map(str::to_owned))
     }
 }

--- a/crates/veld-core/src/setup.rs
+++ b/crates/veld-core/src/setup.rs
@@ -84,11 +84,30 @@ pub async fn require_setup() -> Result<SetupStatus, SetupError> {
 /// Ensure a helper is running and reachable. Tries existing sockets first,
 /// then auto-bootstraps an unprivileged helper if needed.
 pub async fn ensure_helper() -> Result<crate::helper::HelperClient, anyhow::Error> {
-    use crate::helper::{HelperClient, user_socket_path};
+    use crate::helper::{HelperClient, system_socket_path, user_socket_path};
 
     // Migrate caddy-data from system install if needed.
     if let Err(e) = migrate_from_system_install() {
         tracing::warn!(error = %e, "caddy-data migration failed (non-fatal)");
+    }
+
+    // If setup.json records an explicit mode, the helper is a managed
+    // launchd/systemd service that should already be running. Connect to *that*
+    // helper and never silently bootstrap a throwaway auto-helper — doing so
+    // used to clobber the persisted mode to "auto" and move every URL to
+    // :18443, which is exactly what forced users to re-run `veld setup
+    // privileged` after an update. If the service is momentarily down (e.g.
+    // launchd is relaunching it after `veld update` replaced the binary), wait
+    // for it; if it stays down, surface a clear error instead of downgrading.
+    match read_setup_mode().as_deref() {
+        Some("privileged") => {
+            return connect_managed_helper(&system_socket_path(), "privileged").await;
+        }
+        Some("unprivileged") => {
+            return connect_managed_helper(&user_socket_path(), "unprivileged").await;
+        }
+        // "auto" or unset — fall through to the auto-bootstrap path below.
+        _ => {}
     }
 
     // Try connecting to an existing helper (system or user socket).
@@ -175,6 +194,62 @@ pub async fn ensure_helper() -> Result<crate::helper::HelperClient, anyhow::Erro
     eprintln!();
 
     Ok(client)
+}
+
+/// Read the persisted setup mode from `~/.veld/setup.json`, if present.
+/// Returns `"privileged"`, `"unprivileged"`, `"auto"`, or `None` when unset.
+pub fn read_setup_mode() -> Option<String> {
+    let path = dirs::home_dir()?.join(".veld").join("setup.json");
+    let content = std::fs::read_to_string(path).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&content).ok()?;
+    value
+        .get("mode")
+        .and_then(|m| m.as_str())
+        .map(str::to_owned)
+}
+
+/// Connect to a helper that `setup.json` says is a managed service on `socket`.
+///
+/// Retries for a short bounded window so a `veld start` issued while launchd is
+/// relaunching the helper (e.g. right after `veld update` swapped the binary)
+/// rides out the gap. Never falls back to bootstrapping an auto-helper — a
+/// down managed helper is surfaced as an actionable error, not papered over
+/// with a mode downgrade.
+async fn connect_managed_helper(
+    socket: &std::path::Path,
+    mode: &str,
+) -> Result<crate::helper::HelperClient, anyhow::Error> {
+    use crate::helper::HelperClient;
+
+    // Bounded by wall-clock (~10s) rather than a fixed attempt count: each
+    // `connect_to` can itself take up to 3s on a wedged-but-open socket, so a
+    // fixed count could block `veld start` for over a minute. Usually succeeds
+    // on the first attempt.
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let mut announced = false;
+    loop {
+        if let Ok(client) = HelperClient::connect_to(socket).await {
+            if announced {
+                eprintln!("  veld-helper is back up.");
+            }
+            return Ok(client);
+        }
+        if std::time::Instant::now() >= deadline {
+            break;
+        }
+        if !announced {
+            eprintln!("Waiting for the {mode} veld-helper to come back up...");
+            announced = true;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    anyhow::bail!(
+        "the {mode} veld-helper is not responding at {}.\n\
+         It is managed by launchd/systemd and should restart automatically — \
+         check `veld doctor`. If it stays down, re-run `veld setup {mode}`.",
+        socket.display()
+    )
 }
 
 /// Structured JSON representation of the setup-required error.
@@ -511,16 +586,20 @@ pub async fn install_daemon() -> Result<StepResult, anyhow::Error> {
     <string>dev.veld.daemon</string>
     <key>ProgramArguments</key>
     <array>
-        <string>{}</string>
+        <string>{bin_path}</string>
     </array>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
     <true/>
+    <key>WatchPaths</key>
+    <array>
+        <string>{bin_path}</string>
+    </array>
 </dict>
 </plist>
 "#,
-                veld_daemon_bin.display()
+                bin_path = veld_daemon_bin.display()
             );
             let label = "dev.veld.daemon";
             let domain_target = format!("gui/{real_uid}/{label}");
@@ -742,9 +821,14 @@ async fn install_helper_macos(bin: &Path, caddy_bin: Option<&Path>) -> Result<()
     <true/>
     <key>KeepAlive</key>
     <true/>
+    <key>WatchPaths</key>
+    <array>
+        <string>{bin_path}</string>
+    </array>
 </dict>
 </plist>
 "#,
+        bin_path = bin.display(),
     );
 
     // Stop the running service first (required for upgrades). Use the modern

--- a/crates/veld-core/src/setup.rs
+++ b/crates/veld-core/src/setup.rs
@@ -221,11 +221,14 @@ async fn connect_managed_helper(
 ) -> Result<crate::helper::HelperClient, anyhow::Error> {
     use crate::helper::HelperClient;
 
-    // Bounded by wall-clock (~10s) rather than a fixed attempt count: each
-    // `connect_to` can itself take up to 3s on a wedged-but-open socket, so a
-    // fixed count could block `veld start` for over a minute. Usually succeeds
-    // on the first attempt.
-    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    // Bounded by wall-clock rather than a fixed attempt count: each
+    // `connect_to` is itself capped at 3s (its status check timeout), so a fixed
+    // count could block `veld start` for over a minute on a wedged socket.
+    // 20s is chosen to ride out a helper self-restart — the binary-change
+    // watcher can take ~12s to trigger, plus the launchd/systemd relaunch — so a
+    // `veld start` issued mid-restart waits it out instead of bailing early.
+    // Usually succeeds on the first attempt.
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
     let mut announced = false;
     loop {
         if let Ok(client) = HelperClient::connect_to(socket).await {
@@ -805,6 +808,15 @@ async fn install_helper_macos(bin: &Path, caddy_bin: Option<&Path>) -> Result<()
         ));
     }
 
+    // Log to a file next to the binary so the self-healing story (watchdog
+    // restarts, Caddy recovery, pid adoption) is observable — launchd otherwise
+    // discards the helper's stderr, making a post-sleep recovery impossible to
+    // diagnose.
+    let log_path = bin
+        .parent()
+        .map(|p| p.join("veld-helper.log"))
+        .unwrap_or_else(|| PathBuf::from("/tmp/veld-helper.log"));
+
     let plist = format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
@@ -825,10 +837,15 @@ async fn install_helper_macos(bin: &Path, caddy_bin: Option<&Path>) -> Result<()
     <array>
         <string>{bin_path}</string>
     </array>
+    <key>StandardOutPath</key>
+    <string>{log_path}</string>
+    <key>StandardErrorPath</key>
+    <string>{log_path}</string>
 </dict>
 </plist>
 "#,
         bin_path = bin.display(),
+        log_path = log_path.display(),
     );
 
     // Stop the running service first (required for upgrades). Use the modern
@@ -884,8 +901,14 @@ async fn install_helper_linux(bin: &Path, caddy_bin: Option<&Path>) -> Result<()
     if let Some(caddy) = caddy_bin {
         exec_start.push_str(&format!(" --caddy-bin {}", caddy.display()));
     }
+    // KillMode=process: on stop/restart, only kill the helper itself, not its
+    // whole cgroup. The helper spawns Caddy as a child; the default
+    // control-group kill mode would SIGKILL Caddy whenever the helper is
+    // restarted (or exits to pick up a new binary), tearing down every URL.
+    // Leaving Caddy running mirrors the macOS behavior so a helper restart
+    // doesn't drop the proxy.
     let unit = format!(
-        "[Unit]\nDescription=Veld Helper\n\n[Service]\nExecStart={exec_start}\nRestart=always\n\n[Install]\nWantedBy=multi-user.target\n",
+        "[Unit]\nDescription=Veld Helper\n\n[Service]\nExecStart={exec_start}\nRestart=always\nKillMode=process\n\n[Install]\nWantedBy=multi-user.target\n",
     );
     std::fs::write(unit_path, unit).context("failed to write helper systemd unit")?;
 
@@ -1465,8 +1488,17 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), anyhow::Error> {
     std::fs::create_dir_all(dst)?;
     for entry in std::fs::read_dir(src)? {
         let entry = entry?;
+        // Never migrate mode-specific runtime state across the system->user
+        // move. `caddy.pid` and `veld-routes.json` belong to the *previous*
+        // (privileged) helper session; copying them would make the new
+        // user/auto helper adopt the root Caddy's pid or replay routes bound to
+        // the old mode's ports. Migration exists only to preserve the CA/certs.
+        let name = entry.file_name();
+        if name == "caddy.pid" || name == "veld-routes.json" {
+            continue;
+        }
         let ty = entry.file_type()?;
-        let dst_path = dst.join(entry.file_name());
+        let dst_path = dst.join(&name);
         if ty.is_dir() {
             copy_dir_recursive(&entry.path(), &dst_path)?;
         } else {

--- a/crates/veld-daemon/src/gc.rs
+++ b/crates/veld-daemon/src/gc.rs
@@ -20,6 +20,9 @@ const MAX_LOG_AGE_HOURS: i64 = 168; // 7 days
 /// performs GC on the configured interval.
 pub async fn run_gc_scheduler(share_manager: Arc<ShareManager>) {
     let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(GC_INTERVAL_SECS));
+    // Don't fire a backlog of missed ticks after a macOS sleep — one GC pass on
+    // wake is enough.
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {
         interval.tick().await;

--- a/crates/veld-daemon/src/monitor.rs
+++ b/crates/veld-daemon/src/monitor.rs
@@ -14,37 +14,53 @@ const SCAN_INTERVAL_SECS: u64 = 5;
 /// Key: `"project_root:run_name:node:variant"`.
 type LastCheckMap = HashMap<String, Instant>;
 
+/// Bound on how long the login-shell PATH resolution may take.
+const PATH_RESOLVE_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Resolve the user's full PATH by spawning an interactive login shell.
 /// Falls back to the current process PATH if resolution fails.
-fn resolve_user_path() -> String {
+///
+/// Async + timeout-bounded: the previous version ran a *blocking* interactive
+/// login shell (`$SHELL -l -i`) directly on a tokio worker thread every 60s. A
+/// `.zshrc` that stalls right after a macOS wake (version managers, network
+/// init) could freeze the whole health monitor. Now it runs via `tokio::process`
+/// and is abandoned after [`PATH_RESOLVE_TIMEOUT`].
+async fn resolve_user_path() -> String {
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "sh".to_owned());
     // Use -l -i -c to get a fully initialized interactive login shell.
     // This captures PATH after .zprofile/.bash_profile/brew shellenv etc.
-    let output = std::process::Command::new(&shell)
+    let output = tokio::process::Command::new(&shell)
         .arg("-l")
         .arg("-i")
         .arg("-c")
         .arg("echo $PATH")
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
+        // Kill the shell if we abandon it on timeout, so a hung `.zshrc`
+        // (common right after a macOS wake) doesn't leak a live process every
+        // 60s.
+        .kill_on_drop(true)
         .output();
 
-    match output {
-        Ok(o) if o.status.success() => {
+    match tokio::time::timeout(PATH_RESOLVE_TIMEOUT, output).await {
+        Ok(Ok(o)) if o.status.success() => {
             let path = String::from_utf8_lossy(&o.stdout).trim().to_owned();
             if !path.is_empty() {
                 info!(path = %path, "resolved user PATH from login shell");
                 return path;
             }
         }
-        Ok(o) => {
+        Ok(Ok(o)) => {
             debug!(
                 exit_code = o.status.code(),
                 "login shell PATH resolution exited non-zero, using fallback"
             );
         }
-        Err(e) => {
+        Ok(Err(e)) => {
             debug!(error = %e, "failed to resolve user PATH, using fallback");
+        }
+        Err(_) => {
+            warn!("login shell PATH resolution timed out, using fallback");
         }
     }
 
@@ -55,11 +71,16 @@ fn resolve_user_path() -> String {
 /// When a status change is detected, update the registry and broadcast the event.
 pub async fn run_health_monitor(broadcaster: Broadcaster) {
     let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(SCAN_INTERVAL_SECS));
+    // After a macOS sleep the monotonic clock jumps; with the default `Burst`
+    // behavior an overnight sleep queues thousands of missed 5s ticks that all
+    // fire back-to-back on wake (CPU spike, PATH re-resolution storm). Skip the
+    // backlog and resume the normal cadence instead.
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut last_checks: LastCheckMap = HashMap::new();
 
     // Resolve the user's full PATH once at startup so probe commands can
     // find tools like pg_isready even when the daemon starts at boot.
-    let mut user_path = resolve_user_path();
+    let mut user_path = resolve_user_path().await;
     let mut path_resolved_at = Instant::now();
 
     loop {
@@ -68,7 +89,7 @@ pub async fn run_health_monitor(broadcaster: Broadcaster) {
 
         // Re-resolve PATH every 60s to pick up changes after user login.
         if path_resolved_at.elapsed() > Duration::from_secs(60) {
-            user_path = resolve_user_path();
+            user_path = resolve_user_path().await;
             path_resolved_at = Instant::now();
         }
 

--- a/crates/veld-helper/src/caddy.rs
+++ b/crates/veld-helper/src/caddy.rs
@@ -1,4 +1,7 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use tokio::sync::Mutex;
@@ -13,10 +16,24 @@ const MANAGEMENT_HOST: &str = "veld.localhost";
 /// Port the daemon's HTTP server listens on (feedback + management).
 const DAEMON_HTTP_PORT: u16 = 19899;
 
+/// Overall timeout for a single Caddy admin API request. A half-dead Caddy
+/// (e.g. after a macOS sleep/wake that reset the network stack) can accept a
+/// TCP connection but never respond; without this bound the helper's request
+/// handler — and any daemon/CLI call waiting on it — would hang forever.
+const CADDY_ADMIN_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Connect timeout for the Caddy admin API (localhost, so fast).
+const CADDY_CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+
 /// Manages the Caddy process and its routes.
 #[derive(Debug)]
 pub struct CaddyManager {
     inner: Arc<Mutex<CaddyState>>,
+    /// Active per-run routes, keyed by route `@id`, persisted to disk so they
+    /// survive a Caddy restart, a helper restart (update/crash), or a reboot.
+    /// Caddy itself keeps routes only in memory, so the helper is the durable
+    /// source of truth and replays them on every (re)load.
+    routes: Arc<Mutex<RouteStore>>,
     client: reqwest::Client,
     https_port: u16,
     http_port: u16,
@@ -30,11 +47,34 @@ struct CaddyState {
     child_pid: Option<u32>,
 }
 
+/// Durable store of the Caddy routes this helper has been asked to serve.
+#[derive(Debug)]
+struct RouteStore {
+    /// route `@id` -> the fully-built Caddy route JSON (as `build_route_json`
+    /// produces it), ready to splice back into a config on reload.
+    routes: HashMap<String, serde_json::Value>,
+    /// Where the store is persisted on disk.
+    path: PathBuf,
+}
+
 impl CaddyManager {
     pub fn new(https_port: u16, http_port: u16, caddy_bin: Option<std::path::PathBuf>) -> Self {
+        let store_path = routes_store_path(&caddy_bin);
+        let routes = load_route_store(&store_path);
+        if !routes.is_empty() {
+            info!(count = routes.len(), "restored persisted Caddy routes");
+        }
         Self {
             inner: Arc::new(Mutex::new(CaddyState { child_pid: None })),
-            client: reqwest::Client::new(),
+            routes: Arc::new(Mutex::new(RouteStore {
+                routes,
+                path: store_path,
+            })),
+            client: reqwest::Client::builder()
+                .connect_timeout(CADDY_CONNECT_TIMEOUT)
+                .timeout(CADDY_ADMIN_TIMEOUT)
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
             https_port,
             http_port,
             caddy_bin_override: caddy_bin,
@@ -44,8 +84,17 @@ impl CaddyManager {
     /// Start the Caddy process if it is not already running, and ensure the
     /// base config is loaded.
     pub async fn start(&self) -> Result<()> {
+        // Hold the lock across the whole start sequence so a concurrent caller
+        // (e.g. the watchdog racing a client `caddy_start`) can't double-spawn
+        // Caddy — the second caller waits, then sees the running pid and no-ops.
         let mut state = self.inner.lock().await;
+        self.start_locked(&mut state).await
+    }
 
+    /// Start Caddy, assuming the caller already holds the state lock. Split out
+    /// so `ensure_healthy` can re-check liveness and tear down + restart within
+    /// a single held-lock critical section (no concurrent `caddy_start` window).
+    async fn start_locked(&self, state: &mut CaddyState) -> Result<()> {
         if let Some(pid) = state.child_pid {
             if is_process_alive(pid) {
                 info!(pid, "caddy is already running");
@@ -55,19 +104,27 @@ impl CaddyManager {
             state.child_pid = None;
         }
 
-        // Check if Caddy is already running externally (e.g. from a previous
-        // helper instance). If it is, reload the base config to ensure any new
-        // built-in routes (e.g. management UI) are registered.
-        drop(state);
+        // Check if Caddy is already running externally (e.g. an orphaned Caddy
+        // from a previous helper instance that exited without stopping it). If
+        // so, re-adopt it: record its pid (from the pid file) so we can control
+        // it later, then reload our full config (base + persisted routes).
         if self.is_running().await {
-            info!("caddy admin API already reachable, reloading base config");
+            if let Some(pid) = read_caddy_pid(&self.caddy_bin_override) {
+                // Only adopt a pid we can positively confirm is caddy. If we
+                // can't confirm, don't record it — `stop()` still falls back to
+                // the pid file when recovery is actually needed.
+                if is_process_alive(pid) && pid_is_caddy(pid).await == Some(true) {
+                    state.child_pid = Some(pid);
+                    info!(pid, "re-adopted orphaned caddy from pid file");
+                }
+            }
+            info!("caddy admin API already reachable, reloading full config");
             self.reload()
                 .await
-                .context("failed to reload caddy base config on existing instance")?;
+                .context("failed to reload caddy config on existing instance")?;
             return Ok(());
         }
 
-        let mut state = self.inner.lock().await;
         let caddy_bin = self
             .caddy_bin_override
             .clone()
@@ -91,11 +148,13 @@ impl CaddyManager {
 
         let pid = child.id().context("failed to get caddy PID")?;
         state.child_pid = Some(pid);
-        drop(state); // release lock before HTTP call
+        // Record the pid so a future helper instance that adopts this Caddy (or
+        // needs to kill it when wedged) can regain control of it.
+        write_caddy_pid(&self.caddy_bin_override, pid);
 
-        // Wait for the admin API to become available, then load the base config
-        // (TLS internal issuer + HTTP/HTTPS listeners).
-        info!(pid, "caddy process started, loading base config...");
+        // Wait for the admin API to become available, then load the full config
+        // (base + persisted routes). The lock is intentionally still held here.
+        info!(pid, "caddy process started, loading config...");
         for _ in 0..30 {
             tokio::time::sleep(std::time::Duration::from_millis(200)).await;
             if self
@@ -108,53 +167,67 @@ impl CaddyManager {
                 break;
             }
         }
-        self.reload()
-            .await
-            .context("failed to load caddy base config")?;
-        info!(pid, "caddy started with base config");
+        self.reload().await.context("failed to load caddy config")?;
+        info!(pid, "caddy started with full config");
         Ok(())
     }
 
-    /// Stop the Caddy process.
+    /// Stop the Caddy process, ensuring it is really gone.
+    ///
+    /// Tries a graceful admin-API `/stop` first (works even for an adopted
+    /// orphan while its admin API is responsive), then — critically for the
+    /// wedged case where `/stop` timed out — signals the pid (SIGTERM, then
+    /// SIGKILL) so the listener ports are freed for a restart. The pid comes
+    /// from the tracked child or, failing that, the pid file, so a helper that
+    /// adopted an orphaned Caddy can still tear it down.
     pub async fn stop(&self) -> Result<()> {
         let mut state = self.inner.lock().await;
+        self.stop_locked(&mut state).await
+    }
 
-        // Try graceful shutdown via the admin API first.
+    /// Stop Caddy, assuming the caller already holds the state lock.
+    async fn stop_locked(&self, state: &mut CaddyState) -> Result<()> {
+        let known_pid = state.child_pid.take();
+
         let stop_url = format!("{CADDY_ADMIN_API}/stop");
         match self.client.post(&stop_url).send().await {
             Ok(resp) if resp.status().is_success() => {
                 info!("caddy stopped via admin API");
-                state.child_pid = None;
-                return Ok(());
             }
             Ok(resp) => {
-                debug!(
-                    status = %resp.status(),
-                    "caddy admin API /stop returned non-success; falling back to signal"
-                );
+                debug!(status = %resp.status(), "caddy /stop non-success; will signal by pid");
             }
             Err(e) => {
-                debug!("caddy admin API not reachable for /stop: {e}; falling back to signal");
+                debug!("caddy /stop unreachable: {e}; will signal by pid");
             }
         }
 
-        // Fall back to SIGTERM.
-        if let Some(pid) = state.child_pid.take() {
-            let pid = nix::unistd::Pid::from_raw(pid as i32);
-            if let Err(e) = nix::sys::signal::kill(pid, nix::sys::signal::Signal::SIGTERM) {
-                warn!(%e, "failed to send SIGTERM to caddy");
-            } else {
-                info!(?pid, "sent SIGTERM to caddy");
-            }
+        // Ensure the process is actually dead so its ports are released.
+        if let Some(pid) = known_pid.or_else(|| read_caddy_pid(&self.caddy_bin_override)) {
+            terminate_pid(pid).await;
         }
+        clear_caddy_pid(&self.caddy_bin_override);
 
         Ok(())
     }
 
     /// Reload caddy configuration via the admin API.
+    ///
+    /// The posted config is the base config **plus every persisted per-run
+    /// route**. Caddy's `/load` replaces the entire configuration, so emitting
+    /// only the base (as this used to) would silently drop all app routes on
+    /// every reload — the exact bug that made URLs die after a helper/Caddy
+    /// restart. Splicing the stored routes back in makes reload idempotent and
+    /// self-healing.
     pub async fn reload(&self) -> Result<()> {
         let load_url = format!("{CADDY_ADMIN_API}/load");
-        let config = build_base_config(self.https_port, self.http_port, &self.caddy_bin_override);
+        let stored = self.routes.lock().await.routes.clone();
+        let config = build_full_config(
+            self.https_port,
+            self.http_port,
+            &self.caddy_bin_override,
+            &stored,
+        );
 
         let resp = self
             .client
@@ -184,8 +257,20 @@ impl CaddyManager {
     ) -> Result<()> {
         let route = build_route_json(route_id, hostname, upstream, feedback);
 
-        let url = format!("{CADDY_ADMIN_API}/config/apps/http/servers/veld/routes",);
+        // Record in the durable store first (and persist) so the route is
+        // replayed on any future reload/restart even if the live POST below
+        // fails or Caddy later dies. The store is the source of truth.
+        let existed = self.store_route(route_id, route.clone()).await;
 
+        // If this id was already present, a bare POST would create a duplicate
+        // `@id`. Reload the whole config (base + store) to reconcile instead —
+        // no dependency on Caddy's specific error wording.
+        if existed {
+            info!(route_id, "route id already present, reconciling via reload");
+            return self.reload().await;
+        }
+
+        let url = format!("{CADDY_ADMIN_API}/config/apps/http/servers/veld/routes",);
         let resp = self
             .client
             .post(&url)
@@ -206,6 +291,9 @@ impl CaddyManager {
 
     /// Remove a route by its `@id` via the Caddy admin API.
     pub async fn remove_route(&self, route_id: &str) -> Result<()> {
+        // Drop from the durable store first so it is not replayed on reload.
+        self.forget_route(route_id).await;
+
         let url = format!("{CADDY_ADMIN_API}/id/{route_id}");
 
         let resp = self
@@ -227,6 +315,10 @@ impl CaddyManager {
     /// Remove every route whose `@id` starts with `prefix`. Returns how many were
     /// removed. Used to purge orphaned `veld-join-*` routes on daemon startup.
     pub async fn remove_routes_by_prefix(&self, prefix: &str) -> Result<usize> {
+        // Drop matching routes from the durable store first so they are not
+        // replayed on the next reload.
+        self.forget_routes_by_prefix(prefix).await;
+
         let list_url = format!("{CADDY_ADMIN_API}/config/apps/http/servers/veld/routes");
         let resp = self
             .client
@@ -264,6 +356,242 @@ impl CaddyManager {
     pub async fn pid(&self) -> Option<u32> {
         self.inner.lock().await.child_pid
     }
+
+    /// Ensure Caddy is alive and serving. Returns `true` if a recovery restart
+    /// was performed. Called by the watchdog loop: if Caddy has died or wedged
+    /// (its sentinel route is unreachable within the admin timeout), it is
+    /// torn down and respawned, then all persisted routes are replayed via the
+    /// base-config reload inside `start()`.
+    pub async fn ensure_healthy(&self) -> Result<bool> {
+        // Cheap unlocked pre-check: the common case is a healthy Caddy, and we
+        // don't want to contend for the lock every tick.
+        if self.is_running().await {
+            return Ok(false);
+        }
+        // Acquire the lock and re-check *while holding it*. Any in-flight
+        // `caddy_start` holds this same lock, so by the time we get it that
+        // start has fully completed — if Caddy is now healthy we must not tear
+        // it down (which would drop live connections/HMR). Teardown + restart
+        // then happen atomically in this one critical section.
+        let mut state = self.inner.lock().await;
+        if self.is_running().await {
+            return Ok(false);
+        }
+        warn!("caddy is not responding — attempting recovery restart");
+        // Best-effort teardown of any dead/wedged process so the respawn can
+        // bind the listeners cleanly.
+        let _ = self.stop_locked(&mut state).await;
+        self.start_locked(&mut state)
+            .await
+            .context("failed to restart caddy during recovery")?;
+        info!("caddy recovered");
+        Ok(true)
+    }
+
+    // -- Route store ----------------------------------------------------------
+
+    /// Insert or replace a route in the durable store and persist it. Returns
+    /// `true` if a route with this id was already present (i.e. a replace).
+    ///
+    /// The persist happens while the store lock is held so concurrent route
+    /// operations can't write stale snapshots over each other (route ops are
+    /// infrequent, so serializing them is cheap and keeps the file correct).
+    async fn store_route(&self, route_id: &str, route: serde_json::Value) -> bool {
+        let mut store = self.routes.lock().await;
+        let existed = store.routes.insert(route_id.to_owned(), route).is_some();
+        let snapshot = store.snapshot();
+        persist_route_store(&snapshot).await;
+        existed
+    }
+
+    /// Remove a route from the durable store and persist it.
+    async fn forget_route(&self, route_id: &str) {
+        let mut store = self.routes.lock().await;
+        if store.routes.remove(route_id).is_none() {
+            return;
+        }
+        let snapshot = store.snapshot();
+        persist_route_store(&snapshot).await;
+    }
+
+    /// Remove every stored route whose id starts with `prefix` and persist.
+    async fn forget_routes_by_prefix(&self, prefix: &str) {
+        let mut store = self.routes.lock().await;
+        let before = store.routes.len();
+        store.routes.retain(|id, _| !id.starts_with(prefix));
+        if store.routes.len() == before {
+            return;
+        }
+        let snapshot = store.snapshot();
+        persist_route_store(&snapshot).await;
+    }
+
+    /// Number of routes currently in the durable store (for status/tests).
+    pub async fn stored_route_count(&self) -> usize {
+        self.routes.lock().await.routes.len()
+    }
+}
+
+impl RouteStore {
+    /// Clone the routes + path for persisting outside the lock.
+    fn snapshot(&self) -> RouteSnapshot {
+        RouteSnapshot {
+            path: self.path.clone(),
+            routes: self.routes.clone(),
+        }
+    }
+}
+
+/// A point-in-time copy of the route store, used to persist to disk without
+/// holding the store lock across the async write.
+struct RouteSnapshot {
+    path: PathBuf,
+    routes: HashMap<String, serde_json::Value>,
+}
+
+/// Caddy's data directory — where we persist the route store and pid file.
+/// Derived from the caddy binary's parent (a sibling `caddy-data`) so it shares
+/// the same (helper-writable) location across privileged/user modes.
+fn caddy_data_dir(caddy_bin_override: &Option<PathBuf>) -> PathBuf {
+    caddy_bin_override
+        .as_ref()
+        .and_then(|p| p.parent())
+        .map(|p| p.join("caddy-data"))
+        .unwrap_or_else(veld_core::paths::caddy_data_dir)
+}
+
+/// Where the persisted route store lives.
+fn routes_store_path(caddy_bin_override: &Option<PathBuf>) -> PathBuf {
+    caddy_data_dir(caddy_bin_override).join("veld-routes.json")
+}
+
+/// Where the managed Caddy's pid is recorded, so a restarted helper can
+/// re-adopt (or forcibly stop) an orphaned Caddy it did not itself spawn.
+fn caddy_pid_path(caddy_bin_override: &Option<PathBuf>) -> PathBuf {
+    caddy_data_dir(caddy_bin_override).join("caddy.pid")
+}
+
+fn write_caddy_pid(caddy_bin_override: &Option<PathBuf>, pid: u32) {
+    let path = caddy_pid_path(caddy_bin_override);
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(&path, pid.to_string());
+}
+
+fn read_caddy_pid(caddy_bin_override: &Option<PathBuf>) -> Option<u32> {
+    std::fs::read_to_string(caddy_pid_path(caddy_bin_override))
+        .ok()?
+        .trim()
+        .parse()
+        .ok()
+}
+
+fn clear_caddy_pid(caddy_bin_override: &Option<PathBuf>) {
+    let _ = std::fs::remove_file(caddy_pid_path(caddy_bin_override));
+}
+
+/// Whether `pid` currently belongs to a caddy process, used to guard signalling
+/// against PID reuse after a stale pid file. Returns:
+/// - `Some(true)`  — confirmed a caddy process,
+/// - `Some(false)` — `ps` ran and it is not caddy (or the pid is gone),
+/// - `None`        — `ps` could not be executed, so we can't tell.
+///
+/// Uses an absolute `/bin/ps` path (present on macOS and Linux) so PATH quirks
+/// in a launchd/systemd environment don't turn this into a false "not caddy".
+async fn pid_is_caddy(pid: u32) -> Option<bool> {
+    match tokio::process::Command::new("/bin/ps")
+        .args(["-p", &pid.to_string(), "-o", "comm="])
+        .output()
+        .await
+    {
+        Ok(o) if o.status.success() => {
+            let comm = String::from_utf8_lossy(&o.stdout);
+            Some(comm.trim().ends_with("caddy"))
+        }
+        // ps ran but the pid wasn't found → not a live caddy.
+        Ok(_) => Some(false),
+        // ps couldn't be executed → undetermined.
+        Err(_) => None,
+    }
+}
+
+/// Terminate a caddy process by pid: SIGTERM, wait for graceful exit, then
+/// escalate to SIGKILL. Guarded by [`pid_is_caddy`] so a stale/reused pid is
+/// never signalled. Bounded so it cannot hang the caller.
+async fn terminate_pid(pid: u32) {
+    use nix::sys::signal::{Signal, kill};
+    use nix::unistd::Pid;
+
+    if !is_process_alive(pid) {
+        return;
+    }
+    // Only refuse to signal when we've CONFIRMED the pid is some other process
+    // (stale pid file + reuse). If `ps` is unavailable (`None`) we proceed:
+    // the pid came from our own pid file, and refusing would strand a wedged
+    // Caddy and defeat recovery — the whole point of this path.
+    if pid_is_caddy(pid).await == Some(false) {
+        warn!(pid, "pid is not a caddy process; not signalling (stale pid file?)");
+        return;
+    }
+
+    let nix_pid = Pid::from_raw(pid as i32);
+    let _ = kill(nix_pid, Signal::SIGTERM);
+    info!(pid, "sent SIGTERM to caddy");
+    // Up to ~3s for graceful shutdown.
+    for _ in 0..30 {
+        if !is_process_alive(pid) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    warn!(pid, "caddy did not exit after SIGTERM; sending SIGKILL");
+    let _ = kill(nix_pid, Signal::SIGKILL);
+    for _ in 0..20 {
+        if !is_process_alive(pid) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    warn!(pid, "caddy still present after SIGKILL");
+}
+
+/// Load the persisted route store from disk. Missing/corrupt files start empty
+/// (self-healing rather than fatal).
+fn load_route_store(path: &Path) -> HashMap<String, serde_json::Value> {
+    match std::fs::read(path) {
+        Ok(bytes) => serde_json::from_slice(&bytes).unwrap_or_else(|e| {
+            warn!(error = %e, "failed to parse persisted routes; starting with an empty store");
+            HashMap::new()
+        }),
+        Err(_) => HashMap::new(),
+    }
+}
+
+/// Persist the route store atomically (write to a temp file, then rename).
+async fn persist_route_store(snapshot: &RouteSnapshot) {
+    if let Some(parent) = snapshot.path.parent() {
+        let _ = tokio::fs::create_dir_all(parent).await;
+    }
+    let json = match serde_json::to_vec_pretty(&snapshot.routes) {
+        Ok(j) => j,
+        Err(e) => {
+            warn!(error = %e, "failed to serialize routes for persistence");
+            return;
+        }
+    };
+    // Per-process tmp name so two helpers sharing a data dir don't clobber
+    // each other's temp file mid-write.
+    let tmp = snapshot
+        .path
+        .with_extension(format!("json.tmp.{}", std::process::id()));
+    if let Err(e) = tokio::fs::write(&tmp, &json).await {
+        warn!(error = %e, path = %tmp.display(), "failed to write routes store");
+        return;
+    }
+    if let Err(e) = tokio::fs::rename(&tmp, &snapshot.path).await {
+        warn!(error = %e, "failed to move routes store into place");
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -289,6 +617,32 @@ pub struct FeedbackConfig<'a> {
 // ---------------------------------------------------------------------------
 // Caddy JSON config builders
 // ---------------------------------------------------------------------------
+
+/// Build the full Caddy config: the base config plus every persisted per-run
+/// route, spliced in after the built-in management/sentinel routes and sorted
+/// by `@id` for deterministic ordering. This is what `reload()` posts to
+/// Caddy's `/load`, so a reload never drops app routes.
+fn build_full_config(
+    https_port: u16,
+    http_port: u16,
+    caddy_bin_override: &Option<std::path::PathBuf>,
+    stored: &HashMap<String, serde_json::Value>,
+) -> serde_json::Value {
+    let mut config = build_base_config(https_port, http_port, caddy_bin_override);
+
+    let mut entries: Vec<_> = stored.values().cloned().collect();
+    entries.sort_by(|a, b| {
+        a.get("@id")
+            .and_then(|v| v.as_str())
+            .cmp(&b.get("@id").and_then(|v| v.as_str()))
+    });
+    if !entries.is_empty() {
+        if let Some(routes) = config["apps"]["http"]["servers"]["veld"]["routes"].as_array_mut() {
+            routes.extend(entries);
+        }
+    }
+    config
+}
 
 /// Build a minimal base Caddy config with a server block for Veld.
 fn build_base_config(
@@ -902,6 +1256,113 @@ mod tests {
     // -----------------------------------------------------------------------
     // Base config tests
     // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // Route store / full-config tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_build_full_config_splices_stored_routes() {
+        let mut stored = HashMap::new();
+        stored.insert(
+            "veld-run-b".to_string(),
+            build_route_json("veld-run-b", "b.dev.localhost", "localhost:3001", None),
+        );
+        stored.insert(
+            "veld-run-a".to_string(),
+            build_route_json("veld-run-a", "a.dev.localhost", "localhost:3000", None),
+        );
+
+        let config = build_full_config(443, 80, &None, &stored);
+        let routes = config["apps"]["http"]["servers"]["veld"]["routes"]
+            .as_array()
+            .unwrap();
+        // Base management + sentinel, then the two stored routes sorted by id.
+        assert_eq!(routes.len(), 4);
+        assert_eq!(routes[0]["@id"], "veld-management");
+        assert_eq!(routes[1]["@id"], "veld-sentinel");
+        assert_eq!(routes[2]["@id"], "veld-run-a");
+        assert_eq!(routes[3]["@id"], "veld-run-b");
+    }
+
+    #[test]
+    fn test_build_full_config_empty_store_is_base_only() {
+        let stored = HashMap::new();
+        let config = build_full_config(443, 80, &None, &stored);
+        let routes = config["apps"]["http"]["servers"]["veld"]["routes"]
+            .as_array()
+            .unwrap();
+        assert_eq!(routes.len(), 2);
+    }
+
+    #[test]
+    fn test_load_route_store_missing_or_corrupt_is_empty() {
+        // Missing file → empty.
+        let missing = std::env::temp_dir().join("veld-does-not-exist-xyz.json");
+        assert!(load_route_store(&missing).is_empty());
+
+        // Corrupt file → empty (self-healing, not fatal).
+        let corrupt = std::env::temp_dir().join(format!("veld-corrupt-{}.json", std::process::id()));
+        std::fs::write(&corrupt, b"{ not json").unwrap();
+        assert!(load_route_store(&corrupt).is_empty());
+        let _ = std::fs::remove_file(&corrupt);
+    }
+
+    #[tokio::test]
+    async fn test_route_store_persist_load_roundtrip() {
+        let path =
+            std::env::temp_dir().join(format!("veld-routes-roundtrip-{}.json", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+
+        let mut routes = HashMap::new();
+        routes.insert(
+            "veld-run-a".to_string(),
+            build_route_json("veld-run-a", "a.dev.localhost", "localhost:3000", None),
+        );
+        let snapshot = RouteSnapshot {
+            path: path.clone(),
+            routes: routes.clone(),
+        };
+        persist_route_store(&snapshot).await;
+
+        let loaded = load_route_store(&path);
+        assert_eq!(loaded, routes);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_routes_store_path_uses_caddy_data_sibling() {
+        let bin = std::path::PathBuf::from("/opt/veld/lib/caddy");
+        let path = routes_store_path(&Some(bin));
+        assert_eq!(
+            path,
+            std::path::PathBuf::from("/opt/veld/lib/caddy-data/veld-routes.json")
+        );
+    }
+
+    #[test]
+    fn test_caddy_pid_path_uses_caddy_data_sibling() {
+        let bin = std::path::PathBuf::from("/opt/veld/lib/caddy");
+        let path = caddy_pid_path(&Some(bin));
+        assert_eq!(
+            path,
+            std::path::PathBuf::from("/opt/veld/lib/caddy-data/caddy.pid")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_pid_file_roundtrip() {
+        // Use a unique caddy-bin so the pid path is isolated per test run.
+        let dir = std::env::temp_dir().join(format!("veld-pidtest-{}", std::process::id()));
+        let fake_caddy = dir.join("caddy");
+        let over = Some(fake_caddy);
+
+        write_caddy_pid(&over, 4242);
+        assert_eq!(read_caddy_pid(&over), Some(4242));
+        clear_caddy_pid(&over);
+        assert_eq!(read_caddy_pid(&over), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     #[test]
     fn test_build_base_config() {

--- a/crates/veld-helper/src/caddy.rs
+++ b/crates/veld-helper/src/caddy.rs
@@ -388,6 +388,22 @@ impl CaddyManager {
         Ok(true)
     }
 
+    /// On helper startup, re-adopt and reload an already-running Caddy — e.g.
+    /// one left running across our own binary self-restart. This re-applies the
+    /// current base config (so an updated Caddy binary / new built-in routes
+    /// take effect), replays persisted routes, and records the pid so the
+    /// watchdog supervises it thereafter. It deliberately does NOT spawn a new
+    /// Caddy: a cold boot with no runs stays idle until the first `caddy_start`.
+    pub async fn reconcile_on_startup(&self) {
+        if !self.is_running().await {
+            return;
+        }
+        let mut state = self.inner.lock().await;
+        if let Err(e) = self.start_locked(&mut state).await {
+            warn!(error = %format!("{e:#}"), "startup caddy reconcile failed");
+        }
+    }
+
     // -- Route store ----------------------------------------------------------
 
     /// Insert or replace a route in the durable store and persist it. Returns
@@ -476,7 +492,12 @@ fn write_caddy_pid(caddy_bin_override: &Option<PathBuf>, pid: u32) {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    let _ = std::fs::write(&path, pid.to_string());
+    // Warn (don't silently swallow) on failure: e.g. after a mode switch the
+    // data dir may be owned by the other mode's helper, and a silent EACCES here
+    // would quietly disable pid-based recovery.
+    if let Err(e) = std::fs::write(&path, pid.to_string()) {
+        warn!(error = %e, path = %path.display(), "failed to write caddy pid file");
+    }
 }
 
 fn read_caddy_pid(caddy_bin_override: &Option<PathBuf>) -> Option<u32> {
@@ -506,8 +527,12 @@ async fn pid_is_caddy(pid: u32) -> Option<bool> {
         .await
     {
         Ok(o) if o.status.success() => {
+            // macOS `ps -o comm=` prints the full executable path; Linux prints
+            // the command name. Compare the basename EXACTLY so we don't match
+            // an unrelated process like `/x/notcaddy` or `mycaddy`.
             let comm = String::from_utf8_lossy(&o.stdout);
-            Some(comm.trim().ends_with("caddy"))
+            let name = comm.trim().rsplit('/').next().unwrap_or("").trim();
+            Some(name == "caddy")
         }
         // ps ran but the pid wasn't found → not a live caddy.
         Ok(_) => Some(false),

--- a/crates/veld-helper/src/caddy.rs
+++ b/crates/veld-helper/src/caddy.rs
@@ -531,7 +531,10 @@ async fn terminate_pid(pid: u32) {
     // the pid came from our own pid file, and refusing would strand a wedged
     // Caddy and defeat recovery — the whole point of this path.
     if pid_is_caddy(pid).await == Some(false) {
-        warn!(pid, "pid is not a caddy process; not signalling (stale pid file?)");
+        warn!(
+            pid,
+            "pid is not a caddy process; not signalling (stale pid file?)"
+        );
         return;
     }
 
@@ -1302,7 +1305,8 @@ mod tests {
         assert!(load_route_store(&missing).is_empty());
 
         // Corrupt file → empty (self-healing, not fatal).
-        let corrupt = std::env::temp_dir().join(format!("veld-corrupt-{}.json", std::process::id()));
+        let corrupt =
+            std::env::temp_dir().join(format!("veld-corrupt-{}.json", std::process::id()));
         std::fs::write(&corrupt, b"{ not json").unwrap();
         assert!(load_route_store(&corrupt).is_empty());
         let _ = std::fs::remove_file(&corrupt);

--- a/crates/veld-helper/src/handler.rs
+++ b/crates/veld-helper/src/handler.rs
@@ -30,6 +30,24 @@ impl State {
         }
     }
 
+    /// One watchdog iteration: ensure Caddy is alive and serving the persisted
+    /// routes. Only supervises once Caddy is meant to be running — either it has
+    /// been started this session, or there are persisted routes to serve (e.g.
+    /// after a reboot/update). This avoids spawning Caddy on a fresh install
+    /// that has never started a run.
+    pub async fn caddy_watchdog_tick(&self) {
+        let should_run =
+            self.caddy.pid().await.is_some() || self.caddy.stored_route_count().await > 0;
+        if !should_run {
+            return;
+        }
+        match self.caddy.ensure_healthy().await {
+            Ok(true) => info!("watchdog restarted caddy and replayed routes"),
+            Ok(false) => {}
+            Err(e) => warn!(error = %format!("{e:#}"), "watchdog caddy recovery failed"),
+        }
+    }
+
     /// Parse and dispatch a single JSON request line, returning a `Response`.
     pub async fn handle_request(&self, line: &str) -> Response {
         let request: Request = match serde_json::from_str(line) {
@@ -210,6 +228,8 @@ impl State {
             "https_port": self.https_port,
             "http_port": self.http_port,
             "helper_pid": helper_pid,
+            "version": env!("CARGO_PKG_VERSION"),
+            "stored_routes": self.caddy.stored_route_count().await,
         }))
     }
 

--- a/crates/veld-helper/src/handler.rs
+++ b/crates/veld-helper/src/handler.rs
@@ -30,6 +30,13 @@ impl State {
         }
     }
 
+    /// Startup reconcile: re-adopt + reload an already-running Caddy (e.g. one
+    /// orphaned across our own self-restart) so an updated binary/config takes
+    /// effect and the watchdog can supervise it. No-op if Caddy isn't running.
+    pub async fn reconcile_caddy_on_startup(&self) {
+        self.caddy.reconcile_on_startup().await;
+    }
+
     /// One watchdog iteration: ensure Caddy is alive and serving the persisted
     /// routes. Only supervises once Caddy is meant to be running — either it has
     /// been started this session, or there are persisted routes to serve (e.g.

--- a/crates/veld-helper/src/main.rs
+++ b/crates/veld-helper/src/main.rs
@@ -151,6 +151,17 @@ async fn main() -> Result<()> {
         shutdown_tx,
     ));
 
+    // Startup reconcile: if a Caddy is already running (orphaned across our own
+    // self-restart / helper crash), re-adopt it, reload the current config, and
+    // start supervising it. Runs before the watchdog so an updated binary/config
+    // takes effect immediately rather than on the next `veld start`.
+    {
+        let startup_state = Arc::clone(&state);
+        tokio::spawn(async move {
+            startup_state.reconcile_caddy_on_startup().await;
+        });
+    }
+
     // Caddy watchdog: keep Caddy alive and every persisted route served across
     // crashes, macOS sleep/wake, and reboots. launchd's KeepAlive only restarts
     // the *helper* on exit — it cannot detect a dead/wedged child Caddy, so we

--- a/crates/veld-helper/src/main.rs
+++ b/crates/veld-helper/src/main.rs
@@ -3,15 +3,22 @@ mod dns;
 mod handler;
 mod protocol;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixListener;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// How often the watchdog checks that Caddy is alive and serving.
+const WATCHDOG_INTERVAL: Duration = Duration::from_secs(15);
+
+/// How often to check whether the helper's own binary changed on disk.
+const BINARY_WATCH_INTERVAL: Duration = Duration::from_secs(10);
 
 struct HelperConfig {
     socket_path: PathBuf,
@@ -144,6 +151,39 @@ async fn main() -> Result<()> {
         shutdown_tx,
     ));
 
+    // Caddy watchdog: keep Caddy alive and every persisted route served across
+    // crashes, macOS sleep/wake, and reboots. launchd's KeepAlive only restarts
+    // the *helper* on exit — it cannot detect a dead/wedged child Caddy, so we
+    // supervise Caddy ourselves.
+    let watchdog_state = Arc::clone(&state);
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(WATCHDOG_INTERVAL);
+        // Skip missed ticks instead of firing a burst after a long sleep.
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            interval.tick().await;
+            watchdog_state.caddy_watchdog_tick().await;
+        }
+    });
+
+    // Self-restart when our own binary is replaced on disk (by `veld update`),
+    // so launchd relaunches the new version as root — no sudo, no manual
+    // `veld setup privileged`. Complements the plist's WatchPaths, which does
+    // not reliably bounce an already-running KeepAlive daemon.
+    //
+    // Only for the privileged system-domain LaunchDaemon: that's the one whose
+    // restart needs root (the exact gap this closes). The unprivileged
+    // LaunchAgent is already restarted by the installer via user-domain
+    // launchctl (no sudo), and the auto-bootstrapped helper is ephemeral and
+    // has nothing to relaunch it — so exiting there would just drop URLs.
+    if is_system_socket(&config.socket_path) {
+        tokio::spawn(watch_own_binary());
+    }
+
+    // Graceful shutdown on SIGTERM/Ctrl-C (e.g. `launchctl bootout`). Caddy is
+    // intentionally left running so URLs stay up while launchd relaunches us.
+    let mut term = signal_stream();
+
     loop {
         tokio::select! {
             result = listener.accept() => {
@@ -167,10 +207,102 @@ async fn main() -> Result<()> {
                     break;
                 }
             }
+            _ = term.recv() => {
+                info!("received termination signal, exiting (leaving caddy running)");
+                break;
+            }
         }
     }
 
     Ok(())
+}
+
+/// Future that resolves when the process receives SIGTERM or Ctrl-C.
+struct SignalStream {
+    #[cfg(unix)]
+    sigterm: tokio::signal::unix::Signal,
+}
+
+fn signal_stream() -> SignalStream {
+    #[cfg(unix)]
+    {
+        let sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler");
+        SignalStream { sigterm }
+    }
+    #[cfg(not(unix))]
+    {
+        SignalStream {}
+    }
+}
+
+impl SignalStream {
+    async fn recv(&mut self) {
+        #[cfg(unix)]
+        {
+            tokio::select! {
+                _ = self.sigterm.recv() => {}
+                _ = tokio::signal::ctrl_c() => {}
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = tokio::signal::ctrl_c().await;
+        }
+    }
+}
+
+/// Poll the helper's own executable; when its size/mtime changes and settles,
+/// exit(0) so launchd's KeepAlive relaunches the freshly installed binary.
+async fn watch_own_binary() {
+    let exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(error = %e, "could not resolve own executable path; binary self-restart disabled");
+            return;
+        }
+    };
+    let baseline = binary_signature(&exe);
+    let mut interval = tokio::time::interval(BINARY_WATCH_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    // Consume the immediate first tick so we don't compare against ourselves at t=0.
+    interval.tick().await;
+    loop {
+        interval.tick().await;
+        let current = binary_signature(&exe);
+        if current.is_some() && current != baseline {
+            // Debounce: `veld update` does cp + chmod + xattr + codesign — several
+            // writes. Wait for the signature to settle before relaunching so we
+            // don't exit mid-swap.
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            if binary_signature(&exe) == current {
+                info!(
+                    "helper binary changed on disk — exiting so launchd relaunches the new version"
+                );
+                std::process::exit(0);
+            }
+        }
+    }
+}
+
+/// Whether this helper is listening on the privileged system-domain socket
+/// (`/var/run` on macOS, `/run` on Linux), i.e. it is the root LaunchDaemon /
+/// systemd service rather than an unprivileged/auto helper.
+fn is_system_socket(path: &Path) -> bool {
+    let s = path.to_string_lossy();
+    s.starts_with("/var/run") || s.starts_with("/run")
+}
+
+/// A cheap change signature for a file: (size, mtime-seconds).
+fn binary_signature(path: &Path) -> Option<(u64, i64)> {
+    let meta = std::fs::metadata(path).ok()?;
+    let mtime = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    Some((meta.len(), mtime))
 }
 
 async fn handle_connection(

--- a/crates/veld/src/commands/doctor.rs
+++ b/crates/veld/src/commands/doctor.rs
@@ -120,8 +120,23 @@ impl Diagnostics {
     // -- Services ------------------------------------------------------------
 
     async fn gather_services(&mut self) {
-        // Helper
-        match veld_core::helper::HelperClient::connect().await {
+        // Helper — connect to the socket for the CONFIGURED mode so we report on
+        // the right helper. Plain `connect()` falls through system -> user, which
+        // in privileged mode would report a stray user/auto helper on :18443 when
+        // the privileged LaunchDaemon is actually down, masking the real failure
+        // (and contradicting the mode-aware errors from `veld start`/`veld update`).
+        let helper_conn = match super::read_setup_mode().as_deref() {
+            Some("privileged") => veld_core::helper::HelperClient::connect_to(
+                &veld_core::helper::system_socket_path(),
+            )
+            .await,
+            Some("unprivileged") => {
+                veld_core::helper::HelperClient::connect_to(&veld_core::helper::user_socket_path())
+                    .await
+            }
+            _ => veld_core::helper::HelperClient::connect().await,
+        };
+        match helper_conn {
             Ok(client) => {
                 let status_data = client.status().await.ok().and_then(|r| r.data);
 

--- a/crates/veld/src/commands/mod.rs
+++ b/crates/veld/src/commands/mod.rs
@@ -25,14 +25,9 @@ pub mod version;
 use crate::output;
 
 /// Read the setup mode from `~/.veld/setup.json`.
+/// Delegates to the shared implementation in `veld-core` so the two never drift.
 pub fn read_setup_mode() -> Option<String> {
-    let path = dirs::home_dir()?.join(".veld").join("setup.json");
-    let content = std::fs::read_to_string(path).ok()?;
-    let value: serde_json::Value = serde_json::from_str(&content).ok()?;
-    value
-        .get("mode")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
+    veld_core::setup::read_setup_mode()
 }
 
 /// Resolve the run name to use. If `name` is given, use it directly. Otherwise

--- a/crates/veld/src/commands/update.rs
+++ b/crates/veld/src/commands/update.rs
@@ -58,7 +58,7 @@ pub async fn run() -> i32 {
                     output::print_success(&format!("Updated to {new_version}."));
                     cleanup_stale_binaries();
                     output::print_info("Restarting services with new binaries...");
-                    restart_services().await;
+                    restart_services(&new_version).await;
                     refresh_hammerspoon().await;
                     0
                 }
@@ -197,7 +197,13 @@ fn cleanup_stale_binaries() {
 /// version — no sudo), complemented by the plist's `WatchPaths`. Rather than
 /// assume that worked (the old bug), we poll until the helper reports the new
 /// version, and give actionable guidance if it doesn't.
-async fn restart_services() {
+///
+/// `target_version` is the version we just updated TO (from `check_update`),
+/// NOT `env!("CARGO_PKG_VERSION")` — this process is the *old* CLI, so its
+/// compile-time version is the version we updated *from*. Comparing against
+/// that would invert the check (fail on every successful update, pass on a
+/// failed one).
+async fn restart_services(target_version: &str) {
     let mode = super::read_setup_mode();
 
     // Auto mode has no persistent service: stop the ephemeral helper so the
@@ -220,9 +226,8 @@ async fn restart_services() {
     } else {
         veld_core::helper::user_socket_path()
     };
-    let new_version = env!("CARGO_PKG_VERSION");
     output::print_info("Waiting for veld-helper to restart with the new binary...");
-    if wait_for_helper_version(&socket, new_version, std::time::Duration::from_secs(45)).await {
+    if wait_for_helper_version(&socket, target_version, std::time::Duration::from_secs(45)).await {
         output::print_success("veld-helper restarted and healthy.");
     } else {
         output::print_error(

--- a/crates/veld/src/commands/update.rs
+++ b/crates/veld/src/commands/update.rs
@@ -189,37 +189,74 @@ fn cleanup_stale_binaries() {
     }
 }
 
-/// Restart daemon and helper so they run the newly installed binaries.
+/// Restart the helper/daemon so they run the newly installed binaries, then
+/// verify the helper actually came back healthy.
 ///
-/// The install script (run by `perform_update`) already restarts launchd /
-/// systemd services for both privileged and unprivileged modes. This function
-/// only needs to handle the "auto" case (no persistent service) and print
-/// mode-specific guidance after the update.
+/// A managed helper (privileged/unprivileged) restarts *itself* when its binary
+/// changes on disk (an in-process watcher exits so launchd relaunches the new
+/// version — no sudo), complemented by the plist's `WatchPaths`. Rather than
+/// assume that worked (the old bug), we poll until the helper reports the new
+/// version, and give actionable guidance if it doesn't.
 async fn restart_services() {
     let mode = super::read_setup_mode();
 
-    match mode.as_deref() {
-        Some("privileged") => {
-            // The install script already bounced the system LaunchDaemon /
-            // systemd service with the new binaries — no second sudo needed.
-            // The plist on disk still has the correct binary paths since this
-            // is an in-place update (paths unchanged).
-            output::print_success("Services restarted by the installer (privileged mode).");
+    // Auto mode has no persistent service: stop the ephemeral helper so the
+    // next `veld start` re-bootstraps it with the new binary.
+    if !matches!(mode.as_deref(), Some("privileged") | Some("unprivileged")) {
+        output::print_info("Restarting auto-bootstrapped helper...");
+        let user_socket = veld_core::helper::user_socket_path();
+        let client = veld_core::helper::HelperClient::new(&user_socket);
+        if client.shutdown().await.is_ok() {
+            output::print_info("Helper stopped. It will restart on next `veld start`.");
         }
-        Some("unprivileged") => {
-            // Install script already restarted the user-level LaunchAgent /
-            // systemd --user service.
-            output::print_success("Services restarted by the installer.");
-        }
-        _ => {
-            // "auto" mode or no mode — just kill the user-level helper.
-            // Next `veld start` will re-bootstrap with the new binary.
-            output::print_info("Restarting auto-bootstrapped helper...");
-            let user_socket = veld_core::helper::user_socket_path();
-            let client = veld_core::helper::HelperClient::new(&user_socket);
-            if client.shutdown().await.is_ok() {
-                output::print_info("Helper stopped. It will restart on next `veld start`.");
+        return;
+    }
+
+    // Verify against the specific socket for this mode — not `connect()` (which
+    // falls through to the user socket and could latch onto a stale auto-helper
+    // while the privileged one is mid-restart).
+    let socket = if mode.as_deref() == Some("privileged") {
+        veld_core::helper::system_socket_path()
+    } else {
+        veld_core::helper::user_socket_path()
+    };
+    let new_version = env!("CARGO_PKG_VERSION");
+    output::print_info("Waiting for veld-helper to restart with the new binary...");
+    if wait_for_helper_version(&socket, new_version, std::time::Duration::from_secs(45)).await {
+        output::print_success("veld-helper restarted and healthy.");
+    } else {
+        output::print_error(
+            "veld-helper did not pick up the new binary automatically. \
+             Run `veld doctor`; if it stays down, re-run `veld setup`.",
+            false,
+        );
+    }
+}
+
+/// Poll the helper on `socket` until it reports `expected_version`, or the
+/// timeout elapses.
+///
+/// The managed helper keeps serving the OLD binary until its watcher fires
+/// (~12s), so we wait for the version to actually flip rather than treating
+/// "a helper is reachable" as success. A pre-change helper (no `version` field)
+/// reports `None` and never matches, so this correctly times out into the
+/// actionable error instead of falsely reporting success on the first update.
+async fn wait_for_helper_version(
+    socket: &std::path::Path,
+    expected_version: &str,
+    timeout: std::time::Duration,
+) -> bool {
+    let start = std::time::Instant::now();
+    let client = veld_core::helper::HelperClient::new(socket);
+    loop {
+        if let Ok(Some(v)) = client.version().await {
+            if v == expected_version {
+                return true;
             }
         }
+        if start.elapsed() >= timeout {
+            return false;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
     }
 }

--- a/install.sh
+++ b/install.sh
@@ -380,12 +380,21 @@ fi
 
 if [ "$OS" = "macos" ]; then
   if [ -n "$PRIVILEGED_MODE" ] && [ -z "$SWITCHING_TO_USER_PATHS" ]; then
-    # Privileged mode (staying in place): helper runs as a system LaunchDaemon.
+    # Privileged mode (staying in place): helper runs as a system LaunchDaemon
+    # (root). Restarting it in the system domain requires root — the old code
+    # ran `$NEED_SUDO launchctl ... system/...` with NEED_SUDO empty for the
+    # default user-path install, so it silently failed and left a stale helper.
+    # If passwordless sudo is available, kickstart it now for an immediate swap;
+    # otherwise the helper restarts itself when it detects its binary changed
+    # (in-process watcher + the plist's WatchPaths) — no password prompt.
     HELPER_PLIST="/Library/LaunchDaemons/dev.veld.helper.plist"
     if [ -f "$HELPER_PLIST" ]; then
-      echo "Restarting veld-helper service (privileged)..."
-      $NEED_SUDO launchctl bootout system/dev.veld.helper 2>/dev/null || true
-      $NEED_SUDO launchctl bootstrap system "$HELPER_PLIST" 2>/dev/null || true
+      if sudo -n true 2>/dev/null; then
+        echo "Restarting veld-helper service (privileged)..."
+        sudo launchctl kickstart -k system/dev.veld.helper 2>/dev/null || true
+      else
+        echo "veld-helper will restart itself to pick up the new binary (no sudo needed)."
+      fi
     fi
   elif [ -z "$SWITCHING_TO_USER_PATHS" ]; then
     # User mode: helper runs as a user LaunchAgent.

--- a/install.sh
+++ b/install.sh
@@ -279,38 +279,38 @@ echo "Installing binaries..."
 $NEED_SUDO mkdir -p "$INSTALL_DIR"
 $NEED_SUDO mkdir -p "$LIB_DIR"
 
-# veld CLI goes to INSTALL_DIR (on PATH)
-$NEED_SUDO cp "${TMP_DIR}/veld" "${INSTALL_DIR}/veld"
-$NEED_SUDO chmod +x "${INSTALL_DIR}/veld"
+# Install a binary and, on macOS, immediately clear its extended attributes and
+# re-sign it BEFORE moving on to the next file.
+#
+# Downloaded binaries carry com.apple.quarantine / com.apple.provenance; on
+# macOS Sequoia (15+) an unsigned/adhoc binary can be SIGKILLed by Gatekeeper on
+# launch. Signing inline (rather than in a separate pass after all copies) keeps
+# the unsigned window to milliseconds — critical because veld-helper is now
+# relaunched automatically when its binary changes (launchd WatchPaths + the
+# helper's own binary-change watcher), and either could otherwise relaunch a
+# freshly-copied-but-not-yet-signed binary into a Gatekeeper kill/throttle loop.
+# $1 = source, $2 = destination, $3 = "sign" (macOS re-sign) | "nosign".
+install_bin() {
+  $NEED_SUDO cp "$1" "$2"
+  $NEED_SUDO chmod +x "$2"
+  if [ "$OS" = "macos" ] && [ "$3" = "sign" ]; then
+    $NEED_SUDO xattr -cr "$2" 2>/dev/null || true
+    $NEED_SUDO codesign --force --sign - "$2" 2>/dev/null || true
+  fi
+}
 
-# Helper, daemon, and Caddy go to LIB_DIR (bundled in the release tarball).
-for bin in veld-helper veld-daemon caddy; do
+# veld CLI goes to INSTALL_DIR (on PATH).
+install_bin "${TMP_DIR}/veld" "${INSTALL_DIR}/veld" sign
+
+# Helper and daemon go to LIB_DIR (bundled in the release tarball) and are
+# re-signed. Caddy is a Go binary shipped signed upstream, so it is not re-signed.
+for bin in veld-helper veld-daemon; do
   if [ -f "${TMP_DIR}/${bin}" ]; then
-    $NEED_SUDO cp "${TMP_DIR}/${bin}" "${LIB_DIR}/${bin}"
-    $NEED_SUDO chmod +x "${LIB_DIR}/${bin}"
+    install_bin "${TMP_DIR}/${bin}" "${LIB_DIR}/${bin}" sign
   fi
 done
-
-# --- macOS: clear extended attributes and re-sign binaries ---
-#
-# Downloaded binaries carry com.apple.quarantine and com.apple.provenance
-# attributes. On macOS Sequoia (15+), provenance alone can cause Gatekeeper
-# to SIGKILL unsigned/adhoc-signed binaries. Clearing all xattrs and
-# re-signing locally makes macOS treat them as trusted.
-#
-# This MUST happen before restarting services, otherwise Gatekeeper can
-# SIGKILL the freshly installed unsigned binaries on launch.
-
-if [ "$OS" = "macos" ]; then
-  echo "Clearing macOS extended attributes and re-signing binaries..."
-  $NEED_SUDO xattr -cr "${INSTALL_DIR}/veld" 2>/dev/null || true
-  $NEED_SUDO codesign --force --sign - "${INSTALL_DIR}/veld" 2>/dev/null || true
-  for bin in veld-helper veld-daemon; do
-    if [ -f "${LIB_DIR}/${bin}" ]; then
-      $NEED_SUDO xattr -cr "${LIB_DIR}/${bin}" 2>/dev/null || true
-      $NEED_SUDO codesign --force --sign - "${LIB_DIR}/${bin}" 2>/dev/null || true
-    fi
-  done
+if [ -f "${TMP_DIR}/caddy" ]; then
+  install_bin "${TMP_DIR}/caddy" "${LIB_DIR}/caddy" nosign
 fi
 
 # --- Restart running services (picks up new binaries) ---


### PR DESCRIPTION
## Why

Two recurring problems reported by @peter, both rooted in the same architectural gap: veld pushes state into Caddy / the helper **once** and assumes it sticks forever. Nothing reconciles it and nothing supervises Caddy.

### Bug 1 — re-run `veld setup privileged` after `veld update` / `just dev-install`
- `veld update`'s privileged branch was a **print-only no-op** (`update.rs`) that assumed `install.sh` restarted the root helper.
- `install.sh` ran `$NEED_SUDO launchctl bootout system/…` with `NEED_SUDO` **empty** for the default user-path install → a silent, permission-denied no-op. The privileged helper was never restarted.
- The next `veld start` hit `ensure_helper`, which — unable to reach the stale/down helper — **bootstrapped an unprivileged auto-helper on :18443 and overwrote `setup.json` to `{"mode":"auto"}`**, breaking clean 443 URLs and custom apex domains. Re-running `veld setup privileged` "fixed" it. Hence the recurrence.

### Bug 2 — UI doesn't load after an overnight sleep
- The UI is served through Caddy (`veld.localhost` → Caddy → daemon). Caddy is spawned once and **never supervised**; after a macOS wake it can die or wedge and nothing restarts it. launchd `KeepAlive` only restarts on process **exit**, not on a hang.
- Helper→Caddy admin calls had **no timeout** (a half-dead Caddy wedged the handler forever); the daemon's `send()` had none either; the monitor/GC timers **burst** after a long sleep and the PATH probe ran a **blocking** interactive login shell on the hot loop.

## What

**Helper (owns Caddy) — `caddy.rs`, `main.rs`, `handler.rs`**
- Connect + request **timeouts** on the Caddy admin client.
- **Durable route store**: the helper persists every route it's told and replays it; `reload()` now posts base **+ stored routes**, so a reload/restart never wipes per-run routes.
- **Caddy watchdog loop**: detects a dead/wedged Caddy (bounded liveness + sentinel check) and restarts it, replaying routes. `MissedTickBehavior::Skip` avoids a post-sleep burst.
- **Caddy pid file** so a restarted helper can re-adopt or force-kill an orphaned Caddy; `stop()` escalates SIGTERM → SIGKILL and frees the listener ports.
- **Binary-change self-restart** (privileged LaunchDaemon only): the helper exits when its binary is replaced so launchd relaunches the new version **as root, no sudo**. Plists gain `WatchPaths` as a complement.

**Setup / update — `setup.rs`, `update.rs`, `install.sh`**
- `ensure_helper` is **mode-aware and never downgrades** an explicit `privileged`/`unprivileged` setup to `auto`; it waits briefly for the managed helper (bounded ~10s) and surfaces an actionable error instead of clobbering `setup.json`.
- `veld update` now **verifies the helper actually restarted to the new version** rather than assuming.
- `install.sh`'s privileged restart is no longer a silent no-op (`sudo -n` kickstart if available, else rely on the self-restart).

**Daemon (no-wedge) — `helper.rs`, `monitor.rs`, `gc.rs`**
- `HelperClient::send()` overall timeout.
- monitor/gc intervals use `MissedTickBehavior::Skip`; PATH resolution is async, timeout-bounded, and `kill_on_drop`.

## Review
Two adversarial sub-agent review rounds. Round 1 caught two HIGH issues (false-success verification on the first update; an adopted-orphan Caddy that couldn't be killed when wedged) — both fixed. Round 2 caught a concurrent-start recovery bounce and a `ps`-PATH fail-closed regression — both fixed (locked re-check; absolute `/bin/ps` + signal-anyway when undetermined).

## Testing
- `cargo build --workspace`, `cargo clippy --workspace --all-targets` (clean), `cargo test --workspace` (162 pass). New unit tests cover the route store persist/replay/round-trip, config splicing, and pid-file round-trip.

## Notes
- **One-time transition**: the currently-installed (pre-change) privileged helper has no self-restart watcher and no `WatchPaths`, so the *first* update to this version may still need a manual `veld setup privileged` if passwordless sudo isn't available — `veld update` now reports this clearly instead of silently succeeding. Every update after that is clean.
- **Docs**: no new config fields / CLI flags / subcommands, so the AGENTS.md documentation checklist doesn't apply (internal reliability bugfix). No existing docs described the old "re-run setup after update" behavior.