### PR TITLE
fix(setup): kill the bootout/bootstrap race that orphaned the helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,6 +368,27 @@ jobs:
           fi
 
           echo ""
+          echo "=== Re-run setup while helper is running (bootout/bootstrap race) ==="
+          # Regression test: re-running privileged setup used to race launchctl
+          # bootout against bootstrap, silently losing the launchd job and
+          # leaving an unmanaged orphan helper that died on the next update.
+          sudo $VELD setup privileged
+          sleep 2
+          if sudo launchctl print system/dev.veld.helper | grep -qE '^[[:space:]]*pid = [1-9]'; then
+            echo "Helper job still registered and running after re-setup"
+          else
+            echo "FAIL: helper launchd job lost after re-running setup"
+            exit 1
+          fi
+          $VELD doctor --json > /tmp/doctor-resetup.json 2>/dev/null || true
+          if grep -q "NOT managed" /tmp/doctor-resetup.json; then
+            echo "FAIL: doctor reports unmanaged helper after re-setup"
+            cat /tmp/doctor-resetup.json
+            exit 1
+          fi
+          echo "Re-setup race check PASSED"
+
+          echo ""
           echo "=== Uninstall (privileged) ==="
           sudo $VELD uninstall || echo "WARNING: uninstall returned non-zero"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,33 @@ jobs:
             sleep 2
           done
 
+          echo ""
+          echo "=== Re-run setup while helper is running (bootout/bootstrap race) ==="
+          # Regression test: re-running privileged setup used to race launchctl
+          # bootout against bootstrap, silently losing the launchd job and
+          # leaving an unmanaged orphan helper that died on the next update.
+          # Stage Caddy in the user lib dir too: later steps (veld start) can
+          # create ~/.local/lib/veld and flip lib_dir() resolution, so keep the
+          # binary present in both candidate paths.
+          mkdir -p "$HOME/.local/lib/veld"
+          cp /tmp/caddy-preserve "$HOME/.local/lib/veld/caddy" 2>/dev/null || true
+          chmod +x "$HOME/.local/lib/veld/caddy" 2>/dev/null || true
+          sudo $VELD setup privileged
+          sleep 2
+          if sudo launchctl print system/dev.veld.helper | grep -qE '^[[:space:]]*pid = [1-9]'; then
+            echo "Helper job still registered and running after re-setup"
+          else
+            echo "FAIL: helper launchd job lost after re-running setup"
+            exit 1
+          fi
+          $VELD doctor --json > /tmp/doctor-resetup.json 2>/dev/null || true
+          if grep -q "NOT managed" /tmp/doctor-resetup.json; then
+            echo "FAIL: doctor reports unmanaged helper after re-setup"
+            cat /tmp/doctor-resetup.json
+            exit 1
+          fi
+          echo "Re-setup race check PASSED"
+
           if [ "$CADDY_OK" = "1" ]; then
             echo "Caddy running (sentinel verified)"
             curl -sf http://localhost:2019/config/apps/http/servers/veld/listen | grep -q '":443"'
@@ -366,27 +393,6 @@ jobs:
           else
             echo "WARNING: Caddy did not start, skipping service tests"
           fi
