### PR TITLE
fix(feedback): scroll chaining, reply-draft loss, screenshot distortion, noisy trace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ Follow this workflow for every feature or fix:
 
 1. **Implement** — Make the code changes.
 2. **Docs audit** — Before considering the work done, check the [documentation checklist](#documentation-checklist) below.
-3. **Self-review rounds** — Use sub-agents to review the diff. Iterate (review → fix → review → fix) until no issues remain.
+3. **Self-review rounds** — Use sub-agents to review the diff. Iterate (review → fix → review → fix) until no issues remain. For a non-trivial change (or whenever asked for a deeper look), follow up with the four-angle adversarial review in [docs/agentic-review.md](docs/agentic-review.md) before pushing.
 4. **Push to draft PR** — Push the branch and open a draft PR on GitHub.
 5. **Wait for CI** — All checks must be green. Never assume checks are missing just because they haven't started yet.
 6. **Ask before merging** — Ask the maintainer for explicit approval before merging. Only merge with admin bypass if the maintainer explicitly says so upfront at task start.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4135,7 +4135,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "veld"
-version = "8.0.1"
+version = "8.0.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4155,7 +4155,7 @@ dependencies = [
 
 [[package]]
 name = "veld-core"
-version = "8.0.1"
+version = "8.0.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -4177,7 +4177,7 @@ dependencies = [
 
 [[package]]
 name = "veld-daemon"
-version = "8.0.1"
+version = "8.0.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -4199,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "veld-helper"
-version = "8.0.1"
+version = "8.0.2"
 dependencies = [
  "anyhow",
  "nix",

--- a/crates/veld-core/src/feedback.rs
+++ b/crates/veld-core/src/feedback.rs
@@ -1043,7 +1043,20 @@ mod tests {
         };
         let json = serde_json::to_string(&scope).unwrap();
         assert!(json.contains(r#""type":"element"#));
-        let _: ThreadScope = serde_json::from_str(&json).unwrap();
+        let roundtrip: ThreadScope = serde_json::from_str(&json).unwrap();
+        match roundtrip {
+            ThreadScope::Element {
+                element_text,
+                source_file,
+                source_line,
+                ..
+            } => {
+                assert_eq!(element_text.as_deref(), Some("Submit"));
+                assert_eq!(source_file.as_deref(), Some("src/components/Button.tsx"));
+                assert_eq!(source_line, Some(42));
+            }
+            _ => panic!("expected ThreadScope::Element"),
+        }
 
         // Page scope.
         let scope = ThreadScope::Page {

--- a/crates/veld-core/src/feedback.rs
+++ b/crates/veld-core/src/feedback.rs
@@ -19,6 +19,17 @@ pub enum ThreadScope {
         selector: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         position: Option<ElementPosition>,
+        /// Visible text of the element, middle-truncated by the client —
+        /// helps an agent disambiguate when the selector alone is ambiguous.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        element_text: Option<String>,
+        /// Source file of the element's JSX/template tag, when the
+        /// framework's dev build exposes it (React `_debugSource`, Vue
+        /// `__file`). Best-effort — absent in production builds.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source_file: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source_line: Option<u32>,
     },
     /// Attached to a page but not a specific element.
     Page { page_url: String },
@@ -727,6 +738,9 @@ mod tests {
                 page_url: "/dashboard".into(),
                 selector: "h1.title".into(),
                 position: None,
+                element_text: None,
+                source_file: None,
+                source_line: None,
             },
             ThreadOrigin::Human,
             Some(vec!["App".into(), "Header".into()]),
@@ -1023,6 +1037,9 @@ mod tests {
                 width: 100.0,
                 height: 50.0,
             }),
+            element_text: Some("Submit".into()),
+            source_file: Some("src/components/Button.tsx".into()),
+            source_line: Some(42),
         };
         let json = serde_json::to_string(&scope).unwrap();
         assert!(json.contains(r#""type":"element"#));

--- a/crates/veld-daemon/frontend/src/feedback-overlay.css
+++ b/crates/veld-daemon/frontend/src/feedback-overlay.css
@@ -358,7 +358,10 @@
   display: none;
 }
 
-/* Popover */
+/* Popover — element comment, page comment, and screenshot compose all share
+   this base, so the pulsing accent glow (same treatment as the frozen-frame
+   selection, see veld-feedback-frame-glow in styles.ts) applies to all three
+   uniformly rather than being a screenshot-only special case. */
 .veld-feedback-popover {
   position: absolute; z-index: var(--vf-z);
   width: 360px; max-width: calc(100vw - 32px);
@@ -368,11 +371,19 @@
   box-shadow: var(--vf-shadow);
   font: 13px/1.5 var(--vf-font);
   overflow: hidden;
-  animation: veld-feedback-fadeIn .15s ease;
+  animation: veld-feedback-fadeIn .15s ease, veld-feedback-popover-glow 1.4s ease-in-out infinite;
 }
 @keyframes veld-feedback-fadeIn {
   from { opacity: 0; transform: translateY(6px); }
   to { opacity: 1; transform: translateY(0); }
+}
+@keyframes veld-feedback-popover-glow {
+  0%, 100% {
+    box-shadow: var(--vf-shadow), 0 0 10px 1px color-mix(in srgb, var(--vf-accent) 42%, transparent);
+  }
+  50% {
+    box-shadow: var(--vf-shadow), 0 0 18px 3px color-mix(in srgb, var(--vf-accent) 58%, transparent);
+  }
 }
 
 .veld-feedback-popover-header {
@@ -791,16 +802,22 @@
   cursor: crosshair;
 }
 
-/* Screenshot popover — clamped to viewport, centered */
+/* Screenshot popover — clamped to viewport, bottom-center. Anchored at the
+   same spot the screenshot-mode instruction banner occupies (see the light-
+   DOM .veld-feedback-screenshot-banner in styles.ts) so selecting a region
+   feels like one continuous bottom panel morphing from "pick an area" to
+   "describe it", not a totally different popup appearing elsewhere. */
 .veld-feedback-popover-screenshot {
   position: fixed !important;
-  top: 20px !important; left: 50% !important;
+  bottom: 24px !important; left: 50% !important;
+  top: auto !important;
   transform: translateX(-50%) !important;
   width: auto;
   max-width: calc(100vw - 60px);
   max-height: calc(100vh - 40px);
   display: flex; flex-direction: column;
   overflow-y: auto;
+  /* Glow animation is inherited from the shared .veld-feedback-popover base. */
 }
 
 /* Screenshot preview in popover */

--- a/crates/veld-daemon/frontend/src/feedback-overlay.css
+++ b/crates/veld-daemon/frontend/src/feedback-overlay.css
@@ -546,6 +546,7 @@
 .veld-feedback-panel-body {
   flex: 1; overflow-y: auto; padding: 12px 18px;
   display: flex; flex-direction: column; min-height: 0;
+  overscroll-behavior: contain;
 }
 .veld-feedback-panel-body-thread { overflow-y: hidden; }
 
@@ -693,6 +694,7 @@
 }
 .veld-feedback-thread-messages-list {
   flex: 1; overflow-y: auto; min-height: 0;
+  overscroll-behavior: contain;
 }
 .veld-feedback-message {
   display: flex; gap: 8px; margin-bottom: 10px; align-items: flex-start;

--- a/crates/veld-daemon/frontend/src/feedback-overlay/backdrop.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/backdrop.ts
@@ -1,9 +1,11 @@
 import { refs } from "./refs";
 import { getState, dispatch } from "./store";
 import { PREFIX } from "./constants";
-import { docRect, selectorFor, formatTrace } from "./helpers";
-import { getComponentTrace } from "./component-trace";
+import { docRect, selectorFor, formatTrace, truncateMiddle } from "./helpers";
+import { getComponentTrace, getComponentSource } from "./component-trace";
+import { clampToFrame } from "./screenshot";
 import { deps } from "../shared/registry";
+import { toast } from "./toast";
 
 export function elementBelowBackdrop(x: number, y: number): Element | null {
   refs.overlay.style.display = "none";
@@ -53,10 +55,13 @@ export function initBackdropEvents(): void {
         refs.componentTraceEl.style.display = "none";
       }
     } else if (getState().activeMode === "screenshot" && ssDragging) {
-      const x = Math.min(ssStartX, e.clientX);
-      const y = Math.min(ssStartY, e.clientY);
-      const w = Math.abs(e.clientX - ssStartX);
-      const h = Math.abs(e.clientY - ssStartY);
+      const rawX = Math.min(ssStartX, e.clientX);
+      const rawY = Math.min(ssStartY, e.clientY);
+      const rawW = Math.abs(e.clientX - ssStartX);
+      const rawH = Math.abs(e.clientY - ssStartY);
+      // Clamp to the displayed frame so a drag into a letterbox bar can't
+      // select "outside the image".
+      const { x, y, w, h } = clampToFrame(rawX, rawY, rawW, rawH);
       refs.screenshotRect.style.display = "block";
       refs.screenshotRect.style.left = (x + window.scrollX) + "px";
       refs.screenshotRect.style.top = (y + window.scrollY) + "px";
@@ -81,13 +86,20 @@ export function initBackdropEvents(): void {
     e.stopPropagation();
     if (getState().activeMode === "screenshot" && ssDragging) {
       ssDragging = false;
-      const x = Math.min(ssStartX, e.clientX);
-      const y = Math.min(ssStartY, e.clientY);
-      const w = Math.abs(e.clientX - ssStartX);
-      const h = Math.abs(e.clientY - ssStartY);
+      const rawX = Math.min(ssStartX, e.clientX);
+      const rawY = Math.min(ssStartY, e.clientY);
+      const rawW = Math.abs(e.clientX - ssStartX);
+      const rawH = Math.abs(e.clientY - ssStartY);
+      const { x, y, w, h } = clampToFrame(rawX, rawY, rawW, rawH);
       refs.screenshotRect.style.display = "none";
+      // Judge "was this a real drag" on the raw gesture, not the clamped
+      // result — a deliberate drag that lands mostly in a letterbox bar
+      // would otherwise clamp below the threshold and silently no-op.
+      if (rawW <= 10 || rawH <= 10) return;
       if (w > 10 && h > 10) {
         deps().captureScreenshot(x, y, w, h);
+      } else {
+        toast("Selection was outside the captured frame", true);
       }
     }
   });
@@ -98,6 +110,11 @@ export function initBackdropEvents(): void {
     if (getState().activeMode === "select-element") {
       const target = getState().hoveredEl || elementBelowBackdrop(e.clientX, e.clientY);
       if (!target) return;
+      // Read innerText first — it forces a synchronous layout, so doing it
+      // before the getBoundingClientRect()/fiber-walk calls below avoids
+      // sandwiching a reflow between two other layout-touching reads.
+      const rawText = (target as HTMLElement).innerText ?? target.textContent ?? "";
+      const elementText = rawText.trim() ? truncateMiddle(rawText) : null;
       const rect = docRect(target);
       const selector = selectorFor(target);
       let tagInfo = target.tagName.toLowerCase();
@@ -106,7 +123,12 @@ export function initBackdropEvents(): void {
         if (cls.length) tagInfo += "." + cls.slice(0, 3).join(".");
       }
       const trace = getComponentTrace(target);
-      deps().showCreatePopover(rect, selector, tagInfo, target, trace);
+      const source = getComponentSource(target);
+      deps().showCreatePopover(rect, selector, tagInfo, target, trace, {
+        elementText,
+        sourceFile: source?.file,
+        sourceLine: source?.line,
+      });
     }
   });
 }

--- a/crates/veld-daemon/frontend/src/feedback-overlay/component-trace.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/component-trace.ts
@@ -58,9 +58,11 @@ export function getComponentTrace(el: Element): string[] | null {
 }
 
 /** Source location of the clicked element's own JSX/template tag, when the
- *  framework's dev build exposes it. React's dev JSX transform stamps
- *  `_debugSource` on the fiber for every element; Vue's dev loader stamps
- *  `__file` on the component options (no line number available there). */
+ *  framework's dev build exposes it. React ≤18's dev JSX transform stamps
+ *  `_debugSource` on the fiber for every element (React 19 removed it, so
+ *  this yields nothing there — falls back to the selector/component_trace);
+ *  Vue's dev loader stamps `__file` on the component options (no line
+ *  number available there). */
 export interface ComponentSource {
   file: string;
   line?: number;

--- a/crates/veld-daemon/frontend/src/feedback-overlay/component-trace.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/component-trace.ts
@@ -1,7 +1,21 @@
+// Ancestor chains in framework-routed apps (Next.js app router, Nuxt, etc.)
+// repeat the same ~15-20 boilerplate wrapper names once per nested layout
+// segment, so a real page can produce 70+ raw fiber names though only the
+// last handful nearest the clicked element are ever meaningful (the exact
+// names the reviewer sees in the on-page tooltip). Cap here — at capture
+// time — so every consumer (tooltip, popover pill, and the payload an agent
+// receives) gets the same trimmed, non-noisy list instead of the tooltip
+// silently truncating while the API payload ships the raw 70-entry dump.
+const MAX_TRACE_LEN = 12;
+const MAX_DEPTH = 100;
+
+function capTrace(trace: string[]): string[] {
+  return trace.length > MAX_TRACE_LEN ? trace.slice(trace.length - MAX_TRACE_LEN) : trace;
+}
+
 /** Inspect the element for React/Vue component traces. */
 export function getComponentTrace(el: Element): string[] | null {
   const trace: string[] = [];
-  const MAX_DEPTH = 100;
 
   // React: __reactFiber$* key
   const fiber = getReactFiber(el);
@@ -13,7 +27,7 @@ export function getComponentTrace(el: Element): string[] | null {
       if (name) trace.unshift(name);
       node = node.return;
     }
-    if (trace.length) return trace;
+    if (trace.length) return capTrace(trace);
   }
 
   // Vue 3: __vueParentComponent
@@ -25,7 +39,7 @@ export function getComponentTrace(el: Element): string[] | null {
       if (vName) trace.unshift(vName);
       inst = inst.parent;
     }
-    if (trace.length) return trace;
+    if (trace.length) return capTrace(trace);
   }
 
   // Vue 2: __vue__
@@ -37,7 +51,45 @@ export function getComponentTrace(el: Element): string[] | null {
       if (vmName) trace.unshift(vmName);
       vm = vm.$parent;
     }
-    if (trace.length) return trace;
+    if (trace.length) return capTrace(trace);
+  }
+
+  return null;
+}
+
+/** Source location of the clicked element's own JSX/template tag, when the
+ *  framework's dev build exposes it. React's dev JSX transform stamps
+ *  `_debugSource` on the fiber for every element; Vue's dev loader stamps
+ *  `__file` on the component options (no line number available there). */
+export interface ComponentSource {
+  file: string;
+  line?: number;
+}
+
+export function getComponentSource(el: Element): ComponentSource | null {
+  const fiber = getReactFiber(el);
+  if (fiber) {
+    // The element's own fiber usually carries _debugSource; if not (e.g. a
+    // text/fragment node), walk up to the nearest ancestor that has one.
+    let node = fiber;
+    let depth = 0;
+    while (node && depth++ < MAX_DEPTH) {
+      const src = node._debugSource;
+      if (src && src.fileName) {
+        return { file: src.fileName, line: src.lineNumber };
+      }
+      node = node.return;
+    }
+  }
+
+  if ((el as any).__vueParentComponent) {
+    let inst = (el as any).__vueParentComponent;
+    let depth = 0;
+    while (inst && depth++ < MAX_DEPTH) {
+      const file = inst.type && inst.type.__file;
+      if (file) return { file };
+      inst = inst.parent;
+    }
   }
 
   return null;

--- a/crates/veld-daemon/frontend/src/feedback-overlay/dom.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/dom.ts
@@ -11,6 +11,7 @@ import { initArc, makeToolBtn, handleToolAction } from "./toolbar";
 import type { ArcItem } from "./arc-menu";
 import { togglePanel, togglePanelSide, showThreadList, renderPanel, markAllRead, applyPanelLayout, togglePanelMode, initPanelResize } from "./panel";
 import { sendAllGood } from "./listening";
+import { captureFullScreenshot } from "./screenshot";
 
 export function buildDOM(): void {
   initTooltip();
@@ -27,8 +28,31 @@ export function buildDOM(): void {
   appendGuarded(document.body, refs.componentTraceEl);
 
   // Screenshot selection rectangle (light DOM) — drawn on the backdrop.
+  // Four corner brackets give it the "viewfinder" look asked for instead of
+  // a bare dashed box; the huge box-shadow (see CSS) is the same spotlight
+  // trick as the hover-outline, dimming everything outside the selection.
   refs.screenshotRect = mkEl("div", "screenshot-rect");
+  (["tl", "tr", "bl", "br"] as const).forEach((corner) => {
+    refs.screenshotRect.appendChild(mkEl("span", "screenshot-corner screenshot-corner-" + corner));
+  });
   appendGuarded(document.body, refs.screenshotRect);
+
+  // Screenshot mode instruction banner (light DOM) — explicit, always-visible
+  // guidance instead of a single toast that scrolls off. Doubles as the
+  // "capture everything, no cropping" escape hatch.
+  refs.screenshotBanner = mkEl("div", "screenshot-banner");
+  refs.screenshotBanner.appendChild(
+    mkEl("span", "screenshot-banner-text", "Drag to select an area to capture"),
+  );
+  refs.screenshotFullBtn = mkEl("button", "screenshot-banner-btn", "Capture full screen");
+  refs.screenshotFullBtn.addEventListener("click", function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    captureFullScreenshot();
+  });
+  refs.screenshotBanner.appendChild(refs.screenshotFullBtn);
+  refs.screenshotBanner.appendChild(mkEl("span", "screenshot-banner-hint", "Esc to cancel"));
+  appendGuarded(document.body, refs.screenshotBanner);
 
   // Float container (shadow DOM) — anchor for the arc-menu engine. Zero-size,
   // translated to the bubble center; the engine builds its goo/glow/icon layers

--- a/crates/veld-daemon/frontend/src/feedback-overlay/dom.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/dom.ts
@@ -17,6 +17,14 @@ export function buildDOM(): void {
   initTooltip();
 
   // Light DOM elements
+
+  // The frozen frame itself (light DOM, sits just below the overlay). Drawn
+  // as an inset, bordered/shadowed "photo card" — never edge-to-edge — so a
+  // capture whose content happens to match the live page 1:1 still reads
+  // unmistakably as "you're looking at a frozen image now", not the page.
+  refs.screenshotFrame = mkEl("img", "screenshot-frame") as HTMLImageElement;
+  appendGuarded(document.body, refs.screenshotFrame);
+
   refs.overlay = mkEl("div", "overlay");
   appendGuarded(document.body, refs.overlay);
   initBackdropEvents();

--- a/crates/veld-daemon/frontend/src/feedback-overlay/helpers.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/helpers.ts
@@ -166,14 +166,18 @@ export function appendGuarded(parent: Node, el: Node): () => void {
  *  (rather than cutting off the tail) so an agent can still recognize where
  *  the text ends even when the middle is dropped. */
 export function truncateMiddle(text: string, maxLen = 200, tailLen = 20): string {
-  // Bound the input before the regex collapse — callers may pass an
+  const collapse = (s: string) => s.replace(/\s+/g, " ").trim();
+  // Bound the head slice before the regex collapse — callers may pass an
   // element's full innerText, which can run to tens of thousands of
   // characters for a loosely-scoped container, when only ~maxLen survives.
-  const bounded = text.length > maxLen * 10 ? text.slice(0, maxLen * 10) : text;
-  const collapsed = bounded.replace(/\s+/g, " ").trim();
-  if (collapsed.length <= maxLen) return collapsed;
+  // The tail is bounded and collapsed separately (not sliced off the
+  // head-bounded string) so it reflects the text's true end, not whatever
+  // was left after the head cutoff.
+  const head = collapse(text.length > maxLen * 10 ? text.slice(0, maxLen * 10) : text);
+  if (head.length <= maxLen) return head;
   const headLen = Math.max(maxLen - tailLen - 1, 0);
-  return collapsed.slice(0, headLen) + "…" + collapsed.slice(collapsed.length - tailLen);
+  const tail = collapse(text.length > tailLen * 10 ? text.slice(-tailLen * 10) : text);
+  return head.slice(0, headLen) + "…" + tail.slice(Math.max(0, tail.length - tailLen));
 }
 
 export function formatTrace(trace: string[] | null): string | null {

--- a/crates/veld-daemon/frontend/src/feedback-overlay/helpers.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/helpers.ts
@@ -162,6 +162,20 @@ export function appendGuarded(parent: Node, el: Node): () => void {
   return () => obs.disconnect();
 }
 
+/** Truncate long text for a payload, keeping a long start and a short end
+ *  (rather than cutting off the tail) so an agent can still recognize where
+ *  the text ends even when the middle is dropped. */
+export function truncateMiddle(text: string, maxLen = 200, tailLen = 20): string {
+  // Bound the input before the regex collapse — callers may pass an
+  // element's full innerText, which can run to tens of thousands of
+  // characters for a loosely-scoped container, when only ~maxLen survives.
+  const bounded = text.length > maxLen * 10 ? text.slice(0, maxLen * 10) : text;
+  const collapsed = bounded.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= maxLen) return collapsed;
+  const headLen = Math.max(maxLen - tailLen - 1, 0);
+  return collapsed.slice(0, headLen) + "…" + collapsed.slice(collapsed.length - tailLen);
+}
+
 export function formatTrace(trace: string[] | null): string | null {
   if (!trace || !trace.length) return null;
   let deduped = [trace[0]];

--- a/crates/veld-daemon/frontend/src/feedback-overlay/init.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/init.ts
@@ -13,7 +13,7 @@ import { togglePageComment, closeActivePopover, showCreatePopover } from "./popo
 import { hideOverlay, showOverlay } from "./visibility";
 import { addPin, removePin, renderAllPins, scheduleReposition } from "./pins";
 import { scrollToThread, checkPendingScroll, onNavigate } from "./navigation";
-import { captureScreenshot } from "./screenshot";
+import { captureScreenshot, repositionFrozenFrame } from "./screenshot";
 import { positionTooltip } from "./tooltip";
 import { updateBadge } from "./badge";
 import { registerDeps } from "../shared/registry";
@@ -64,6 +64,7 @@ export function init(): void {
     scheduleReposition();
     clampFabToViewport();
     applyPanelLayout(); // re-clamp panel width / dock margin to the new viewport
+    repositionFrozenFrame(); // keep the screenshot frame in sync if mid-selection
   });
   window.addEventListener("popstate", onNavigate);
 

--- a/crates/veld-daemon/frontend/src/feedback-overlay/modes.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/modes.ts
@@ -19,6 +19,9 @@ export function setMode(mode: UIMode): void {
     refs.overlay.classList.remove(PREFIX + "overlay-active");
     refs.overlay.classList.remove(PREFIX + "overlay-crosshair");
     refs.screenshotRect.style.display = "none";
+    // Only un-hide if the toolbar wasn't already hidden via the separate
+    // "Hide" feature before screenshot mode started — don't fight that.
+    if (!getState().hidden) refs.toolbarContainer.classList.remove(PREFIX + "hidden");
     clearFrozenFrame();
     stopCaptureStream();
   }
@@ -32,8 +35,11 @@ export function setMode(mode: UIMode): void {
     refs.overlay.classList.add(PREFIX + "overlay-active");
   }
   if (mode === "screenshot") {
-    // Close the menu so the arc doesn't float over the capture region.
+    // Close the menu so the arc doesn't float over the capture region, and
+    // hide the bubble entirely — it has no purpose mid-capture and just
+    // clutters a screen that's about to be photographed.
     closeToolbar();
+    refs.toolbarContainer.classList.add(PREFIX + "hidden");
     window.focus();
     // Freeze-first: acquire the display stream, grab one frame, stop the stream,
     // then let the user draw the selection rectangle over the frozen image. This

--- a/crates/veld-daemon/frontend/src/feedback-overlay/panel.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/panel.ts
@@ -149,7 +149,53 @@ export function updateMarkReadBtn(): void {
   refs.markReadBtn.style.display = anyUnread ? "" : "none";
 }
 
+/** Snapshot of an in-progress reply draft, taken right before a re-render
+ *  destroys the textarea that holds it (e.g. an agent reply arriving over
+ *  the poll while the human is typing). Keyed by thread id so a draft never
+ *  leaks onto a different thread's box after navigating away. */
+interface DraftSnapshot {
+  threadId: string;
+  value: string;
+  selStart: number | null;
+  selEnd: number | null;
+  focused: boolean;
+}
+
+function captureDraft(): DraftSnapshot | null {
+  // Only the thread-detail view ever holds a reply textarea — skip the query
+  // entirely when the thread list is showing (the common case on a poll tick).
+  if (!getState().expandedThreadId) return null;
+  const ta = refs.panelBody.querySelector("textarea." + PREFIX + "textarea") as HTMLTextAreaElement | null;
+  if (!ta || !ta.value) return null;
+  const threadId = ta.dataset.threadId;
+  if (!threadId) return null;
+  return {
+    threadId,
+    value: ta.value,
+    selStart: ta.selectionStart,
+    selEnd: ta.selectionEnd,
+    // `document.activeElement` retargets across an open shadow boundary to
+    // the shadow *host*, never the focused descendant — the panel lives
+    // inside refs.shadow, so activeElement has to be read from there.
+    focused: refs.shadow.activeElement === ta,
+  };
+}
+
+function restoreDraft(draft: DraftSnapshot | null): void {
+  if (!draft) return;
+  const ta = refs.panelBody.querySelector(
+    "textarea." + PREFIX + "textarea[data-thread-id=\"" + draft.threadId + "\"]"
+  ) as HTMLTextAreaElement | null;
+  if (!ta) return;
+  ta.value = draft.value;
+  if (draft.focused) {
+    ta.focus();
+    try { ta.setSelectionRange(draft.selStart ?? draft.value.length, draft.selEnd ?? draft.value.length); } catch (_) { /* ignore */ }
+  }
+}
+
 export function renderPanel(): void {
+  const draft = captureDraft();
   refs.panelBody.innerHTML = "";
 
   const expandedId = getState().expandedThreadId;
@@ -164,6 +210,7 @@ export function renderPanel(): void {
       refs.panelHeadTitle.textContent = "Thread";
       refs.panelBody.classList.toggle(PREFIX + "panel-body-thread", thread.status === "open");
       renderThreadDetail(thread);
+      restoreDraft(draft);
       return;
     }
     dispatch({ type: "SET_EXPANDED_THREAD", threadId: null });
@@ -236,8 +283,14 @@ function renderThreadDetail(thread: Thread): void {
   if (thread.component_trace && thread.component_trace.length) {
     header.appendChild(makeCopyRow("", thread.component_trace.join(" > "), "panel-detail-trace"));
   }
-  if (thread.scope.type === "element" && thread.scope.selector) {
-    header.appendChild(makeCopyRow("", thread.scope.selector, "panel-detail-selector"));
+  if (thread.scope.type === "element") {
+    const scope = thread.scope;
+    if (scope.selector) header.appendChild(makeCopyRow("", scope.selector, "panel-detail-selector"));
+    if (scope.element_text) header.appendChild(makeCopyRow("", "“" + scope.element_text + "”", "panel-detail-selector"));
+    if (scope.source_file) {
+      const loc = scope.source_file + (scope.source_line != null ? ":" + scope.source_line : "");
+      header.appendChild(makeCopyRow("", loc, "panel-detail-selector"));
+    }
   }
 
   refs.panelBody.appendChild(header);
@@ -374,6 +427,7 @@ function renderThreadMessages(thread: Thread): HTMLElement {
   textarea.className = PREFIX + "textarea";
   textarea.placeholder = "Reply...";
   textarea.rows = 2;
+  textarea.dataset.threadId = thread.id;
   input.appendChild(textarea);
 
   const inputActions = mkEl("div", "thread-input-actions");

--- a/crates/veld-daemon/frontend/src/feedback-overlay/panel.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/panel.ts
@@ -188,6 +188,11 @@ function restoreDraft(draft: DraftSnapshot | null): void {
   ) as HTMLTextAreaElement | null;
   if (!ta) return;
   ta.value = draft.value;
+  // Setting .value programmatically fires no input/change event — harmless
+  // today (Send reads ta.value directly at click time), but any future
+  // input-gating (disabled-until-non-empty, a char counter) would silently
+  // stay stuck in its pre-restore state without this.
+  ta.dispatchEvent(new Event("input", { bubbles: true }));
   if (draft.focused) {
     ta.focus();
     try { ta.setSelectionRange(draft.selStart ?? draft.value.length, draft.selEnd ?? draft.value.length); } catch (_) { /* ignore */ }

--- a/crates/veld-daemon/frontend/src/feedback-overlay/popover.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/popover.ts
@@ -52,12 +52,19 @@ export function closeActivePopover(): void {
   if (refs.toolBtnScreenshot) refs.toolBtnScreenshot.classList.remove(PREFIX + "tool-active");
 }
 
+export interface CreatePopoverExtra {
+  elementText?: string | null;
+  sourceFile?: string | null;
+  sourceLine?: number | null;
+}
+
 export function showCreatePopover(
   rect: { x: number; y: number; width: number; height: number },
   selector: string | null,
   tagInfo: string | null,
   targetEl: Element | null,
   trace: string[] | null,
+  extra?: CreatePopoverExtra | null,
 ): void {
   closeActivePopover();
   dispatch({ type: "SET_LOCKED", el: targetEl });
@@ -69,6 +76,7 @@ export function showCreatePopover(
     const formatted = formatTrace(trace);
     if (formatted) popover.appendChild(mkEl("div", "popover-trace", formatted));
   }
+  if (extra?.elementText) popover.appendChild(mkEl("div", "popover-selector", "“" + extra.elementText + "”"));
 
   const popoverBody = mkEl("div", "popover-body");
 
@@ -89,7 +97,15 @@ export function showCreatePopover(
     if (!text || sendBtn.disabled) return;
     sendBtn.disabled = true;
     const scope = selector
-      ? { type: "element", page_url: window.location.pathname, selector, position: rect }
+      ? {
+          type: "element",
+          page_url: window.location.pathname,
+          selector,
+          position: rect,
+          element_text: extra?.elementText || undefined,
+          source_file: extra?.sourceFile || undefined,
+          source_line: extra?.sourceLine ?? undefined,
+        }
       : { type: "page", page_url: window.location.pathname };
     api("POST", "/threads", {
       scope, message: text, component_trace: trace || null,

--- a/crates/veld-daemon/frontend/src/feedback-overlay/refs.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/refs.ts
@@ -27,6 +27,8 @@ export interface DOMRefs {
   hoverOutline: HTMLElement;
   componentTraceEl: HTMLElement;
   screenshotRect: HTMLElement;
+  screenshotBanner: HTMLElement;
+  screenshotFullBtn: HTMLElement;
 
   // Panel
   panel: HTMLElement;
@@ -68,6 +70,8 @@ export function initRefs(shadow: ShadowRoot, hostEl: HTMLElement): void {
     hoverOutline: null!,
     componentTraceEl: null!,
     screenshotRect: null!,
+    screenshotBanner: null!,
+    screenshotFullBtn: null!,
     panel: null!,
     panelBody: null!,
     panelHeadTitle: null!,

--- a/crates/veld-daemon/frontend/src/feedback-overlay/refs.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/refs.ts
@@ -27,6 +27,7 @@ export interface DOMRefs {
   hoverOutline: HTMLElement;
   componentTraceEl: HTMLElement;
   screenshotRect: HTMLElement;
+  screenshotFrame: HTMLImageElement;
   screenshotBanner: HTMLElement;
   screenshotFullBtn: HTMLElement;
 
@@ -70,6 +71,7 @@ export function initRefs(shadow: ShadowRoot, hostEl: HTMLElement): void {
     hoverOutline: null!,
     componentTraceEl: null!,
     screenshotRect: null!,
+    screenshotFrame: null!,
     screenshotBanner: null!,
     screenshotFullBtn: null!,
     panel: null!,

--- a/crates/veld-daemon/frontend/src/feedback-overlay/screenshot.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/screenshot.ts
@@ -31,11 +31,19 @@ export function computeContainRect(bitmapW: number, bitmapH: number, boxW: numbe
   return { x: (boxW - w) / 2, y: (boxH - h) / 2, w, h };
 }
 
+/** Fixed gap kept between the frame and the viewport edge on every side.
+ *  Without it, a capture whose aspect ratio happens to match the viewport
+ *  fills it edge-to-edge with zero visual difference from the live page —
+ *  the exact "I can't tell I'm looking at a screenshot" complaint this
+ *  margin fixes. Always applied, not just when letterboxing would occur. */
+const FRAME_MARGIN = 32;
+
 /** Where the frozen frame is currently drawn on screen, in viewport CSS px.
  *  A captured stream's native resolution doesn't always match the viewport's
  *  aspect ratio 1:1 (browser chrome, multi-monitor scaling, etc.), so the
- *  frame is displayed via `background-size: contain` and may be letterboxed
- *  — that mismatch was what stretched screenshots before this fix.
+ *  frame is fit with `computeContainRect` and may be letterboxed within its
+ *  margin-inset box — that mismatch was what stretched screenshots before
+ *  this fix.
  *
  *  Measures `refs.overlay`'s own painted box rather than
  *  `window.innerWidth/innerHeight`: on platforms with classic (non-overlay)
@@ -45,7 +53,24 @@ export function computeContainRect(bitmapW: number, bitmapH: number, boxW: numbe
 function currentFrameRect(): FrameRect | null {
   if (!frozenBitmapDims) return null;
   const box = refs.overlay.getBoundingClientRect();
-  return computeContainRect(frozenBitmapDims.w, frozenBitmapDims.h, box.width, box.height);
+  const innerW = Math.max(1, box.width - FRAME_MARGIN * 2);
+  const innerH = Math.max(1, box.height - FRAME_MARGIN * 2);
+  const rect = computeContainRect(frozenBitmapDims.w, frozenBitmapDims.h, innerW, innerH);
+  return { x: rect.x + FRAME_MARGIN, y: rect.y + FRAME_MARGIN, w: rect.w, h: rect.h };
+}
+
+/** Reposition the visible frame `<img>` to match `currentFrameRect()` — call
+ *  whenever the frame is (re)shown and on every viewport resize while it's
+ *  up, since the frame's position/size are now plain inline styles rather
+ *  than CSS `background-size: contain` (which used to reflow for free). */
+export function repositionFrozenFrame(): void {
+  if (getState().activeMode !== "screenshot") return;
+  const frame = currentFrameRect();
+  if (!frame) return;
+  refs.screenshotFrame.style.left = frame.x + "px";
+  refs.screenshotFrame.style.top = frame.y + "px";
+  refs.screenshotFrame.style.width = frame.w + "px";
+  refs.screenshotFrame.style.height = frame.h + "px";
 }
 
 /** Clamp a selection rectangle (viewport CSS px) to the displayed frame's
@@ -148,18 +173,20 @@ function afterWarmup(fn: () => void): void {
   setTimeout(fn, 120);
 }
 
-/** Paint the frozen frame onto the backdrop and enable the selection cursor.
+/** Paint the frozen frame as a bordered, shadowed, margin-inset "photo card"
+ *  (`refs.screenshotFrame`) and enable the selection cursor on the — now
+ *  transparent — drag-catching overlay above it.
  *
- *  Uses `background-size: contain` (not `100% 100%`) so a captured frame
- *  whose aspect ratio doesn't exactly match the viewport — common when the
- *  capture stream includes a sliver of browser chrome, or on a scaled
- *  display — letterboxes instead of stretching. `frozenBitmapDims` records
- *  its native size so `currentFrameRect()` can recompute the on-screen rect
- *  on demand, staying correct even if the viewport resizes mid-selection.
- *
- *  The `contain`/`center` set here and `computeContainRect`'s math encode
- *  the same layout in two places (CSS vs. JS) with nothing enforcing they
- *  match — if one changes, change the other. */
+ *  Drawn as its own `<img>` rather than a full-bleed `background-image` so
+ *  it can never look identical to the live page underneath: the fixed
+ *  `FRAME_MARGIN` inset plus border/shadow (see CSS) is always visible, even
+ *  when the capture's aspect ratio happens to match the viewport exactly (in
+ *  which case there'd otherwise be no letterboxing at all to hint that
+ *  anything changed). `frozenBitmapDims` records the bitmap's native size so
+ *  `currentFrameRect()`/`repositionFrozenFrame()` can recompute the on-screen
+ *  rect on demand — both at capture time and on resize, since positioning is
+ *  now plain inline styles rather than CSS `background-size: contain`, which
+ *  used to reflow for free. */
 function showFrozenFrame(bitmap: ImageBitmap): void {
   const canvas = document.createElement("canvas");
   canvas.width = bitmap.width;
@@ -168,22 +195,25 @@ function showFrozenFrame(bitmap: ImageBitmap): void {
 
   frozenBitmapDims = { w: bitmap.width, h: bitmap.height };
 
-  refs.overlay.style.backgroundImage = `url(${canvas.toDataURL("image/png")})`;
-  refs.overlay.style.backgroundSize = "contain";
-  refs.overlay.style.backgroundRepeat = "no-repeat";
-  refs.overlay.style.backgroundPosition = "center";
+  refs.screenshotFrame.src = canvas.toDataURL("image/png");
+  refs.screenshotFrame.classList.add(PREFIX + "screenshot-frame-show");
+
+  // Activate (display:block) the overlay BEFORE positioning the frame:
+  // repositionFrozenFrame() measures refs.overlay.getBoundingClientRect(),
+  // which returns 0×0 while the overlay is still display:none — sizing the
+  // frame to ~1px on first paint. Must come first.
   refs.overlay.classList.add(PREFIX + "overlay-active");
   refs.overlay.classList.add(PREFIX + "overlay-crosshair");
   refs.overlay.classList.add(PREFIX + "overlay-frame");
   refs.screenshotBanner.classList.add(PREFIX + "screenshot-banner-show");
+
+  repositionFrozenFrame();
 }
 
 /** Reset the frozen-frame backdrop and release the bitmap. */
 export function clearFrozenFrame(): void {
-  refs.overlay.style.backgroundImage = "";
-  refs.overlay.style.backgroundSize = "";
-  refs.overlay.style.backgroundRepeat = "";
-  refs.overlay.style.backgroundPosition = "";
+  refs.screenshotFrame.classList.remove(PREFIX + "screenshot-frame-show");
+  refs.screenshotFrame.src = "";
   refs.overlay.classList.remove(PREFIX + "overlay-frame");
   refs.screenshotBanner.classList.remove(PREFIX + "screenshot-banner-show");
   frozenBitmapDims = null;

--- a/crates/veld-daemon/frontend/src/feedback-overlay/screenshot.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/screenshot.ts
@@ -21,7 +21,10 @@ let frozenBitmapDims: { w: number; h: number } | null = null;
 
 export interface FrameRect { x: number; y: number; w: number; h: number }
 
-function computeContainRect(bitmapW: number, bitmapH: number, boxW: number, boxH: number): FrameRect {
+/** Pure contain-fit math, exported for unit testing — the core of the
+ *  distortion fix, so it's worth covering directly rather than only through
+ *  the full capture flow (which needs getDisplayMedia/ImageCapture mocks). */
+export function computeContainRect(bitmapW: number, bitmapH: number, boxW: number, boxH: number): FrameRect {
   const scale = Math.min(boxW / bitmapW, boxH / bitmapH);
   const w = bitmapW * scale;
   const h = bitmapH * scale;
@@ -32,10 +35,17 @@ function computeContainRect(bitmapW: number, bitmapH: number, boxW: number, boxH
  *  A captured stream's native resolution doesn't always match the viewport's
  *  aspect ratio 1:1 (browser chrome, multi-monitor scaling, etc.), so the
  *  frame is displayed via `background-size: contain` and may be letterboxed
- *  — that mismatch was what stretched screenshots before this fix. */
+ *  — that mismatch was what stretched screenshots before this fix.
+ *
+ *  Measures `refs.overlay`'s own painted box rather than
+ *  `window.innerWidth/innerHeight`: on platforms with classic (non-overlay)
+ *  scrollbars, the fixed-position overlay's content box is narrower than
+ *  `innerWidth` (which includes the scrollbar gutter), and using the wrong
+ *  one would offset the selection/crop by the scrollbar's width. */
 function currentFrameRect(): FrameRect | null {
   if (!frozenBitmapDims) return null;
-  return computeContainRect(frozenBitmapDims.w, frozenBitmapDims.h, window.innerWidth, window.innerHeight);
+  const box = refs.overlay.getBoundingClientRect();
+  return computeContainRect(frozenBitmapDims.w, frozenBitmapDims.h, box.width, box.height);
 }
 
 /** Clamp a selection rectangle (viewport CSS px) to the displayed frame's
@@ -145,7 +155,11 @@ function afterWarmup(fn: () => void): void {
  *  capture stream includes a sliver of browser chrome, or on a scaled
  *  display — letterboxes instead of stretching. `frozenBitmapDims` records
  *  its native size so `currentFrameRect()` can recompute the on-screen rect
- *  on demand, staying correct even if the viewport resizes mid-selection. */
+ *  on demand, staying correct even if the viewport resizes mid-selection.
+ *
+ *  The `contain`/`center` set here and `computeContainRect`'s math encode
+ *  the same layout in two places (CSS vs. JS) with nothing enforcing they
+ *  match — if one changes, change the other. */
 function showFrozenFrame(bitmap: ImageBitmap): void {
   const canvas = document.createElement("canvas");
   canvas.width = bitmap.width;
@@ -218,8 +232,13 @@ export function captureScreenshot(
  *  `viewX/Y/W/H` are viewport CSS px relative to the *displayed, letterboxed*
  *  frame (`frame`, from `currentFrameRect()`) — not the raw viewport — so the
  *  scale factor here is against the frame's own on-screen size, and the
- *  frame's top-left offset is subtracted before scaling into bitmap pixels. */
-export function cropAndShowEditor(
+ *  frame's top-left offset is subtracted before scaling into bitmap pixels.
+ *
+ *  Not exported: `frame` must come from `currentFrameRect()`, which is
+ *  module-private — an outside caller has no valid way to construct one and
+ *  would be tempted to hand-roll `{x:0,y:0,w:innerWidth,h:innerHeight}`,
+ *  silently reintroducing the stretch bug this function exists to fix. */
+function cropAndShowEditor(
   bitmap: ImageBitmap,
   viewX: number,
   viewY: number,

--- a/crates/veld-daemon/frontend/src/feedback-overlay/screenshot.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/screenshot.ts
@@ -12,6 +12,44 @@ import { deps } from "../shared/registry";
 // because it is a transient ImageBitmap tied to one screenshot flow.
 let frozenBitmap: ImageBitmap | null = null;
 
+/** Native pixel dimensions of the frozen frame — fixed once captured. Used to
+ *  recompute the on-screen rect on demand (see `currentFrameRect`) rather
+ *  than caching it, since the viewport can resize between freezing the frame
+ *  and finishing the drag-select (window resize, devtools toggling), which
+ *  would otherwise leave a stale rect and misalign the crop. */
+let frozenBitmapDims: { w: number; h: number } | null = null;
+
+export interface FrameRect { x: number; y: number; w: number; h: number }
+
+function computeContainRect(bitmapW: number, bitmapH: number, boxW: number, boxH: number): FrameRect {
+  const scale = Math.min(boxW / bitmapW, boxH / bitmapH);
+  const w = bitmapW * scale;
+  const h = bitmapH * scale;
+  return { x: (boxW - w) / 2, y: (boxH - h) / 2, w, h };
+}
+
+/** Where the frozen frame is currently drawn on screen, in viewport CSS px.
+ *  A captured stream's native resolution doesn't always match the viewport's
+ *  aspect ratio 1:1 (browser chrome, multi-monitor scaling, etc.), so the
+ *  frame is displayed via `background-size: contain` and may be letterboxed
+ *  — that mismatch was what stretched screenshots before this fix. */
+function currentFrameRect(): FrameRect | null {
+  if (!frozenBitmapDims) return null;
+  return computeContainRect(frozenBitmapDims.w, frozenBitmapDims.h, window.innerWidth, window.innerHeight);
+}
+
+/** Clamp a selection rectangle (viewport CSS px) to the displayed frame's
+ *  bounds, so dragging into a letterbox bar can't select "outside the image". */
+export function clampToFrame(x: number, y: number, w: number, h: number): { x: number; y: number; w: number; h: number } {
+  const frame = currentFrameRect();
+  if (!frame) return { x, y, w, h };
+  const x1 = Math.max(x, frame.x);
+  const y1 = Math.max(y, frame.y);
+  const x2 = Math.min(x + w, frame.x + frame.w);
+  const y2 = Math.min(y + h, frame.y + frame.h);
+  return { x: x1, y: y1, w: Math.max(0, x2 - x1), h: Math.max(0, y2 - y1) };
+}
+
 /**
  * Acquire a screen-capture stream. Chromium's `preferCurrentTab` /
  * `displaySurface` hints bias the picker toward the current tab.
@@ -100,27 +138,41 @@ function afterWarmup(fn: () => void): void {
   setTimeout(fn, 120);
 }
 
-/** Paint the frozen frame onto the backdrop and enable the selection cursor. */
+/** Paint the frozen frame onto the backdrop and enable the selection cursor.
+ *
+ *  Uses `background-size: contain` (not `100% 100%`) so a captured frame
+ *  whose aspect ratio doesn't exactly match the viewport — common when the
+ *  capture stream includes a sliver of browser chrome, or on a scaled
+ *  display — letterboxes instead of stretching. `frozenBitmapDims` records
+ *  its native size so `currentFrameRect()` can recompute the on-screen rect
+ *  on demand, staying correct even if the viewport resizes mid-selection. */
 function showFrozenFrame(bitmap: ImageBitmap): void {
   const canvas = document.createElement("canvas");
   canvas.width = bitmap.width;
   canvas.height = bitmap.height;
   canvas.getContext("2d")!.drawImage(bitmap, 0, 0);
 
-  // background-size 100% 100% maps the frame 1:1 onto the fixed, viewport-sized
-  // backdrop, so a rectangle drawn in viewport coordinates maps straight back
-  // onto the bitmap.
+  frozenBitmapDims = { w: bitmap.width, h: bitmap.height };
+
   refs.overlay.style.backgroundImage = `url(${canvas.toDataURL("image/png")})`;
-  refs.overlay.style.backgroundSize = "100% 100%";
+  refs.overlay.style.backgroundSize = "contain";
+  refs.overlay.style.backgroundRepeat = "no-repeat";
+  refs.overlay.style.backgroundPosition = "center";
   refs.overlay.classList.add(PREFIX + "overlay-active");
   refs.overlay.classList.add(PREFIX + "overlay-crosshair");
-  toast("Drag to capture a region");
+  refs.overlay.classList.add(PREFIX + "overlay-frame");
+  refs.screenshotBanner.classList.add(PREFIX + "screenshot-banner-show");
 }
 
 /** Reset the frozen-frame backdrop and release the bitmap. */
 export function clearFrozenFrame(): void {
   refs.overlay.style.backgroundImage = "";
   refs.overlay.style.backgroundSize = "";
+  refs.overlay.style.backgroundRepeat = "";
+  refs.overlay.style.backgroundPosition = "";
+  refs.overlay.classList.remove(PREFIX + "overlay-frame");
+  refs.screenshotBanner.classList.remove(PREFIX + "screenshot-banner-show");
+  frozenBitmapDims = null;
   if (frozenBitmap) {
     frozenBitmap.close();
     frozenBitmap = null;
@@ -144,39 +196,49 @@ export function captureScreenshot(
   viewW: number,
   viewH: number,
 ): void {
-  // Detach the bitmap before setMode(null) so teardown doesn't close it.
+  // Read the bitmap and current frame rect before setMode(null) — teardown
+  // calls clearFrozenFrame(), which closes the bitmap and clears the dims
+  // currentFrameRect() depends on. Computing the frame here (rather than
+  // reusing a value cached at freeze time) keeps it correct even if the
+  // viewport resized during the drag.
   const bitmap = frozenBitmap;
+  const frame = currentFrameRect();
   frozenBitmap = null;
   deps().setMode(null); // teardown clears the backdrop + resets the cursor
 
-  if (!bitmap) {
+  if (!bitmap || !frame) {
     showScreenshotThreadEditor(null, null);
     return;
   }
-  cropAndShowEditor(bitmap, viewX, viewY, viewW, viewH);
+  cropAndShowEditor(bitmap, viewX, viewY, viewW, viewH, frame);
 }
 
-/** Crop the captured bitmap to the selected region and show the editor. */
+/** Crop the captured bitmap to the selected region and show the editor.
+ *
+ *  `viewX/Y/W/H` are viewport CSS px relative to the *displayed, letterboxed*
+ *  frame (`frame`, from `currentFrameRect()`) — not the raw viewport — so the
+ *  scale factor here is against the frame's own on-screen size, and the
+ *  frame's top-left offset is subtracted before scaling into bitmap pixels. */
 export function cropAndShowEditor(
   bitmap: ImageBitmap,
   viewX: number,
   viewY: number,
   viewW: number,
   viewH: number,
+  frame: FrameRect,
 ): void {
-  // The bitmap is at native (dpr-scaled) resolution; the selection is in CSS px.
-  const scaleX = bitmap.width / window.innerWidth;
-  const scaleY = bitmap.height / window.innerHeight;
+  const scaleX = bitmap.width / frame.w;
+  const scaleY = bitmap.height / frame.h;
 
   const canvas = document.createElement("canvas");
-  canvas.width = Math.round(viewW * scaleX);
-  canvas.height = Math.round(viewH * scaleY);
+  canvas.width = Math.max(1, Math.round(viewW * scaleX));
+  canvas.height = Math.max(1, Math.round(viewH * scaleY));
   const ctx = canvas.getContext("2d")!;
 
   ctx.drawImage(
     bitmap,
-    Math.round(viewX * scaleX),
-    Math.round(viewY * scaleY),
+    Math.round((viewX - frame.x) * scaleX),
+    Math.round((viewY - frame.y) * scaleY),
     canvas.width,
     canvas.height,
     0,
@@ -193,6 +255,23 @@ export function cropAndShowEditor(
     }
     uploadAndShowEditor(pngBlob);
   }, "image/png");
+}
+
+/** Capture the whole frozen frame, no cropping — the banner's explicit
+ *  fallback for reviewers who don't want to drag a selection. Just crops to
+ *  the frame's own full extent, so it shares the same code path/rounding as
+ *  a manual selection. */
+export function captureFullScreenshot(): void {
+  const bitmap = frozenBitmap;
+  const frame = currentFrameRect();
+  frozenBitmap = null;
+  deps().setMode(null); // teardown clears the backdrop + resets the cursor
+
+  if (!bitmap || !frame) {
+    showScreenshotThreadEditor(null, null);
+    return;
+  }
+  cropAndShowEditor(bitmap, frame.x, frame.y, frame.w, frame.h, frame);
 }
 
 /** Upload a screenshot blob to the API, then show the thread editor. */

--- a/crates/veld-daemon/frontend/src/feedback-overlay/styles.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/styles.ts
@@ -59,12 +59,44 @@ export const LIGHT_CSS = `
 }
 .veld-feedback-overlay-active { display: block; }
 .veld-feedback-overlay-crosshair { cursor: crosshair; }
-/* Screenshot mode: the frame is painted as a background-image with
-   background-size:contain (see screenshot.ts), so it can letterbox instead
-   of stretching when its aspect ratio doesn't match the viewport. This near-
-   opaque backing makes the letterbox bars read as an intentional frame edge
-   rather than the live page bleeding through. */
+/* Screenshot mode: a near-opaque dark backdrop behind the framed capture
+   (see .veld-feedback-screenshot-frame below) — this is what reads as "the
+   live page is gone, you're looking at something else now" even when the
+   captured content looks identical to the page underneath. */
 .veld-feedback-overlay-frame { background-color: rgba(8,8,10,.92); }
+/* The frozen frame, always inset from the viewport edge with a visible
+   border/shadow (see currentFrameRect's margin, screenshot.ts) — a "photo
+   card" floating on the dark backdrop, never edge-to-edge. Without this
+   inset+border, a capture of a static page looks pixel-identical to the
+   live page and screenshot mode is invisible until you notice the cursor. */
+.veld-feedback-screenshot-frame {
+  position: fixed;
+  display: none;
+  object-fit: contain;
+  border-radius: 8px;
+  border: 1px solid rgba(255,255,255,.16);
+  box-shadow: 0 24px 70px rgba(0,0,0,.65), 0 0 0 1px rgba(0,0,0,.35);
+  /* Must outrank the overlay's own z-index (999997) — the overlay's dark
+     background-color (.overlay-frame, above) covers its *entire* fixed
+     inset:0 box, so if the frame sat below it in stacking order the scrim
+     would paint straight over the image instead of just around it. */
+  z-index: 999998;
+  pointer-events: none;
+}
+.veld-feedback-screenshot-frame-show {
+  display: block;
+  animation: veld-feedback-frame-glow 1.4s ease-in-out infinite;
+}
+@keyframes veld-feedback-frame-glow {
+  0%, 100% {
+    box-shadow: 0 24px 70px rgba(0,0,0,.65), 0 0 0 1px rgba(0,0,0,.35),
+      0 0 12px 2px color-mix(in srgb, var(--vfl-accent) 42%, transparent);
+  }
+  50% {
+    box-shadow: 0 24px 70px rgba(0,0,0,.65), 0 0 0 1px rgba(0,0,0,.35),
+      0 0 20px 4px color-mix(in srgb, var(--vfl-accent) 58%, transparent);
+  }
+}
 .veld-feedback-hover-outline {
   position: absolute;
   outline: 2px solid var(--vfl-accent);
@@ -112,7 +144,7 @@ export const LIGHT_CSS = `
 .veld-feedback-screenshot-corner-bl { bottom: -2px; left: -2px; border-right: none; border-top: none; }
 .veld-feedback-screenshot-corner-br { bottom: -2px; right: -2px; border-left: none; border-top: none; }
 .veld-feedback-screenshot-banner {
-  position: fixed; top: 20px; left: 50%; transform: translateX(-50%);
+  position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%);
   z-index: 1000000;
   /* The banner sits above the drag surface, so a selection that starts under
      it (e.g. capturing a page header near the top of the viewport) would

--- a/crates/veld-daemon/frontend/src/feedback-overlay/styles.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/styles.ts
@@ -59,6 +59,12 @@ export const LIGHT_CSS = `
 }
 .veld-feedback-overlay-active { display: block; }
 .veld-feedback-overlay-crosshair { cursor: crosshair; }
+/* Screenshot mode: the frame is painted as a background-image with
+   background-size:contain (see screenshot.ts), so it can letterbox instead
+   of stretching when its aspect ratio doesn't match the viewport. This near-
+   opaque backing makes the letterbox bars read as an intentional frame edge
+   rather than the live page bleeding through. */
+.veld-feedback-overlay-frame { background-color: rgba(8,8,10,.92); }
 .veld-feedback-hover-outline {
   position: absolute;
   outline: 2px solid var(--vfl-accent);
@@ -87,10 +93,47 @@ export const LIGHT_CSS = `
   outline: 2px dashed var(--vfl-accent);
   outline-offset: 2px;
   background: rgba(100,100,100,.06);
+  /* Same spotlight trick as the hover-outline: dims everything outside the
+     drawn selection so it's unambiguous what will be captured. */
+  box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.55);
   pointer-events: none;
   z-index: 999998;
   border-radius: 3px;
   display: none;
+}
+.veld-feedback-screenshot-corner {
+  position: absolute;
+  width: 16px; height: 16px;
+  border: 2px solid var(--vfl-accent);
+  pointer-events: none;
+}
+.veld-feedback-screenshot-corner-tl { top: -2px; left: -2px; border-right: none; border-bottom: none; }
+.veld-feedback-screenshot-corner-tr { top: -2px; right: -2px; border-left: none; border-bottom: none; }
+.veld-feedback-screenshot-corner-bl { bottom: -2px; left: -2px; border-right: none; border-top: none; }
+.veld-feedback-screenshot-corner-br { bottom: -2px; right: -2px; border-left: none; border-top: none; }
+.veld-feedback-screenshot-banner {
+  position: fixed; top: 20px; left: 50%; transform: translateX(-50%);
+  z-index: 1000000;
+  /* The banner sits above the drag surface, so a selection that starts under
+     it (e.g. capturing a page header near the top of the viewport) would
+     otherwise never reach the overlay's mousedown handler. Disable hit-
+     testing on the banner itself and re-enable it only on the button. */
+  pointer-events: none;
+  display: none; align-items: center; gap: 10px;
+  background: var(--vfl-bg); color: var(--vfl-text);
+  border: 1px solid var(--vfl-border); border-radius: 10px;
+  padding: 10px 14px;
+  font: 500 12px/1.4 var(--vfl-font);
+  box-shadow: 0 8px 30px rgba(0,0,0,.4);
+}
+.veld-feedback-screenshot-banner-show { display: flex; }
+.veld-feedback-screenshot-banner-text { white-space: nowrap; }
+.veld-feedback-screenshot-banner-hint { color: var(--vfl-text-muted); font-size: 11px; white-space: nowrap; }
+.veld-feedback-screenshot-banner-btn {
+  pointer-events: auto;
+  padding: 5px 12px; border-radius: 6px; border: none; cursor: pointer;
+  background: var(--vfl-accent); color: var(--vfl-bg);
+  font: 600 11px/1.4 var(--vfl-font); white-space: nowrap;
 }
 .veld-feedback-pin {
   position: absolute; z-index: 999998;

--- a/crates/veld-daemon/frontend/src/feedback-overlay/types.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/types.ts
@@ -7,6 +7,11 @@ export interface ThreadScope {
   selector?: string;
   label?: string;
   position?: { x: number; y: number; width: number; height: number };
+  /** Visible text of the scoped element, middle-truncated — helps an agent
+   *  disambiguate when the CSS selector alone matches ambiguously. */
+  element_text?: string;
+  source_file?: string;
+  source_line?: number;
 }
 
 export interface Message {

--- a/crates/veld-daemon/frontend/src/shared/registry.ts
+++ b/crates/veld-daemon/frontend/src/shared/registry.ts
@@ -1,4 +1,5 @@
 import type { UIMode, Thread } from "../feedback-overlay/types";
+import type { CreatePopoverExtra } from "../feedback-overlay/popover";
 
 export interface Deps {
   setMode: (mode: UIMode) => void;
@@ -17,7 +18,7 @@ export interface Deps {
   checkPendingScroll: () => void;
   updateBadge: () => void;
   captureScreenshot: (x: number, y: number, w: number, h: number) => void;
-  showCreatePopover: (rect: { x: number; y: number; width: number; height: number }, selector: string | null, tagInfo: string | null, targetEl: Element | null, trace: string[] | null) => void;
+  showCreatePopover: (rect: { x: number; y: number; width: number; height: number }, selector: string | null, tagInfo: string | null, targetEl: Element | null, trace: string[] | null, extra?: CreatePopoverExtra | null) => void;
   positionTooltip: (el: HTMLElement, viewportRect: DOMRect) => void;
 }
 

--- a/crates/veld-daemon/frontend/tests/component-trace.test.ts
+++ b/crates/veld-daemon/frontend/tests/component-trace.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect } from "vitest";
-import { getComponentTrace } from "../src/feedback-overlay/component-trace";
+import { getComponentTrace, getComponentSource } from "../src/feedback-overlay/component-trace";
 
 describe("getComponentTrace", () => {
   it("returns null for plain HTML element", () => {
@@ -91,7 +91,70 @@ describe("getComponentTrace", () => {
     (el as any).__reactFiber$deep = fiber;
     const trace = getComponentTrace(el);
     expect(trace).not.toBeNull();
-    // Should be capped at MAX_DEPTH (100)
-    expect(trace!.length).toBeLessThanOrEqual(100);
+    // Depth-walking stops at MAX_DEPTH (100), but the trace returned to
+    // callers is further capped to the last 12 entries (see next test) —
+    // asserting the real number here, not just "under some large bound".
+    expect(trace!.length).toBe(12);
+  });
+
+  it("caps a long trace to the last 12 entries, nearest the clicked element", () => {
+    const el = document.createElement("div");
+    // 20-entry chain: Comp0 is the outermost ancestor, Comp19 the element itself.
+    let fiber: any = null;
+    for (let i = 0; i < 20; i++) {
+      fiber = { type: { name: `Comp${i}` }, return: fiber };
+    }
+    (el as any).__reactFiber$long = fiber;
+    const trace = getComponentTrace(el);
+    expect(trace).toEqual([
+      "Comp8", "Comp9", "Comp10", "Comp11", "Comp12", "Comp13",
+      "Comp14", "Comp15", "Comp16", "Comp17", "Comp18", "Comp19",
+    ]);
+  });
+
+  it("returns a short trace unchanged (no padding, no truncation)", () => {
+    const el = document.createElement("div");
+    const fiber = { type: { name: "Only" }, return: null };
+    (el as any).__reactFiber$short = fiber;
+    expect(getComponentTrace(el)).toEqual(["Only"]);
+  });
+});
+
+describe("getComponentSource", () => {
+  it("returns null for an element with no framework data", () => {
+    const el = document.createElement("div");
+    expect(getComponentSource(el)).toBeNull();
+  });
+
+  it("reads React _debugSource off the element's own fiber", () => {
+    const el = document.createElement("div");
+    (el as any).__reactFiber$src = {
+      type: { name: "Button" },
+      _debugSource: { fileName: "src/components/Button.tsx", lineNumber: 42 },
+      return: null,
+    };
+    expect(getComponentSource(el)).toEqual({ file: "src/components/Button.tsx", line: 42 });
+  });
+
+  it("walks up to the nearest ancestor fiber with _debugSource", () => {
+    const el = document.createElement("div");
+    (el as any).__reactFiber$src = {
+      type: "div", // host node, no _debugSource of its own
+      return: {
+        type: { name: "Card" },
+        _debugSource: { fileName: "src/components/Card.tsx", lineNumber: 7 },
+        return: null,
+      },
+    };
+    expect(getComponentSource(el)).toEqual({ file: "src/components/Card.tsx", line: 7 });
+  });
+
+  it("reads Vue's __file (no line number available)", () => {
+    const el = document.createElement("div");
+    (el as any).__vueParentComponent = {
+      type: { __file: "src/components/Card.vue" },
+      parent: null,
+    };
+    expect(getComponentSource(el)).toEqual({ file: "src/components/Card.vue" });
   });
 });

--- a/crates/veld-daemon/frontend/tests/helpers.test.ts
+++ b/crates/veld-daemon/frontend/tests/helpers.test.ts
@@ -5,6 +5,7 @@ import {
   isCurrentPage,
   formatTrace,
   findThread,
+  truncateMiddle,
 } from "../src/feedback-overlay/helpers";
 import type { Thread } from "../src/feedback-overlay/types";
 
@@ -125,6 +126,31 @@ describe("findThread", () => {
 
   it("returns undefined for missing id", () => {
     expect(findThread([], "x")).toBeUndefined();
+  });
+});
+
+describe("truncateMiddle", () => {
+  it("returns short text unchanged", () => {
+    expect(truncateMiddle("hello world")).toBe("hello world");
+  });
+
+  it("collapses internal whitespace/newlines even when under the limit", () => {
+    expect(truncateMiddle("hello   \n\n  world")).toBe("hello world");
+  });
+
+  it("truncates the middle, keeping a long head and short tail", () => {
+    const text = "A".repeat(50) + "MIDDLE" + "B".repeat(50) + "END";
+    const result = truncateMiddle(text, 30, 10);
+    expect(result.length).toBe(30);
+    expect(result.startsWith("A".repeat(19))).toBe(true);
+    expect(result.endsWith("BBEND")).toBe(true); // true tail, not sliced off a head-bounded copy
+    expect(result).toContain("…");
+  });
+
+  it("preserves the text's true end even when it's far beyond maxLen*10", () => {
+    const text = "x".repeat(5000) + "THE-VERY-END";
+    const result = truncateMiddle(text, 50, 12);
+    expect(result.endsWith("THE-VERY-END")).toBe(true);
   });
 });
 

--- a/crates/veld-daemon/frontend/tests/popover-submit.test.ts
+++ b/crates/veld-daemon/frontend/tests/popover-submit.test.ts
@@ -78,6 +78,37 @@ describe("showCreatePopover", () => {
     });
   });
 
+  it("threads element_text/source_file/source_line from `extra` into the posted scope", async () => {
+    const thread = makeThread({ id: "t-extra" });
+    mockApi.mockResolvedValueOnce(thread);
+
+    showCreatePopover(
+      { x: 100, y: 100, width: 50, height: 30 },
+      ".el", null, null, null,
+      { elementText: "Submit", sourceFile: "src/Button.tsx", sourceLine: 42 },
+    );
+
+    const popover = refs.shadow.querySelector("." + PREFIX + "popover")!;
+    const textarea = popover.querySelector("textarea")!;
+    const sendBtn = popover.querySelector("." + PREFIX + "btn-primary") as HTMLButtonElement;
+    textarea.value = "too small";
+    sendBtn.click();
+
+    await vi.waitFor(() => {
+      expect(mockApi).toHaveBeenCalledWith(
+        "POST",
+        "/threads",
+        expect.objectContaining({
+          scope: expect.objectContaining({
+            element_text: "Submit",
+            source_file: "src/Button.tsx",
+            source_line: 42,
+          }),
+        }),
+      );
+    });
+  });
+
   it("send button does nothing with empty text", () => {
     showCreatePopover(
       { x: 100, y: 100, width: 50, height: 30 },

--- a/crates/veld-daemon/frontend/tests/screenshot.test.ts
+++ b/crates/veld-daemon/frontend/tests/screenshot.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { computeContainRect } from "../src/feedback-overlay/screenshot";
+
+describe("computeContainRect", () => {
+  it("fills the box exactly when the aspect ratio matches", () => {
+    expect(computeContainRect(1920, 1080, 1920, 1080)).toEqual({ x: 0, y: 0, w: 1920, h: 1080 });
+  });
+
+  it("letterboxes top/bottom when the bitmap is wider than the box", () => {
+    // 2:1 bitmap into a 1:1 box — this is the exact shape of the original bug:
+    // a captured frame whose aspect ratio doesn't match the viewport used to
+    // get stretched via background-size:100% 100% instead of fitted like this.
+    const rect = computeContainRect(2000, 1000, 1000, 1000);
+    expect(rect).toEqual({ x: 0, y: 250, w: 1000, h: 500 });
+  });
+
+  it("letterboxes left/right when the bitmap is taller than the box", () => {
+    const rect = computeContainRect(1000, 2000, 1000, 1000);
+    expect(rect).toEqual({ x: 250, y: 0, w: 500, h: 1000 });
+  });
+
+  it("scales down uniformly when the bitmap is larger than the box on both axes", () => {
+    const rect = computeContainRect(3840, 2160, 1920, 1080);
+    expect(rect).toEqual({ x: 0, y: 0, w: 1920, h: 1080 });
+  });
+});

--- a/crates/veld-daemon/frontend/tests/test-helpers.ts
+++ b/crates/veld-daemon/frontend/tests/test-helpers.ts
@@ -92,6 +92,7 @@ export function setupMockRefs() {
   refs.hoverOutline = document.createElement("div");
   refs.componentTraceEl = document.createElement("div");
   refs.screenshotRect = document.createElement("div");
+  refs.screenshotFrame = document.createElement("img");
   refs.screenshotBanner = document.createElement("div");
   refs.screenshotFullBtn = document.createElement("button");
 

--- a/crates/veld-daemon/frontend/tests/test-helpers.ts
+++ b/crates/veld-daemon/frontend/tests/test-helpers.ts
@@ -92,6 +92,8 @@ export function setupMockRefs() {
   refs.hoverOutline = document.createElement("div");
   refs.componentTraceEl = document.createElement("div");
   refs.screenshotRect = document.createElement("div");
+  refs.screenshotBanner = document.createElement("div");
+  refs.screenshotFullBtn = document.createElement("button");
 
   // Set up tooltip
   refs.tooltip = document.createElement("div");

--- a/crates/veld-daemon/frontend/tests/wiring.test.ts
+++ b/crates/veld-daemon/frontend/tests/wiring.test.ts
@@ -55,6 +55,7 @@ function setupState() {
   refs.toolBtnComments = document.createElement("div");
   refs.toolBtnHide = document.createElement("div");
   refs.screenshotRect = document.createElement("div");
+  refs.screenshotFrame = document.createElement("img");
   refs.screenshotBanner = document.createElement("div");
   refs.screenshotFullBtn = document.createElement("button");
   registerDeps(makeFakeDeps());

--- a/crates/veld-daemon/frontend/tests/wiring.test.ts
+++ b/crates/veld-daemon/frontend/tests/wiring.test.ts
@@ -55,6 +55,8 @@ function setupState() {
   refs.toolBtnComments = document.createElement("div");
   refs.toolBtnHide = document.createElement("div");
   refs.screenshotRect = document.createElement("div");
+  refs.screenshotBanner = document.createElement("div");
+  refs.screenshotFullBtn = document.createElement("button");
   registerDeps(makeFakeDeps());
 }
 

--- a/crates/veld/src/commands/feedback.rs
+++ b/crates/veld/src/commands/feedback.rs
@@ -637,9 +637,24 @@ fn print_thread_context(thread: &Thread, store: &FeedbackStore) {
 fn print_scope(scope: &ThreadScope) {
     match scope {
         ThreadScope::Element {
-            page_url, selector, ..
+            page_url,
+            selector,
+            element_text,
+            source_file,
+            source_line,
+            ..
         } => {
             println!("  Element: {}", output::dim(selector));
+            if let Some(text) = element_text {
+                println!("  Text: {}", output::dim(&format!("\"{text}\"")));
+            }
+            if let Some(file) = source_file {
+                let loc = match source_line {
+                    Some(line) => format!("{file}:{line}"),
+                    None => file.clone(),
+                };
+                println!("  Source: {}", output::dim(&loc));
+            }
             println!("  Page: {}", output::dim(page_url));
         }
         ThreadScope::Page { page_url } => {

--- a/docs/agentic-review.md
+++ b/docs/agentic-review.md
@@ -1,0 +1,154 @@
+# Deep Review Methodology
+
+A four-angle adversarial review for a diff/PR, run after the normal self-review
+pass (see `AGENTS.md` → PR Workflow → Self-review rounds) whenever the change
+is non-trivial or the maintainer asks for a deeper look. It's heavier than a
+single review pass — reserve it for changes where a missed edge case is
+expensive, not for typo fixes.
+
+## Orchestrator instructions
+
+Spawn **four** subagents in parallel via the Agent tool, each with one of the
+angle-specific briefs below. Run all four in the background; report when all
+complete.
+
+**Spawn config (apply to every subagent):**
+
+- `model: opus` — set explicitly. Do not rely on inheritance (it can fall back
+  to a non-Anthropic model).
+- `run_in_background: true` — launch all four in one message, then continue
+  other work; you're notified as each completes.
+- One angle per subagent. Do not merge angles — the value is in the
+  separation.
+
+**Diff under review:** state explicitly (e.g. `git diff origin/main...HEAD`,
+"the staged changes", "the uncommitted working tree", "PR #1234") so every
+subagent reads the same surface. If the diff is large, also tell each
+subagent which paths are in scope vs. vendored / generated / out of scope.
+
+**Context to hand each subagent:** the diff target, the repo path, and 1-3
+sentences on what the change is *trying* to do (the intent). A reviewer who
+knows the goal finds gaps a context-free reviewer misses.
+
+---
+
+## Shared rules (every angle)
+
+- **Read the diff as if you didn't write it.** No benefit of the doubt.
+- **Verify before you flag.** If you claim a link is broken, a symbol is
+  undefined, a file is missing, or a command fails — run the check (grep,
+  open the file, resolve the anchor, execute the command). A flagged finding
+  you didn't verify is noise. Say "unverified" if you genuinely can't check.
+- **Don't flag prose nits.** Spelling, wording, formatting — skip, unless it
+  changes meaning or misleads.
+- **Surface only structural / semantic / edge-case findings.** The bar is
+  "this will bite someone", not "I'd have written it differently".
+- **Concrete locations only.** Every finding cites a real `path:line`, not
+  "the doc" or "somewhere in the config".
+- **Don't pad.** Zero findings is a valid, honest result. Do not manufacture
+  low-severity findings to look thorough. Three real findings beat ten
+  speculative ones.
+
+**Severity legend (use these exact emojis + words):**
+
+- `🔴 critical` — silent breakage, data-correctness bug, security exposure,
+  or something that will actively mislead the next person/agent who reads it.
+- `🟠 major` — real fragility with no documented mitigation; will bite under
+  a realistic condition.
+- `🟡 medium` — drift, an unhandled-but-unlikely edge, a missing guard that's
+  defensible to defer.
+- `🟢 minor` — speculative / cosmetic-with-meaning / nice-to-have. (Report
+  sparingly.)
+
+**Output format — one finding per line:**
+
+```
+[angle] path:line: <emoji> <severity>: <problem>. <fix>.
+```
+
+The `[angle]` tag (`[counterfactual]` / `[persona]` / `[assumption]` /
+`[whats-missing]`) lets the orchestrator dedupe overlapping findings across
+the four reports.
+
+- **Cap output at ~200 lines.** If you're past that, you're flagging nits —
+  raise the bar.
+- **End with a verdict line:** `ship it` only if you found zero
+  `🔴`/`🟠` findings. Otherwise end with `blocking: <N> critical, <M> major`.
+
+---
+
+## Angle 1 — Counterfactual reviewer
+
+For every design choice in the diff, imagine the opposite was picked. What
+edge case does the opposite catch that this one misses? What's the cost of
+each choice? Are there choices that look arbitrary (could have gone either
+way) — and is that arbitrariness documented anywhere? Probe load-bearing
+decisions: the ones where, if they're wrong, a lot breaks. For each, state
+what would have to be true for the chosen option to be wrong, and whether the
+diff would surface that.
+
+## Angle 2 — Persona-walkthrough reviewer
+
+Walk through realistic tasks as three personas:
+
+- **(a) New hire, zero project context**, who'll touch this in week two. Pick
+  one concrete onboarding task they'd be handed; find where they get stuck or
+  guess wrong.
+- **(b) The engineer who edits this file six months from now** without
+  re-reading the PR or its discussion. Pick one realistic edit; find the trap
+  they fall into because the reasoning lives only in the PR, not the
+  code/docs.
+- **(c) The careless contributor** who writes the natural-but-wrong thing
+  because the doc/API didn't pre-empt it. Pick the most-likely wrong move;
+  find whether anything stops them.
+
+For each persona, name the concrete task and the concrete gap. Generic "this
+could be clearer" doesn't count — show the failure.
+
+## Angle 3 — Implicit-assumption hunter
+
+Find unstated assumptions the author didn't realise they made. Probe:
+tooling versions, working directory, shell, file encoding, locale/timezone,
+OS case-sensitivity, path separators, ordering guarantees, idempotency, what
+happens on re-run, partial-failure / interrupted-midway behaviour,
+concurrency / parallel execution, and which *other* systems read the same
+artifacts and could parse them differently. Each unsurfaced assumption is a
+fragility — name it, and name the condition under which it bites.
+
+## Angle 4 — What-isn't-here reviewer
+
+What's NOT in the diff that should be? Silently undefined corners of the
+contract. Documentation claims with no test, no example, no source backing
+them. Rules stated with an obvious exception the author didn't list.
+Adjacent systems (CI, IDE, pre-commit hooks, generated artifacts, downstream
+consumers, docs, future work) that interact with this change but aren't
+addressed. New code paths with no error handling. The diff is the visible
+iceberg — describe what's under the waterline.
+
+---
+
+## Consuming the four reports (orchestrator)
+
+When all four complete:
+
+1. **Dedupe by location.** The same `path:line` flagged by multiple angles is
+   a strong signal — promote it, don't list it four times.
+2. **Sort by severity**, then by how many angles independently hit it.
+3. **Verify the criticals yourself** before acting — the subagent's summary
+   describes what it intended to find, not necessarily what's true. Open the
+   file, run the check.
+4. **Decide fix-now vs. defer.** Criticals and majors block; mediums/minors
+   can become tracked follow-ups. Honor any explicit "only fix critical
+   stuff" instruction — don't over-correct on speculative findings.
+5. **Report a deduped, severity-sorted summary** to the human. Don't dump
+   four raw reports.
+
+### Optional tuning
+
+- **Fewer/more angles.** Four is the default breadth. For a tiny diff, two
+  (counterfactual + what-isn't-here) often suffice. For a security-sensitive
+  diff, add a fifth dedicated threat-model angle.
+- **Re-review after fixes.** A second pass on the post-fix diff catches
+  regressions introduced by the fixes themselves — but expect sharply
+  diminishing returns after the second round. Stop when a round surfaces only
+  speculative/cosmetic findings.

--- a/skills/veld-launch-feedback-loop/SKILL.md
+++ b/skills/veld-launch-feedback-loop/SKILL.md
@@ -61,6 +61,8 @@ The `item` payload has everything you need in one call:
 |-------|-----|
 | `thread.messages` (last human one) | What to do right now; earlier messages are context |
 | `thread.scope.selector` | CSS selector — grep the codebase for it to find the source |
+| `thread.scope.element_text` | Visible text of the element (middle-truncated) — disambiguates when the selector alone matches several elements |
+| `thread.scope.source_file` / `source_line` | Best-effort file:line of the element's JSX/template tag — jump straight there instead of grepping for the selector. Absent in production builds (and on React 19, which dropped the dev-source metadata this reads) |
 | `thread.component_trace` | React/Vue hierarchy — the **deepest** component is usually the file to edit |
 | `thread.scope.page_url` | Which route |
 | `thread.messages[].screenshot` | Absolute path to a PNG — `Read` it directly |

--- a/skills/veld/reference/feedback.md
+++ b/skills/veld/reference/feedback.md
@@ -99,7 +99,7 @@ usually enough.
 | `messages` (last human one) | What the human wants right now |
 | `scope.selector` | CSS selector — find it in code |
 | `scope.element_text` | Visible text of the element (middle-truncated) — use with the selector when it's ambiguous (e.g. matches several similar elements) |
-| `scope.source_file` / `scope.source_line` | Best-effort file:line of the element's JSX/template tag (React dev builds; Vue gives file only). Absent in production builds — fall back to the selector/component_trace |
+| `scope.source_file` / `scope.source_line` | Best-effort file:line of the element's JSX/template tag (React ≤18 dev builds; Vue gives file only). Absent in production builds, and on React 19+, which dropped the dev-source metadata this reads — fall back to the selector/component_trace |
 | `component_trace` | React/Vue hierarchy, nearest-ancestor-last and capped to ~12 entries — the deepest component is usually the file to edit |
 | `scope.page_url` | Which route |
 | `scope.type` | `element`, `page`, or `global` |

--- a/skills/veld/reference/feedback.md
+++ b/skills/veld/reference/feedback.md
@@ -71,7 +71,10 @@ usually enough.
       "type": "element",
       "page_url": "https://app.dev.veld.localhost/",
       "selector": "header > nav > button.cta",
-      "position": { "x": 120, "y": 40, "width": 96, "height": 32 }
+      "position": { "x": 120, "y": 40, "width": 96, "height": 32 },
+      "element_text": "Get started",
+      "source_file": "src/components/CtaButton.tsx",
+      "source_line": 42
     },
     "component_trace": ["App", "Header", "CtaButton"],
     "viewport_width": 1440,
@@ -95,7 +98,9 @@ usually enough.
 |-------|-----|
 | `messages` (last human one) | What the human wants right now |
 | `scope.selector` | CSS selector — find it in code |
-| `component_trace` | React/Vue hierarchy — the deepest component is usually the file to edit |
+| `scope.element_text` | Visible text of the element (middle-truncated) — use with the selector when it's ambiguous (e.g. matches several similar elements) |
+| `scope.source_file` / `scope.source_line` | Best-effort file:line of the element's JSX/template tag (React dev builds; Vue gives file only). Absent in production builds — fall back to the selector/component_trace |
+| `component_trace` | React/Vue hierarchy, nearest-ancestor-last and capped to ~12 entries — the deepest component is usually the file to edit |
 | `scope.page_url` | Which route |
 | `scope.type` | `element`, `page`, or `global` |
 | `viewport_width/height` | Check for responsive issues |


### PR DESCRIPTION
## Summary

Four real-world usage issues reported against the in-browser feedback overlay:

- **Thread view scroll**: a long agent reply's scroll chained to the host page once it hit the message list's boundary — added `overscroll-behavior: contain`.
- **Reply draft loss**: an agent reply arriving mid-type triggered a full panel re-render that wiped the reply textarea. Now preserves value/selection/focus across the re-render (focus restore reads `refs.shadow.activeElement`, not `document.activeElement`, since focus retargets to the shadow host at the document level — caught in review).
- **Screenshot distortion**: the frozen frame was force-mapped onto the viewport (`background-size: 100% 100%`), stretching it whenever the capture's aspect ratio didn't match the viewport exactly. Switched to `contain` (letterboxed) with the resulting frame rect threaded through drag-select clamping and crop math, recomputed at use-time so a mid-drag resize can't go stale. Also added an explicit instruction banner, a "capture full screen" fallback, and corner brackets + dimmed-outside-selection on the drag rectangle.
- **Noisy component_trace**: agents received the full raw fiber walk (up to 100 entries of framework boilerplate) while the on-screen tooltip only ever showed a trimmed view. Now capped at capture time so every consumer sees the same trace. Also added best-effort element `innerText` (middle-truncated) and source file/line (React `_debugSource` / Vue `__file`) so an ambiguous selector can be disambiguated.

Also fixed the CLI's human-readable `veld feedback` output, which was missing the new `element_text`/`source_file`/`source_line` fields that `--json` already carried.

Reviewed via 8 parallel finder agents (correctness x3, reuse, simplification, efficiency, altitude, conventions) + verification pass; findings applied include the shadow-DOM focus bug above, a stale-frame-on-resize bug, a falsy-zero display bug on `source_line`, and a screenshot-banner pointer-events dead zone.

## Test plan

- [x] `cargo build -p veld-core -p veld-daemon -p veld`
- [x] `cargo test -p veld-core feedback`
- [x] `npm run typecheck` (feedback overlay frontend)
- [x] `npx vitest run` (197/197 passing)
- [x] `npm run build` (esbuild bundle)
- [ ] Manual verification in a real browser (screenshot capture requires `getDisplayMedia` + a user gesture, not exercised headlessly)