### PR TITLE
fix(update): verify the daemon restarted after update, not just the helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4135,7 +4135,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "veld"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4155,7 +4155,7 @@ dependencies = [
 
 [[package]]
 name = "veld-core"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -4177,7 +4177,7 @@ dependencies = [
 
 [[package]]
 name = "veld-daemon"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -4199,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "veld-helper"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "anyhow",
  "nix",

--- a/crates/veld-daemon/src/management.rs
+++ b/crates/veld-daemon/src/management.rs
@@ -24,6 +24,10 @@ pub fn routes() -> Router {
         .route("/", get(dashboard))
         // Same SPA; the join ticket rides in the URL fragment (client-only).
         .route("/join", get(dashboard))
+        // Liveness + version probe. `veld update` polls this to confirm the
+        // daemon actually restarted onto the new binary (not just that *some*
+        // daemon is reachable), mirroring the helper's version check.
+        .route("/api/health", get(health))
         .route("/api/environments", get(list_environments))
         .route("/api/logs/{run}", get(get_logs))
         .route("/api/open-terminal", post(open_terminal))
@@ -35,6 +39,15 @@ pub fn routes() -> Router {
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
+
+/// Liveness + version. Returns the daemon's compiled version so callers can
+/// confirm which binary is actually serving.
+async fn health() -> Json<serde_json::Value> {
+    Json(serde_json::json!({
+        "status": "ok",
+        "version": env!("CARGO_PKG_VERSION"),
+    }))
+}
 
 async fn dashboard() -> Response {
     (

--- a/crates/veld/src/commands/update.rs
+++ b/crates/veld/src/commands/update.rs
@@ -236,6 +236,54 @@ async fn restart_services(target_version: &str) {
             false,
         );
     }
+
+    // The daemon is a user-level service (LaunchAgent / systemd --user) that the
+    // installer restarts. Verify it came back on the new binary too — otherwise
+    // `veld update` returns while the daemon is mid-restart, and an immediate
+    // `veld doctor` shows "Daemon: not running / Feedback server not responding"
+    // even though it self-heals moments later.
+    output::print_info("Waiting for veld-daemon to restart with the new binary...");
+    if wait_for_daemon_version(target_version, std::time::Duration::from_secs(45)).await {
+        output::print_success("veld-daemon restarted and healthy.");
+    } else {
+        output::print_error(
+            "veld-daemon did not pick up the new binary automatically. \
+             Run `veld doctor`; if it stays down, re-run `veld setup`.",
+            false,
+        );
+    }
+}
+
+/// Poll the daemon's `/api/health` until it reports `expected_version`, or the
+/// timeout elapses.
+///
+/// The daemon is hard-restarted by the installer (bootout + bootstrap), so its
+/// HTTP endpoint goes down and comes back; waiting for the version to match
+/// confirms the NEW daemon is serving, not a lingering old instance or a
+/// pre-change daemon that has no `version` field (which reports nothing and
+/// correctly times out into the actionable error).
+async fn wait_for_daemon_version(expected_version: &str, timeout: std::time::Duration) -> bool {
+    let client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(2))
+        .build()
+    {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    let start = std::time::Instant::now();
+    loop {
+        if let Ok(resp) = client.get("http://127.0.0.1:19899/api/health").send().await {
+            if let Ok(body) = resp.json::<serde_json::Value>().await {
+                if body.get("version").and_then(|v| v.as_str()) == Some(expected_version) {
+                    return true;
+                }
+            }
+        }
+        if start.elapsed() >= timeout {
+            return false;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
 }
 
 /// Poll the helper on `socket` until it reports `expected_version`, or the


### PR DESCRIPTION
## Why

Right after `veld update`, `veld doctor` showed:

```
Daemon:       not running
✗ Feedback server not responding
```

Investigated live: the daemon was actually **fine** — it self-healed via launchd `KeepAlive` within seconds (verified pid running, `:19899` responding, v8.0.1). The report was **transient**: `veld update` restarts the daemon (a user-level LaunchAgent, hard bootout+bootstrap by the installer) but returned *before* the daemon finished coming back, so a `doctor` run in that window looked broken.

#129 taught `veld update` to verify the **helper** came back on the new version — but not the **daemon**. This closes that gap.

## What

- **veld-daemon**: add `GET /api/health` → `{"status":"ok","version":"…"}` on the existing `:19899` management router (already mounted via `feedback_server`).
- **veld update**: after the helper check, poll `/api/health` until the daemon reports the **target** version, bounded (~45s) with an actionable error on timeout. Waiting for the version to *flip* (not just "reachable") avoids a false pass on a lingering old daemon — same reasoning as the helper check. Runs only in privileged/unprivileged mode (where `veld setup` installed the daemon); auto mode has no persistent daemon and is skipped.

## Testing

- `cargo build --workspace`, `cargo clippy --workspace --all-targets` (clean), `cargo test --workspace`, `cargo fmt --check`.
- Confirmed `/api/health` is served on `:19899` (management router merged into the daemon HTTP server).

## Notes
- No new config/CLI surface → AGENTS.md doc checklist doesn't apply.
- Small follow-up to #129; the daemon (user-level) doesn't need the helper's self-restart-on-binary-change (the installer's user-domain launchctl restart works without sudo) — it only needed update to *wait for and confirm* it.