-
-          echo ""
-          echo "=== Re-run setup while helper is running (bootout/bootstrap race) ==="
-          # Regression test: re-running privileged setup used to race launchctl
-          # bootout against bootstrap, silently losing the launchd job and
-          # leaving an unmanaged orphan helper that died on the next update.
-          sudo $VELD setup privileged
-          sleep 2
-          if sudo launchctl print system/dev.veld.helper | grep -qE '^[[:space:]]*pid = [1-9]'; then
-            echo "Helper job still registered and running after re-setup"
-          else
-            echo "FAIL: helper launchd job lost after re-running setup"
-            exit 1
-          fi
-          $VELD doctor --json > /tmp/doctor-resetup.json 2>/dev/null || true
-          if grep -q "NOT managed" /tmp/doctor-resetup.json; then
-            echo "FAIL: doctor reports unmanaged helper after re-setup"
-            cat /tmp/doctor-resetup.json
-            exit 1
-          fi
-          echo "Re-setup race check PASSED"
 
           echo ""
           echo "=== Uninstall (privileged) ==="

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ Follow this workflow for every feature or fix:
 
 1. **Implement** — Make the code changes.
 2. **Docs audit** — Before considering the work done, check the [documentation checklist](#documentation-checklist) below.
-3. **Self-review rounds** — Use sub-agents to review the diff. Iterate (review → fix → review → fix) until no issues remain. For a non-trivial change (or whenever asked for a deeper look), follow up with the four-angle adversarial review in [docs/agentic-review.md](docs/agentic-review.md) before pushing.
+3. **Review rounds (repeated four-angle)** — Run the four-angle adversarial review in [docs/agentic-review.md](docs/agentic-review.md) on the diff, fix the findings, then repeat the four-angle review on the post-fix diff. Iterate until a round surfaces no critical/major findings. Do not run separate single-reviewer warm-up rounds — the four-angle pass replaces them. (For trivial changes, two angles — counterfactual + what-isn't-here — suffice, per the tuning notes in the review doc.)
 4. **Push to draft PR** — Push the branch and open a draft PR on GitHub.
 5. **Wait for CI** — All checks must be green. Never assume checks are missing just because they haven't started yet.
 6. **Ask before merging** — Ask the maintainer for explicit approval before merging. Only merge with admin bypass if the maintainer explicitly says so upfront at task start.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4135,7 +4135,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "veld"
-version = "8.0.2"
+version = "8.0.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4155,7 +4155,7 @@ dependencies = [
 
 [[package]]
 name = "veld-core"
-version = "8.0.2"
+version = "8.0.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -4177,7 +4177,7 @@ dependencies = [
 
 [[package]]
 name = "veld-daemon"
-version = "8.0.2"
+version = "8.0.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -4199,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "veld-helper"
-version = "8.0.2"
+version = "8.0.3"
 dependencies = [
  "anyhow",
  "nix",

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ Both modes support the full feature set with one difference: unprivileged mode u
 
 To install a specific version: `VELD_VERSION=1.0.0 curl -fsSL https://veld.oss.life.li/get | bash`
 
+In containers or CI images without a working launchd/systemd, `veld setup` fails
+service registration on purpose (an unmanaged helper dies permanently on the next
+update). Set `VELD_ALLOW_UNMANAGED_HELPER=1` to let setup direct-spawn the helper
+anyway — it will not survive reboots or binary updates.
+
 ### Build from source
 
 ```sh

--- a/crates/veld-core/src/setup.rs
+++ b/crates/veld-core/src/setup.rs
@@ -617,6 +617,13 @@ pub async fn install_daemon() -> Result<StepResult, anyhow::Error> {
                 .status()
                 .await;
 
+            // Same bootout/bootstrap race as the helper: bootout returns
+            // before the job is gone, and bootstrapping into that window
+            // fails. Wait for the removal to drain.
+            let _ =
+                wait_for_launchd_job_removal(&domain, label, std::time::Duration::from_secs(10))
+                    .await;
+
             std::fs::write(&plist_path, &plist)
                 .context("failed to write daemon LaunchAgent plist")?;
 
@@ -629,49 +636,34 @@ pub async fn install_daemon() -> Result<StepResult, anyhow::Error> {
                 .status()
                 .await;
 
-            // Load the agent as the real user via `launchctl asuser <uid>`.
-            // This works even when the current process is root.
-            let result = tokio::time::timeout(
-                std::time::Duration::from_secs(15),
-                Command::new("launchctl")
-                    .args([
-                        "asuser",
-                        &real_uid,
-                        "launchctl",
-                        "bootstrap",
-                        &domain,
-                        &plist_path.to_string_lossy(),
-                    ])
-                    .stdin(std::process::Stdio::null())
-                    .status(),
-            )
-            .await;
-            match result {
-                Ok(Ok(status)) if status.success() => {}
-                Ok(Ok(status)) if status.code() == Some(37) => {
-                    // Already loaded — kickstart to restart with new binary.
-                    let _ = Command::new("launchctl")
-                        .args(["kickstart", "-k", &domain_target])
-                        .stdin(std::process::Stdio::null())
-                        .status()
-                        .await;
+            // Load the agent as the real user via `launchctl asuser <uid>`
+            // (works even when the current process is root), with the shared
+            // race-safe choreography: retry-on-drain, kickstart last resort,
+            // legacy `load -w` fallback for sessions without a GUI domain
+            // (CI/SSH). Soft-fail: the daemon is non-critical for setup and
+            // the verification below reports a dead one.
+            match bootstrap_launchd_job(&domain, label, &plist_path, Some(&real_uid), true).await {
+                Ok(BootstrapOutcome::Bootstrapped) | Ok(BootstrapOutcome::LegacyLoaded) => {}
+                Ok(BootstrapOutcome::KickstartedStale) => {
+                    eprintln!(
+                        "  Warning: could not load the new veld-daemon service definition; \
+                         restarted the existing registration instead."
+                    );
                 }
-                _ => {
-                    // bootstrap failed (e.g. no GUI domain in CI/SSH).
-                    // Fall back to `launchctl asuser <uid> launchctl load`.
-                    let _ = Command::new("launchctl")
-                        .args([
-                            "asuser",
-                            &real_uid,
-                            "launchctl",
-                            "load",
-                            "-w",
-                            &plist_path.to_string_lossy(),
-                        ])
-                        .stdin(std::process::Stdio::null())
-                        .status()
-                        .await;
+                Err(e) => {
+                    eprintln!("  Warning: could not register veld-daemon with launchd: {e:#}");
                 }
+            }
+
+            // Soft verification only: CI/SSH sessions have no GUI domain, so a
+            // missing job is expected there — but on a real machine this makes
+            // a silently-dead daemon visible instead of reporting success.
+            if !wait_for_launchd_job_running(&domain, label, std::time::Duration::from_secs(10))
+                .await
+            {
+                eprintln!(
+                    "  Warning: launchd does not report veld-daemon running; run `veld doctor` to check."
+                );
             }
         }
         "linux" => {
@@ -691,6 +683,15 @@ pub async fn install_daemon() -> Result<StepResult, anyhow::Error> {
             // restart to pick up new binary on upgrades.
             let _ = run_cmd("systemctl", &["--user", "restart", "veld-daemon"]).await;
             run_cmd("systemctl", &["--user", "enable", "--now", "veld-daemon"]).await?;
+
+            // Soft verification, mirroring the macOS branch.
+            if !wait_for_systemd_running("veld-daemon", true, std::time::Duration::from_secs(10))
+                .await
+            {
+                eprintln!(
+                    "  Warning: systemd does not report veld-daemon running; run `veld doctor` to check."
+                );
+            }
         }
         other => anyhow::bail!("unsupported OS: {other}"),
     }
@@ -730,47 +731,71 @@ async fn install_helper_inner(
 ) -> Result<StepResult, anyhow::Error> {
     let socket = crate::helper::system_socket_path();
 
-    // Try to register as a system service. If launchctl/systemctl fails
-    // (e.g. in CI), fall back to starting the helper directly.
-    let service_ok = match std::env::consts::OS {
-        "macos" => install_helper_macos(&veld_helper_bin, caddy_bin.as_deref())
-            .await
-            .is_ok(),
-        "linux" => install_helper_linux(&veld_helper_bin, caddy_bin.as_deref())
-            .await
-            .is_ok(),
+    // Register as a system service. No silent direct-spawn fallback here: a
+    // directly-spawned root helper has no service manager behind it, so it
+    // dies permanently on the next binary update or reboot — and it can
+    // split-brain against a registered KeepAlive job that is still starting.
+    // That orphan state is exactly the incident this code path used to cause.
+    // `VELD_ALLOW_UNMANAGED_HELPER=1` restores the old fallback for
+    // environments with no working service manager (e.g. containers).
+    let service_result = match std::env::consts::OS {
+        "macos" => install_helper_macos(&veld_helper_bin, caddy_bin.as_deref()).await,
+        "linux" => install_helper_linux(&veld_helper_bin, caddy_bin.as_deref()).await,
         other => anyhow::bail!("unsupported OS: {other}"),
     };
+    let allow_unmanaged = matches!(
+        std::env::var("VELD_ALLOW_UNMANAGED_HELPER")
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes"
+    );
+    let service_ok = match service_result {
+        Ok(()) => true,
+        Err(e) if allow_unmanaged => {
+            eprintln!("  Warning: service registration failed: {e:#}");
+            eprintln!("  Starting unmanaged helper (VELD_ALLOW_UNMANAGED_HELPER=1).");
+            let _child = std::process::Command::new(&veld_helper_bin)
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+                .context("failed to spawn veld-helper directly")?;
+            false
+        }
+        Err(e) => {
+            return Err(e.context(
+                "veld-helper service registration failed — an unmanaged helper would die \
+                 permanently on the next update, so setup stops here. Re-run `veld setup`; \
+                 set VELD_ALLOW_UNMANAGED_HELPER=1 to force a direct spawn anyway",
+            ));
+        }
+    };
 
-    // Give the service a moment to start.
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-
-    // Check if the helper is reachable.
+    // Wait for the helper (whether launchd/systemd just started it, or the
+    // unmanaged spawn above) to serve its socket. 40×250ms = 10s: the service
+    // manager already confirmed the process is up, so this only covers socket
+    // bind + permission setup, which is near-instant when healthy.
     let client = HelperClient::new(&socket);
-    let helper_up = client.status().await.is_ok();
-
+    let mut helper_up = false;
+    for _ in 0..40 {
+        if client.status().await.is_ok() {
+            helper_up = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
     if !helper_up {
-        // Service registration may have failed or the daemon hasn't started
-        // yet. Start the helper directly as a background process.
-        tracing::info!("helper not reachable via service manager, starting directly");
-        let _child = std::process::Command::new(&veld_helper_bin)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-            .context("failed to spawn veld-helper directly")?;
-
-        // Wait for the socket to appear.
-        for _ in 0..20 {
-            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
-            if client.status().await.is_ok() {
-                break;
-            }
+        if service_ok {
+            anyhow::bail!(
+                "veld-helper service is registered but its socket at {} is not answering",
+                socket.display()
+            );
         }
-
-        if client.status().await.is_err() {
-            anyhow::bail!("veld-helper failed to start — socket not reachable");
-        }
+        anyhow::bail!(
+            "directly-spawned veld-helper did not answer on its socket at {}",
+            socket.display()
+        );
     }
 
     // Start Caddy via the helper (with timeout — Caddy startup waits for
@@ -788,7 +813,7 @@ async fn install_helper_inner(
     let via = if service_ok {
         "service registered and running"
     } else {
-        "started directly (service registration skipped)"
+        "started directly (service registration FAILED — helper will not survive reboots or updates; re-run `veld setup`)"
     };
     Ok(StepResult::success(format!(
         "veld-helper {via}, Caddy started"
@@ -796,8 +821,12 @@ async fn install_helper_inner(
 }
 
 async fn install_helper_macos(bin: &Path, caddy_bin: Option<&Path>) -> Result<(), anyhow::Error> {
-    let plist_path = Path::new("/Library/LaunchDaemons/dev.veld.helper.plist");
-    let label = "dev.veld.helper";
+    let plist_path_buf = PathBuf::from(format!(
+        "/Library/LaunchDaemons/{}",
+        helper_plist_filename()
+    ));
+    let plist_path = plist_path_buf.as_path();
+    let label = HELPER_LABEL_MACOS;
 
     // Build ProgramArguments with optional --caddy-bin.
     let mut program_args = format!("        <string>{}</string>", bin.display());
@@ -831,6 +860,9 @@ async fn install_helper_macos(bin: &Path, caddy_bin: Option<&Path>) -> Result<()
     </array>
     <key>RunAtLoad</key>
     <true/>
+    <!-- KeepAlive must stay unconditionally true: the helper self-updates by
+         exit(0) from its binary watcher and relies on launchd relaunching it.
+         A SuccessfulExit=false variant would leave it dead after every update. -->
     <key>KeepAlive</key>
     <true/>
     <key>WatchPaths</key>
@@ -859,44 +891,366 @@ async fn install_helper_macos(bin: &Path, caddy_bin: Option<&Path>) -> Result<()
         .status()
         .await;
 
+    // `bootout` can return before launchd finishes tearing the job down.
+    // Bootstrapping into that window fails with exit 5, and the kickstart
+    // fallback then targets a registration that is being removed — leaving no
+    // service loaded at all while every error is swallowed. Wait until the job
+    // is actually gone before re-registering.
+    let removed =
+        wait_for_launchd_job_removal("system", label, std::time::Duration::from_secs(10)).await;
+    if !removed {
+        tracing::warn!("old {label} job still registered after bootout; bootstrap may conflict");
+    }
+
     std::fs::write(plist_path, plist).context("failed to write helper LaunchDaemon plist")?;
 
-    // Register and start via the modern `bootstrap` API.
-    let result = tokio::time::timeout(
-        std::time::Duration::from_secs(15),
-        Command::new("launchctl")
-            .args(["bootstrap", "system", &plist_path.to_string_lossy()])
-            .stdin(std::process::Stdio::null())
-            .status(),
-    )
-    .await;
+    match bootstrap_launchd_job("system", label, plist_path, None, false).await? {
+        BootstrapOutcome::Bootstrapped | BootstrapOutcome::LegacyLoaded => {}
+        BootstrapOutcome::KickstartedStale => {
+            // User-visible, not just a trace log: the running job uses the OLD
+            // plist until the next successful setup.
+            eprintln!(
+                "  Warning: could not load the new veld-helper service definition; restarted \
+                 the existing registration instead. Re-run `veld setup privileged` if helper \
+                 settings changed."
+            );
+        }
+    }
 
-    match result {
-        Ok(Ok(status)) if status.success() => Ok(()),
-        Ok(Ok(status)) => {
-            // bootstrap returns 37 if already loaded, or 5 (I/O error) if the
-            // service is still registered from a previous install and the
-            // bootout hasn't fully completed. In both cases, kickstart the
-            // existing service instead.
-            let code = status.code().unwrap_or(-1);
-            if code == 37 || code == 5 {
-                let _ = Command::new("launchctl")
-                    .args(["kickstart", "-k", &format!("system/{label}")])
-                    .stdin(std::process::Stdio::null())
-                    .status()
-                    .await;
-                Ok(())
-            } else {
-                anyhow::bail!("launchctl bootstrap failed for veld-helper (exit {})", code)
+    // Don't trust bootstrap/kickstart exit codes alone: verify launchd actually
+    // has the job registered and running before reporting success. 20s covers
+    // a slow first launch (Gatekeeper verification of the freshly-signed
+    // binary) without stalling setup badly when genuinely broken.
+    if !wait_for_launchd_job_running("system", label, std::time::Duration::from_secs(20)).await {
+        // Registered-but-slow is a transient (launchd will still start it),
+        // and an inconclusive query proves nothing — only a definitive
+        // "no job" is a hard failure.
+        if launchd_job_registered("system", label).await == Some(false) {
+            anyhow::bail!(
+                "veld-helper service was bootstrapped but launchd does not report it running"
+            );
+        }
+        eprintln!(
+            "  Warning: veld-helper is registered but launchd has not reported it running \
+             yet; run `veld doctor` to confirm it came up."
+        );
+    }
+    Ok(())
+}
+
+/// How a launchd job ended up loaded (see [`bootstrap_launchd_job`]).
+#[derive(Debug, PartialEq)]
+pub enum BootstrapOutcome {
+    /// The new plist was bootstrapped cleanly.
+    Bootstrapped,
+    /// The new plist could not be loaded; the pre-existing registration was
+    /// kickstarted instead and may run a STALE service definition.
+    KickstartedStale,
+    /// Registered via legacy `launchctl load -w` (no bootstrap-capable
+    /// domain, e.g. headless CI/SSH sessions).
+    LegacyLoaded,
+}
+
+/// Load-and-start a launchd job from `plist_path` with the full race-safe
+/// choreography this codebase requires: bootstrap → on exit 5/37 re-drain the
+/// old registration and retry (loads the NEW plist) → kickstart the surviving
+/// registration only as a last resort → optionally fall back to legacy
+/// `load -w` for sessions without a bootstrap-capable domain.
+///
+/// Callers must have written the plist and booted out + drained the old job
+/// first (`wait_for_launchd_job_removal`). `asuser_uid` wraps bootstrap/load
+/// in `launchctl asuser <uid>` so a root process can load user-domain agents.
+pub async fn bootstrap_launchd_job(
+    domain: &str,
+    label: &str,
+    plist_path: &Path,
+    asuser_uid: Option<&str>,
+    legacy_load_fallback: bool,
+) -> Result<BootstrapOutcome, anyhow::Error> {
+    let plist_str = plist_path.to_string_lossy().to_string();
+    let bootstrap_args: Vec<String> = match asuser_uid {
+        Some(uid) => vec![
+            "asuser".into(),
+            uid.into(),
+            "launchctl".into(),
+            "bootstrap".into(),
+            domain.into(),
+            plist_str.clone(),
+        ],
+        None => vec!["bootstrap".into(), domain.into(), plist_str.clone()],
+    };
+
+    let mut attempt = 0;
+    loop {
+        attempt += 1;
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(15),
+            Command::new("launchctl")
+                .args(&bootstrap_args)
+                .stdin(std::process::Stdio::null())
+                .status(),
+        )
+        .await;
+
+        let code = match result {
+            Ok(Ok(status)) if status.success() => return Ok(BootstrapOutcome::Bootstrapped),
+            Ok(Ok(status)) => status.code().unwrap_or(-1),
+            Ok(Err(e)) => return Err(e.into()),
+            Err(_) => anyhow::bail!("launchctl bootstrap timed out for {label}"),
+        };
+
+        // 37 = already loaded; 5 = I/O error from a registration still
+        // draining out of launchd. Both can clear once the old job is gone.
+        if (code == 37 || code == 5) && attempt == 1 {
+            let _ = wait_for_launchd_job_removal(domain, label, std::time::Duration::from_secs(5))
+                .await;
+            continue;
+        }
+        if code == 37 || code == 5 {
+            tracing::warn!(
+                "bootstrap still failing (exit {code}) for {label}; kickstarting the existing \
+                 registration (may run a stale plist until the next setup)"
+            );
+            let kick = Command::new("launchctl")
+                .args(["kickstart", "-k", &format!("{domain}/{label}")])
+                .stdin(std::process::Stdio::null())
+                .status()
+                .await;
+            if kick.map(|s| s.success()).unwrap_or(false) {
+                return Ok(BootstrapOutcome::KickstartedStale);
+            }
+            if !legacy_load_fallback {
+                anyhow::bail!(
+                    "launchctl bootstrap failed (exit {code}) and kickstart fallback also failed for {label}"
+                );
+            }
+            // Fall through to legacy load: a missing GUI domain (headless
+            // CI/SSH) also surfaces as exit 5, where kickstart has nothing to
+            // target but `load -w` can still register the agent.
+        }
+
+        // Optionally fall back to legacy `load -w` (headless sessions where
+        // the target domain can't be bootstrapped).
+        if legacy_load_fallback {
+            let load_args: Vec<String> = match asuser_uid {
+                Some(uid) => vec![
+                    "asuser".into(),
+                    uid.into(),
+                    "launchctl".into(),
+                    "load".into(),
+                    "-w".into(),
+                    plist_str.clone(),
+                ],
+                None => vec!["load".into(), "-w".into(), plist_str.clone()],
+            };
+            let load = Command::new("launchctl")
+                .args(&load_args)
+                .stdin(std::process::Stdio::null())
+                .status()
+                .await;
+            if load.map(|s| s.success()).unwrap_or(false) {
+                return Ok(BootstrapOutcome::LegacyLoaded);
             }
         }
-        Ok(Err(e)) => Err(e.into()),
-        Err(_) => anyhow::bail!("launchctl bootstrap timed out for veld-helper"),
+        anyhow::bail!("launchctl bootstrap failed for {label} (exit {code})");
     }
 }
 
+/// Poll `launchctl print <domain>/<label>` until it no longer finds the job
+/// (bootout finished), or the timeout elapses. Returns true if the job is gone.
+pub async fn wait_for_launchd_job_removal(
+    domain: &str,
+    label: &str,
+    timeout: std::time::Duration,
+) -> bool {
+    let start = std::time::Instant::now();
+    loop {
+        // Only a clean "not found" proves removal; a failed/timed-out query
+        // proves nothing, so keep polling until the deadline.
+        if launchd_job_registered(domain, label).await == Some(false) {
+            return true;
+        }
+        if start.elapsed() >= timeout {
+            return false;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+}
+
+/// Whether launchd has a job registered under `domain/label` — `Some(true)`
+/// even for a registered-but-not-running job (contrast [`launchd_job_pid`],
+/// which requires a live pid). `None` means the query itself failed or timed
+/// out ([`SERVICE_QUERY_TIMEOUT`]) and proves nothing — callers must not
+/// treat that as "job absent" (a wedged launchctl would otherwise read as an
+/// orphaned helper).
+pub async fn launchd_job_registered(domain: &str, label: &str) -> Option<bool> {
+    let status = tokio::time::timeout(
+        SERVICE_QUERY_TIMEOUT,
+        Command::new("launchctl")
+            .args(["print", &format!("{domain}/{label}")])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status(),
+    )
+    .await;
+    match status {
+        Ok(Ok(s)) => Some(s.success()),
+        _ => None,
+    }
+}
+
+/// Poll systemd until `service` reports a running MainPID, or the timeout
+/// elapses. `user_unit` selects the `--user` manager.
+pub async fn wait_for_systemd_running(
+    service: &str,
+    user_unit: bool,
+    timeout: std::time::Duration,
+) -> bool {
+    let start = std::time::Instant::now();
+    loop {
+        if systemd_main_pid_in(service, user_unit).await.is_some() {
+            return true;
+        }
+        if start.elapsed() >= timeout {
+            return false;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+}
+
+/// Poll `launchctl print <domain>/<label>` until the job reports a running
+/// pid, or the timeout elapses.
+pub async fn wait_for_launchd_job_running(
+    domain: &str,
+    label: &str,
+    timeout: std::time::Duration,
+) -> bool {
+    let start = std::time::Instant::now();
+    loop {
+        if launchd_job_pid(domain, label).await.is_some() {
+            return true;
+        }
+        if start.elapsed() >= timeout {
+            return false;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+}
+
+/// launchd label of the helper on macOS (system LaunchDaemon in privileged
+/// mode, user LaunchAgent in unprivileged mode). The helper's binary watcher,
+/// doctor's managed-check, the plists, and uninstall all key on this — a
+/// rename must change every consumer atomically or the helper stops
+/// recognising itself as managed and auto-update silently dies. Shell copies
+/// exist in `install.sh` and `.github/workflows/ci.yml`; update those in
+/// lockstep.
+pub const HELPER_LABEL_MACOS: &str = "dev.veld.helper";
+
+/// systemd unit name of the helper on Linux. Same lockstep rules as
+/// [`HELPER_LABEL_MACOS`].
+pub const HELPER_SERVICE_LINUX: &str = "veld-helper";
+
+/// Filename of the helper's launchd plist (shared by the system LaunchDaemon
+/// and user LaunchAgent installs), derived from the label so the two cannot
+/// drift apart.
+pub fn helper_plist_filename() -> String {
+    format!("{HELPER_LABEL_MACOS}.plist")
+}
+
+/// Upper bound on a single launchctl/systemctl query. These are queried from
+/// polling loops, `veld doctor`, and the helper's own binary watcher — a
+/// wedged service manager must degrade to "unknown", never hang the caller.
+pub const SERVICE_QUERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// The MainPID systemd reports for a service, if it exists and is running.
+/// `MainPID=0` means not running. `user_unit` selects `systemctl --user`.
+pub async fn systemd_main_pid(service: &str) -> Option<u32> {
+    systemd_main_pid_in(service, false).await
+}
+
+/// See [`systemd_main_pid`]; `user_unit` selects the `--user` manager.
+pub async fn systemd_main_pid_in(service: &str, user_unit: bool) -> Option<u32> {
+    systemd_pid_query(service, user_unit).await.flatten()
+}
+
+/// Three-state systemd query: `None` = systemctl failed/timed out (proves
+/// nothing), `Some(None)` = query succeeded but the unit is not running
+/// (MainPID=0), `Some(Some(pid))` = running. Callers that need to tell "unit
+/// down" apart from "can't tell" (e.g. doctor's orphan check) must use this
+/// instead of the flattened [`systemd_main_pid_in`].
+pub async fn systemd_pid_query(service: &str, user_unit: bool) -> Option<Option<u32>> {
+    let mut args = vec!["show", "-p", "MainPID", "--value", service];
+    if user_unit {
+        args.insert(0, "--user");
+    }
+    let out = tokio::time::timeout(
+        SERVICE_QUERY_TIMEOUT,
+        Command::new("systemctl")
+            .args(&args)
+            .stdin(std::process::Stdio::null())
+            .output(),
+    )
+    .await
+    .ok()?
+    .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(parse_systemd_main_pid(&String::from_utf8_lossy(
+        &out.stdout,
+    )))
+}
+
+/// Parse `systemctl show -p MainPID --value` output into a running pid.
+/// `0` means the unit exists but is not running.
+pub fn parse_systemd_main_pid(output: &str) -> Option<u32> {
+    output.trim().parse().ok().filter(|&pid: &u32| pid != 0)
+}
+
+/// The pid launchd reports for a job in `domain` (e.g. `system` or
+/// `gui/501`), if the job exists and is running.
+pub async fn launchd_job_pid(domain: &str, label: &str) -> Option<u32> {
+    let out = tokio::time::timeout(
+        SERVICE_QUERY_TIMEOUT,
+        Command::new("launchctl")
+            .args(["print", &format!("{domain}/{label}")])
+            .stdin(std::process::Stdio::null())
+            .output(),
+    )
+    .await
+    .ok()?
+    .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    parse_launchctl_pid(&String::from_utf8_lossy(&out.stdout))
+}
+
+/// The pid launchd reports for a system-domain job, if the job exists and is
+/// running.
+pub async fn macos_job_pid(label: &str) -> Option<u32> {
+    launchd_job_pid("system", label).await
+}
+
+/// Extract the running pid from `launchctl print` output (the `pid = N`
+/// line). A registered-but-not-running job (no pid line, or `pid = 0`) is
+/// `None` — mirrors the `MainPID=0` filter for systemd.
+pub fn parse_launchctl_pid(output: &str) -> Option<u32> {
+    for line in output.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("pid = ") {
+            return rest.trim().parse().ok().filter(|&pid| pid != 0);
+        }
+    }
+    None
+}
+
 async fn install_helper_linux(bin: &Path, caddy_bin: Option<&Path>) -> Result<(), anyhow::Error> {
-    let unit_path = Path::new("/etc/systemd/system/veld-helper.service");
+    let unit_path_buf = PathBuf::from(format!(
+        "/etc/systemd/system/{HELPER_SERVICE_LINUX}.service"
+    ));
+    let unit_path = unit_path_buf.as_path();
     let mut exec_start = bin.display().to_string();
     if let Some(caddy) = caddy_bin {
         exec_start.push_str(&format!(" --caddy-bin {}", caddy.display()));
@@ -914,8 +1268,20 @@ async fn install_helper_linux(bin: &Path, caddy_bin: Option<&Path>) -> Result<()
 
     run_cmd("systemctl", &["daemon-reload"]).await?;
     // restart (not just enable) to pick up new binary on upgrades.
-    let _ = run_cmd("systemctl", &["restart", "veld-helper"]).await;
-    run_cmd("systemctl", &["enable", "--now", "veld-helper"]).await?;
+    let _ = run_cmd("systemctl", &["restart", HELPER_SERVICE_LINUX]).await;
+    run_cmd("systemctl", &["enable", "--now", HELPER_SERVICE_LINUX]).await?;
+
+    // Mirror the macOS path: don't trust exit codes alone, verify systemd
+    // actually reports the service running.
+    if !wait_for_systemd_running(
+        HELPER_SERVICE_LINUX,
+        false,
+        std::time::Duration::from_secs(20),
+    )
+    .await
+    {
+        anyhow::bail!("veld-helper service was enabled but systemd does not report it running");
+    }
     Ok(())
 }
 
@@ -1023,18 +1389,24 @@ pub async fn uninstall() -> Result<(), anyhow::Error> {
     match std::env::consts::OS {
         "macos" => {
             // Stop and remove helper (system daemon).
-            let helper_plist = "/Library/LaunchDaemons/dev.veld.helper.plist";
+            let helper_plist = format!("/Library/LaunchDaemons/{}", helper_plist_filename());
             let _ = Command::new("launchctl")
-                .args(["bootout", "system/dev.veld.helper"])
+                .args(["bootout", &format!("system/{HELPER_LABEL_MACOS}")])
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
                 .status()
                 .await;
-            let _ = std::fs::remove_file(helper_plist);
+            let _ = std::fs::remove_file(&helper_plist);
 
             // Stop and remove daemon (user agent). Use resolve_real_user_macos
             // so uninstall works correctly when running under sudo.
             if let Ok((_user, uid, home)) = resolve_real_user_macos() {
                 let _ = Command::new("launchctl")
                     .args(["bootout", &format!("gui/{uid}/dev.veld.daemon")])
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
                     .status()
                     .await;
                 let daemon_plist = home.join("Library/LaunchAgents/dev.veld.daemon.plist");
@@ -1042,24 +1414,30 @@ pub async fn uninstall() -> Result<(), anyhow::Error> {
 
                 // Stop and remove user-level helper LaunchAgent (unprivileged mode).
                 let _ = Command::new("launchctl")
-                    .args(["bootout", &format!("gui/{uid}/dev.veld.helper")])
+                    .args(["bootout", &format!("gui/{uid}/{HELPER_LABEL_MACOS}")])
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
                     .status()
                     .await;
-                let helper_agent_plist = home.join("Library/LaunchAgents/dev.veld.helper.plist");
+                let helper_agent_plist = home
+                    .join("Library/LaunchAgents")
+                    .join(helper_plist_filename());
                 let _ = std::fs::remove_file(&helper_agent_plist);
             }
         }
         "linux" => {
             // Stop and disable helper (system service).
+            let helper_unit = format!("{HELPER_SERVICE_LINUX}.service");
             let _ = Command::new("systemctl")
-                .args(["stop", "veld-helper"])
+                .args(["stop", HELPER_SERVICE_LINUX])
                 .status()
                 .await;
             let _ = Command::new("systemctl")
-                .args(["disable", "veld-helper"])
+                .args(["disable", HELPER_SERVICE_LINUX])
                 .status()
                 .await;
-            let _ = std::fs::remove_file("/etc/systemd/system/veld-helper.service");
+            let _ = std::fs::remove_file(format!("/etc/systemd/system/{helper_unit}"));
 
             // Stop and disable daemon (user service).
             let _ = Command::new("systemctl")
@@ -1075,14 +1453,15 @@ pub async fn uninstall() -> Result<(), anyhow::Error> {
 
                 // Stop and remove user-level helper service (unprivileged mode).
                 let _ = Command::new("systemctl")
-                    .args(["--user", "stop", "veld-helper"])
+                    .args(["--user", "stop", HELPER_SERVICE_LINUX])
                     .status()
                     .await;
                 let _ = Command::new("systemctl")
-                    .args(["--user", "disable", "veld-helper"])
+                    .args(["--user", "disable", HELPER_SERVICE_LINUX])
                     .status()
                     .await;
-                let _ = std::fs::remove_file(home.join(".config/systemd/user/veld-helper.service"));
+                let _ =
+                    std::fs::remove_file(home.join(format!(".config/systemd/user/{helper_unit}")));
             }
         }
         _ => {}
@@ -1506,4 +1885,55 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), anyhow::Error> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_launchctl_pid, parse_systemd_main_pid};
+
+    #[test]
+    fn launchctl_pid_running_job() {
+        let out = "system/dev.veld.helper = {\n\tactive count = 1\n\tpath = /Library/LaunchDaemons/dev.veld.helper.plist\n\tstate = running\n\n\tprogram = /Users/x/.local/lib/veld/veld-helper\n\tpid = 48490\n\truns = 2\n}\n";
+        assert_eq!(parse_launchctl_pid(out), Some(48490));
+    }
+
+    #[test]
+    fn launchctl_pid_zero_is_not_running() {
+        assert_eq!(parse_launchctl_pid("\tpid = 0\n"), None);
+    }
+
+    #[test]
+    fn launchctl_pid_missing_line_is_not_running() {
+        let out = "system/dev.veld.helper = {\n\tstate = not running\n\tlast exit code = 0\n}\n";
+        assert_eq!(parse_launchctl_pid(out), None);
+    }
+
+    #[test]
+    fn launchctl_pid_garbage_is_none() {
+        assert_eq!(parse_launchctl_pid("pid = abc\n"), None);
+        assert_eq!(parse_launchctl_pid(""), None);
+    }
+
+    #[test]
+    fn launchctl_pid_ignores_other_pid_like_lines() {
+        // "spawn pid" style lines must not match the `pid = ` prefix check.
+        let out = "\tspawn pid = 99\n\tpid = 1234\n";
+        assert_eq!(parse_launchctl_pid(out), Some(1234));
+    }
+
+    #[test]
+    fn systemd_main_pid_running() {
+        assert_eq!(parse_systemd_main_pid("1234\n"), Some(1234));
+    }
+
+    #[test]
+    fn systemd_main_pid_zero_is_not_running() {
+        assert_eq!(parse_systemd_main_pid("0\n"), None);
+    }
+
+    #[test]
+    fn systemd_main_pid_garbage_is_none() {
+        assert_eq!(parse_systemd_main_pid(""), None);
+        assert_eq!(parse_systemd_main_pid("not-a-pid"), None);
+    }
 }

--- a/crates/veld-helper/src/main.rs
+++ b/crates/veld-helper/src/main.rs
@@ -278,6 +278,10 @@ async fn watch_own_binary() {
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     // Consume the immediate first tick so we don't compare against ourselves at t=0.
     interval.tick().await;
+    // Re-warn periodically (not once, not every 10s tick): an operator who
+    // starts tailing the log later must still see the unmanaged-stale state.
+    const REWARN_TICKS: u32 = 60; // ~10 minutes at BINARY_WATCH_INTERVAL
+    let mut ticks_since_warn: u32 = 0;
     loop {
         interval.tick().await;
         let current = binary_signature(&exe);
@@ -287,12 +291,49 @@ async fn watch_own_binary() {
             // don't exit mid-swap.
             tokio::time::sleep(Duration::from_secs(2)).await;
             if binary_signature(&exe) == current {
-                info!(
-                    "helper binary changed on disk — exiting so launchd relaunches the new version"
-                );
-                std::process::exit(0);
+                // Binding the system socket does not prove launchd/systemd is
+                // behind us: a helper spawned directly (e.g. by setup's
+                // fallback path) also binds it, and if that one exits nothing
+                // relaunches it — every URL goes dark until the next
+                // `veld setup`. Only exit when the service manager reports
+                // *this* pid as the managed instance. Keep polling on failure:
+                // the query can fail transiently, and the binary still differs
+                // from baseline, so a later tick gets another chance to exit.
+                if service_manager_owns_us().await {
+                    info!(
+                        "helper binary changed on disk — exiting so launchd relaunches the new version"
+                    );
+                    std::process::exit(0);
+                }
+                if ticks_since_warn == 0 {
+                    warn!(
+                        "helper binary changed on disk, but this helper is not managed by a \
+                         service manager — staying alive on the old binary. Run `veld setup` \
+                         to restart onto the new version."
+                    );
+                }
+                ticks_since_warn = (ticks_since_warn + 1) % REWARN_TICKS;
             }
         }
+    }
+}
+
+/// Whether the SYSTEM-DOMAIN service manager reports *this process* as the
+/// running instance of the veld-helper service. Distinguishes a
+/// launchd/systemd-managed helper (safe to exit — it gets relaunched) from a
+/// directly-spawned orphan that merely bound the same socket (exiting would
+/// leave nothing behind). Queries are bounded inside veld-core
+/// ([`veld_core::setup::SERVICE_QUERY_TIMEOUT`]) and degrade to "not owned" —
+/// the safe direction. NOTE: system domain only (`system/…`, root systemd);
+/// do not copy this for user-domain agents like veld-daemon.
+async fn service_manager_owns_us() -> bool {
+    let own_pid = std::process::id();
+    if cfg!(target_os = "macos") {
+        veld_core::setup::launchd_job_pid("system", veld_core::setup::HELPER_LABEL_MACOS).await
+            == Some(own_pid)
+    } else {
+        veld_core::setup::systemd_main_pid(veld_core::setup::HELPER_SERVICE_LINUX).await
+            == Some(own_pid)
     }
 }
 

--- a/crates/veld/src/commands/doctor.rs
+++ b/crates/veld/src/commands/doctor.rs
@@ -62,6 +62,22 @@ struct Check {
     label: String,
 }
 
+/// The real user's uid — `SUDO_UID` when running under sudo (the services
+/// live in the invoking user's gui domain, not root's), else `id -u`.
+fn current_uid() -> Option<String> {
+    if let Ok(uid) = std::env::var("SUDO_UID") {
+        if !uid.is_empty() {
+            return Some(uid);
+        }
+    }
+    let out = std::process::Command::new("id").arg("-u").output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let uid = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!uid.is_empty()).then_some(uid)
+}
+
 struct Extension {
     name: String,
     status: String,
@@ -248,6 +264,90 @@ impl Diagnostics {
 
     // -- Checks --------------------------------------------------------------
 
+    /// Verify the mode-appropriate helper is actually owned by its service
+    /// manager (launchd/systemd), not an unmanaged direct-spawned process.
+    /// Three-state: pid match → pass; job absent or pid mismatch → fail
+    /// (orphan); query failure/timeout → no check emitted, since a transient
+    /// launchctl/systemctl hiccup must not tell users to redo setup.
+    async fn check_helper_managed(&mut self, privileged: bool) {
+        let socket = if privileged {
+            veld_core::helper::system_socket_path()
+        } else {
+            veld_core::helper::user_socket_path()
+        };
+        let Ok(client) = veld_core::helper::HelperClient::connect_to(&socket).await else {
+            return; // helper down — already reported by the socket check
+        };
+        let Some(socket_pid) = client
+            .status()
+            .await
+            .ok()
+            .and_then(|r| r.data)
+            .and_then(|d| d.get("helper_pid").and_then(|v| v.as_u64()))
+        else {
+            return; // pre-`helper_pid` helper — can't verify
+        };
+
+        let verdict = if cfg!(target_os = "macos") {
+            let label = veld_core::setup::HELPER_LABEL_MACOS;
+            let domain = if privileged {
+                "system".to_string()
+            } else {
+                let Some(uid) = current_uid() else { return };
+                format!("gui/{uid}")
+            };
+            // Job absent is the orphan signal; distinguish it from a wedged
+            // launchctl (query returns None) which proves nothing.
+            match veld_core::setup::launchd_job_pid(&domain, label).await {
+                Some(pid) => Some(pid == socket_pid as u32),
+                // In unprivileged mode "no job in gui/<uid>" is NOT proof of an
+                // orphan: a legacy `load -w` agent (headless-session fallback)
+                // is genuinely managed but invisible to that query. Only the
+                // system domain gives a definitive answer.
+                None if !privileged => None,
+                None => match veld_core::setup::launchd_job_registered(&domain, label).await {
+                    Some(false) => Some(false), // no job at all: unmanaged orphan
+                    // Registered without readable pid, or query failed/timed
+                    // out — inconclusive either way.
+                    Some(true) | None => None,
+                },
+            }
+            .map(|m| (m, "launchd"))
+        } else {
+            // Same three-state on Linux: `systemctl show` succeeding with
+            // MainPID=0 means the unit exists but is NOT running this helper —
+            // orphan. Only a failed/timed-out query is inconclusive.
+            match veld_core::setup::systemd_pid_query(
+                veld_core::setup::HELPER_SERVICE_LINUX,
+                !privileged,
+            )
+            .await
+            {
+                Some(Some(pid)) => Some(pid == socket_pid as u32),
+                Some(None) => Some(false),
+                None => None,
+            }
+            .map(|m| (m, "systemd"))
+        };
+
+        let Some((managed, manager)) = verdict else {
+            return;
+        };
+        let setup_cmd = if privileged {
+            "veld setup privileged"
+        } else {
+            "veld setup unprivileged"
+        };
+        self.checks.push(Check {
+            pass: managed,
+            label: if managed {
+                format!("Helper managed by {manager}")
+            } else {
+                format!("Helper running but NOT managed by {manager} — run `{setup_cmd}`")
+            },
+        });
+    }
+
     async fn gather_checks(&mut self) {
         // 1. Helper socket reachable
         let helper_ok = veld_core::helper::HelperClient::connect().await.is_ok();
@@ -260,11 +360,30 @@ impl Diagnostics {
             },
         });
 
-        // Determine HTTPS port for later checks
-        let https_port: u16 = if let Ok(client) = veld_core::helper::HelperClient::connect().await {
-            client.https_port().await.unwrap_or(18443)
+        // In managed modes, a reachable socket is not enough: a helper spawned
+        // outside launchd/systemd (setup's direct-spawn fallback) serves the
+        // socket fine but nothing relaunches it after a crash, reboot, or binary
+        // update. Catch that state while everything still looks healthy.
+        let mode = super::read_setup_mode();
+        if matches!(mode.as_deref(), Some("privileged") | Some("unprivileged")) {
+            self.check_helper_managed(mode.as_deref() == Some("privileged"))
+                .await;
+        }
+
+        // Determine HTTPS port for later checks. When the helper is down we
+        // can't ask it, so fall back based on the configured mode — privileged
+        // serves on 443; probing 18443 there checks a port nothing should be
+        // listening on and misdiagnoses a healthy Caddy.
+        let mode = super::read_setup_mode();
+        let fallback_port: u16 = if mode.as_deref() == Some("privileged") {
+            443
         } else {
             18443
+        };
+        let https_port: u16 = if let Ok(client) = veld_core::helper::HelperClient::connect().await {
+            client.https_port().await.unwrap_or(fallback_port)
+        } else {
+            fallback_port
         };
 
         // 2. Caddy admin API responds

--- a/crates/veld/src/commands/setup/privileged.rs
+++ b/crates/veld/src/commands/setup/privileged.rs
@@ -90,14 +90,22 @@ pub async fn run(
                 .unwrap_or_default();
             if !uid.is_empty() {
                 let _ = tokio::process::Command::new("launchctl")
-                    .args(["bootout", &format!("gui/{uid}/dev.veld.helper")])
+                    .args([
+                        "bootout",
+                        &format!("gui/{uid}/{}", veld_core::setup::HELPER_LABEL_MACOS),
+                    ])
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
                     .status()
                     .await;
             }
             // Also try to remove the plist file
             if let Ok(sudo_user) = std::env::var("SUDO_USER") {
-                let plist =
-                    format!("/Users/{sudo_user}/Library/LaunchAgents/dev.veld.helper.plist");
+                let plist = format!(
+                    "/Users/{sudo_user}/Library/LaunchAgents/{}",
+                    veld_core::setup::helper_plist_filename()
+                );
                 let _ = std::fs::remove_file(&plist);
             }
         }
@@ -111,7 +119,7 @@ pub async fn run(
                         "systemctl",
                         "--user",
                         "stop",
-                        "veld-helper",
+                        veld_core::setup::HELPER_SERVICE_LINUX,
                     ])
                     .status()
                     .await;
@@ -122,7 +130,7 @@ pub async fn run(
                         "systemctl",
                         "--user",
                         "disable",
-                        "veld-helper",
+                        veld_core::setup::HELPER_SERVICE_LINUX,
                     ])
                     .status()
                     .await;

--- a/crates/veld/src/commands/setup/unprivileged.rs
+++ b/crates/veld/src/commands/setup/unprivileged.rs
@@ -145,7 +145,7 @@ async fn install_unprivileged_helper() -> Result<String, anyhow::Error> {
     let via = if service_ok {
         "service registered and running"
     } else {
-        "started directly (service registration skipped)"
+        "started directly (service registration FAILED — helper will not survive reboots; re-run `veld setup unprivileged`)"
     };
     Ok(format!("veld-helper {via}, Caddy started"))
 }
@@ -158,9 +158,9 @@ async fn install_helper_launchagent(
     let home = dirs::home_dir().context("cannot determine home directory")?;
     let plist_dir = home.join("Library/LaunchAgents");
     std::fs::create_dir_all(&plist_dir).context("failed to create LaunchAgents directory")?;
-    let plist_path = plist_dir.join("dev.veld.helper.plist");
+    let plist_path = plist_dir.join(veld_core::setup::helper_plist_filename());
 
-    let label = "dev.veld.helper";
+    let label = veld_core::setup::HELPER_LABEL_MACOS;
     let plist = format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
@@ -204,39 +204,54 @@ async fn install_helper_launchagent(
         .status()
         .await;
 
-    std::fs::write(&plist_path, &plist).context("failed to write helper LaunchAgent plist")?;
-
-    // Bootstrap the agent in the current user's GUI domain.
-    let result = tokio::time::timeout(
-        std::time::Duration::from_secs(15),
-        Command::new("launchctl")
-            .args(["bootstrap", &domain, &plist_path.to_string_lossy()])
-            .stdin(std::process::Stdio::null())
-            .status(),
+    // Same race as the privileged LaunchDaemon path: bootout returns before
+    // launchd finishes removing the job, and bootstrapping into that window
+    // fails with exit 5. Wait for the removal to drain first.
+    let _ = veld_core::setup::wait_for_launchd_job_removal(
+        &domain,
+        label,
+        std::time::Duration::from_secs(10),
     )
     .await;
 
-    match result {
-        Ok(Ok(status)) if status.success() => Ok(true),
-        Ok(Ok(status)) if status.code() == Some(37) => {
-            // Already loaded — kickstart to restart with new binary.
-            let _ = Command::new("launchctl")
-                .args(["kickstart", "-k", &domain_target])
-                .stdin(std::process::Stdio::null())
-                .status()
-                .await;
-            Ok(true)
+    std::fs::write(&plist_path, &plist).context("failed to write helper LaunchAgent plist")?;
+
+    // Bootstrap the agent in the current user's GUI domain with the shared
+    // race-safe choreography (retry-on-drain, kickstart last resort, legacy
+    // `load -w` fallback for headless sessions).
+    let outcome = match veld_core::setup::bootstrap_launchd_job(
+        &domain,
+        label,
+        &plist_path,
+        None,
+        true,
+    )
+    .await
+    {
+        Ok(o) => o,
+        Err(e) => {
+            tracing::warn!(error = %e, "helper LaunchAgent registration failed");
+            return Ok(false);
         }
-        Ok(Ok(_)) | Ok(Err(_)) | Err(_) => {
-            // bootstrap failed — fall back to legacy `load` command.
-            let load_result = Command::new("launchctl")
-                .args(["load", "-w", &plist_path.to_string_lossy()])
-                .stdin(std::process::Stdio::null())
-                .status()
-                .await;
-            Ok(load_result.is_ok_and(|s| s.success()))
-        }
+    };
+
+    // Legacy `load -w` (headless SSH: no bootstrappable GUI domain) places the
+    // job where a gui/<uid> query may not see it — verifying there would
+    // mislabel a genuinely managed helper as unmanaged. The caller's socket
+    // check still validates it actually serves.
+    if outcome == veld_core::setup::BootstrapOutcome::LegacyLoaded {
+        return Ok(true);
     }
+
+    // Don't trust exit codes alone — confirm launchd reports the agent
+    // running. A false here sends the caller down the direct-spawn fallback,
+    // which is reported to the user as unmanaged.
+    Ok(veld_core::setup::wait_for_launchd_job_running(
+        &domain,
+        label,
+        std::time::Duration::from_secs(20),
+    )
+    .await)
 }
 
 /// Install veld-helper as a systemd user unit (Linux, no sudo needed).

--- a/crates/veld/src/commands/update.rs
+++ b/crates/veld/src/commands/update.rs
@@ -51,6 +51,29 @@ pub async fn run() -> i32 {
             }
 
             output::print_info(&format!("New version available: {current} → {new_version}"));
+
+            // Privileged mode relies on the helper's own binary-change watcher
+            // plus launchd/systemd (KeepAlive + WatchPaths) to bring up the new
+            // version — restarting the root service from here would need sudo.
+            // Both mechanisms require the service to still be REGISTERED. A
+            // merely-unresponsive process behind an intact registration gets
+            // relaunched onto the new binary, so only the job being gone means
+            // the update truly can't self-apply. Check BEFORE installing so
+            // that's reported as the pre-existing problem it is, instead of a
+            // 45-second wait ending in a misleading "did not pick up the new
+            // binary". In unprivileged mode the installer bootstraps the
+            // LaunchAgent itself, so no pre-flight skip there.
+            let helper_dead_privileged = super::read_setup_mode().as_deref() == Some("privileged")
+                && !privileged_helper_serviceable().await;
+            if helper_dead_privileged {
+                output::print_error(
+                    "The veld-helper service is not registered with the service manager. The \
+                     update will install new binaries, but the helper cannot restart itself — \
+                     run `veld setup privileged` afterwards.",
+                    false,
+                );
+            }
+
             output::print_info("Installing update...");
 
             match veld_core::setup::perform_update(&new_version).await {
@@ -58,7 +81,7 @@ pub async fn run() -> i32 {
                     output::print_success(&format!("Updated to {new_version}."));
                     cleanup_stale_binaries();
                     output::print_info("Restarting services with new binaries...");
-                    restart_services(&new_version).await;
+                    restart_services(&new_version, helper_dead_privileged).await;
                     refresh_hammerspoon().await;
                     0
                 }
@@ -189,6 +212,29 @@ fn cleanup_stale_binaries() {
     }
 }
 
+/// Whether the privileged helper can pick up a new binary by itself: either
+/// its socket answers (live helper with a watcher), or the service manager
+/// still has it registered (launchd KeepAlive/WatchPaths or systemd
+/// Restart=always relaunch it onto the new binary even if the process is
+/// transiently down).
+async fn privileged_helper_serviceable() -> bool {
+    let socket = veld_core::helper::system_socket_path();
+    let client = veld_core::helper::HelperClient::new(&socket);
+    if client.status().await.is_ok() {
+        return true;
+    }
+    if cfg!(target_os = "macos") {
+        // Only a definitive "no job" counts as unserviceable — a failed/timed
+        // out query (None) must not scare the user into re-running setup.
+        veld_core::setup::launchd_job_registered("system", veld_core::setup::HELPER_LABEL_MACOS)
+            .await
+            != Some(false)
+    } else {
+        veld_core::setup::systemd_pid_query(veld_core::setup::HELPER_SERVICE_LINUX, false).await
+            != Some(None)
+    }
+}
+
 /// Restart the helper/daemon so they run the newly installed binaries, then
 /// verify the helper actually came back healthy.
 ///
@@ -203,7 +249,7 @@ fn cleanup_stale_binaries() {
 /// compile-time version is the version we updated *from*. Comparing against
 /// that would invert the check (fail on every successful update, pass on a
 /// failed one).
-async fn restart_services(target_version: &str) {
+async fn restart_services(target_version: &str, helper_dead_privileged: bool) {
     let mode = super::read_setup_mode();
 
     // Auto mode has no persistent service: stop the ephemeral helper so the
@@ -218,23 +264,36 @@ async fn restart_services(target_version: &str) {
         return;
     }
 
-    // Verify against the specific socket for this mode — not `connect()` (which
-    // falls through to the user socket and could latch onto a stale auto-helper
-    // while the privileged one is mid-restart).
-    let socket = if mode.as_deref() == Some("privileged") {
-        veld_core::helper::system_socket_path()
-    } else {
-        veld_core::helper::user_socket_path()
-    };
-    output::print_info("Waiting for veld-helper to restart with the new binary...");
-    if wait_for_helper_version(&socket, target_version, std::time::Duration::from_secs(45)).await {
-        output::print_success("veld-helper restarted and healthy.");
-    } else {
+    if helper_dead_privileged {
+        // Already reported before the install; a dead privileged helper has no
+        // watcher and nothing here can restart it without sudo, so waiting 45s
+        // for its version to flip would only produce a second, misleading error.
         output::print_error(
-            "veld-helper did not pick up the new binary automatically. \
-             Run `veld doctor`; if it stays down, re-run `veld setup`.",
+            "Skipping helper restart check — the helper service was not registered before the \
+             update. Run `veld setup privileged` to start it on the new version.",
             false,
         );
+    } else {
+        // Verify against the specific socket for this mode — not `connect()` (which
+        // falls through to the user socket and could latch onto a stale auto-helper
+        // while the privileged one is mid-restart).
+        let socket = if mode.as_deref() == Some("privileged") {
+            veld_core::helper::system_socket_path()
+        } else {
+            veld_core::helper::user_socket_path()
+        };
+        output::print_info("Waiting for veld-helper to restart with the new binary...");
+        if wait_for_helper_version(&socket, target_version, std::time::Duration::from_secs(45))
+            .await
+        {
+            output::print_success("veld-helper restarted and healthy.");
+        } else {
+            output::print_error(
+                "veld-helper did not pick up the new binary automatically. \
+                 Run `veld doctor`; if it stays down, re-run `veld setup`.",
+                false,
+            );
+        }
     }
 
     // The daemon is a user-level service (LaunchAgent / systemd --user) that the

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,12 @@
 # Options (via env vars):
 #   VELD_VERSION=1.0.0    Install a specific version (default: latest)
 #   VELD_INSTALL_DIR=$HOME/.local/bin   Where to put the veld binary
+#
+# Related (read by `veld setup`, not this script):
+#   VELD_ALLOW_UNMANAGED_HELPER=1   Let setup direct-spawn the helper when
+#                                   service registration fails (containers/CI
+#                                   without launchd/systemd). Unmanaged helpers
+#                                   do not survive reboots or binary updates.
 
 set -euo pipefail
 
@@ -393,7 +399,7 @@ if [ "$OS" = "macos" ]; then
         echo "Restarting veld-helper service (privileged)..."
         sudo launchctl kickstart -k system/dev.veld.helper 2>/dev/null || true
       else
-        echo "veld-helper will restart itself to pick up the new binary (no sudo needed)."
+        echo "Privileged veld-helper will restart itself to pick up the new binary (no sudo needed)."
       fi
     fi
   elif [ -z "$SWITCHING_TO_USER_PATHS" ]; then


### PR DESCRIPTION
## The real bug (forensics, not speculation)

The 8.0.2→8.0.3 update failure was **not** the updater. Timeline recovered from `veld-helper.log` + shell history on the affected machine:

1. **Yesterday's update worked**: the helper's binary watcher fired and launchd relaunched 8.0.2 within 1s (`22:17:27` exit → `22:17:28` new version listening).
2. **21 seconds later, `veld setup privileged` killed it**: `launchctl bootout` SIGTERMed the healthy helper (`22:17:49`, the last log line for 16 hours), `bootstrap` raced the still-draining removal (exit 5), and the `kickstart -k` fallback targeted a half-removed job — leaving **no launchd job**, with every error swallowed by `let _`.
3. **The direct-spawn fallback masked it**: setup spawned an unmanaged root orphan helper (stdio → /dev/null), the socket answered, setup printed ✓, doctor passed.
4. **Today's update killed the orphan**: its watcher `exit(0)`'d expecting launchd to relaunch it. Nothing manages an orphan. URLs dark until manual setup.

Same command — arsonist yesterday, firefighter today (it worked the second time only because nothing was running, so there was no race).

## Fixes

- **Shared race-safe launchd choreography** (`bootstrap_launchd_job`): drain bootout before bootstrapping, retry bootstrap (loads the NEW plist), kickstart only as a last resort (surfaced to the user as potentially stale), legacy `load -w` for headless sessions. Used by system helper, LaunchAgent helper, and daemon installs.
- **Post-install verification**: launchd pid / systemd MainPID must confirm the job is running before setup reports success (Linux helper install verifies too).
- **Watcher exit-guard**: the helper only `exit(0)`s on binary change when the service manager reports *its own pid* as the managed instance; an unmanaged helper stays alive on the old binary and warns every ~10 min.
- **No silent orphan factory**: system-helper registration failure now fails setup loudly. `VELD_ALLOW_UNMANAGED_HELPER=1` restores direct-spawn for containers/CI (documented in README + install.sh header).
- **Update pre-flight**: a helper whose service registration is gone is reported *before* installing, instead of a misleading 45s wait. A merely-unresponsive process behind an intact registration still gets the normal wait (KeepAlive/WatchPaths revive it).
- **Doctor**: new three-state `Helper managed by launchd/systemd` check (pass / orphan / inconclusive-skip) for both modes and OSes — would have caught yesterday's trap state while everything looked healthy. HTTPS-port fallback is 443 in privileged mode (was hardcoded 18443).
- **Consts + tests + CI**: service names/plist paths via shared consts; pid parsers extracted and unit-tested (8 tests); CI now re-runs privileged setup while the helper is live and asserts the launchd job survives + doctor reports managed.

## Review

Repeated four-angle adversarial review (per updated AGENTS.md): R1 (7 majors fixed), R2 (6 majors fixed, incl. Linux orphan-detection no-op and shared-choreography extraction), R3 delta (both angles "ship it"; 3 consistency minors fixed).

## Consciously deferred (follow-ups)

- flock against concurrent `veld setup`/`veld update` (the in-run race is fixed; only simultaneous invocations remain)
- `veld doctor --fix` auto-heal (re-running setup already recovers an orphan; the new managed helper steals the stale socket cleanly)
- Users already orphaned on ≤8.0.3 are routed to `veld setup privileged` by the existing update error message; nothing auto-heals them on update.

## Note for CI

The silent direct-spawn fallback is gone, so the macOS privileged lifecycle job now genuinely depends on system-domain `launchctl bootstrap` succeeding on the runner — if it was ever silently falling back before, this run will show it.