### PR TITLE
fix(feedback): keep theme attribute off host <html> to stop React hydration mismatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4135,7 +4135,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "veld"
-version = "8.0.3"
+version = "8.0.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4155,7 +4155,7 @@ dependencies = [
 
 [[package]]
 name = "veld-core"
-version = "8.0.3"
+version = "8.0.4"
 dependencies = [
  "anyhow",
  "base64",
@@ -4177,7 +4177,7 @@ dependencies = [
 
 [[package]]
 name = "veld-daemon"
-version = "8.0.3"
+version = "8.0.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -4199,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "veld-helper"
-version = "8.0.3"
+version = "8.0.4"
 dependencies = [
  "anyhow",
  "nix",

--- a/crates/veld-daemon/frontend/src/feedback-overlay/dom.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/dom.ts
@@ -18,22 +18,32 @@ export function buildDOM(): void {
 
   // Light DOM elements
 
+  // Light-DOM root wrapper. Everything below is appended here instead of
+  // straight to <body>, and this element (not <html>) carries the theme
+  // attribute. `display:contents` means it creates no box and no containing
+  // block, so its fixed/absolute-positioned children behave exactly as if
+  // they were direct <body> children — but the host app's SSR-owned
+  // <html>/<body> stay untouched, so React never sees a hydration mismatch.
+  refs.lightRoot = mkEl("div", "light-root");
+  refs.lightRoot.style.cssText = "display:contents";
+  appendGuarded(document.body, refs.lightRoot);
+
   // The frozen frame itself (light DOM, sits just below the overlay). Drawn
   // as an inset, bordered/shadowed "photo card" — never edge-to-edge — so a
   // capture whose content happens to match the live page 1:1 still reads
   // unmistakably as "you're looking at a frozen image now", not the page.
   refs.screenshotFrame = mkEl("img", "screenshot-frame") as HTMLImageElement;
-  appendGuarded(document.body, refs.screenshotFrame);
+  appendGuarded(refs.lightRoot, refs.screenshotFrame);
 
   refs.overlay = mkEl("div", "overlay");
-  appendGuarded(document.body, refs.overlay);
+  appendGuarded(refs.lightRoot, refs.overlay);
   initBackdropEvents();
 
   refs.hoverOutline = mkEl("div", "hover-outline");
-  appendGuarded(document.body, refs.hoverOutline);
+  appendGuarded(refs.lightRoot, refs.hoverOutline);
 
   refs.componentTraceEl = mkEl("div", "component-trace");
-  appendGuarded(document.body, refs.componentTraceEl);
+  appendGuarded(refs.lightRoot, refs.componentTraceEl);
 
   // Screenshot selection rectangle (light DOM) — drawn on the backdrop.
   // Four corner brackets give it the "viewfinder" look asked for instead of
@@ -43,7 +53,7 @@ export function buildDOM(): void {
   (["tl", "tr", "bl", "br"] as const).forEach((corner) => {
     refs.screenshotRect.appendChild(mkEl("span", "screenshot-corner screenshot-corner-" + corner));
   });
-  appendGuarded(document.body, refs.screenshotRect);
+  appendGuarded(refs.lightRoot, refs.screenshotRect);
 
   // Screenshot mode instruction banner (light DOM) — explicit, always-visible
   // guidance instead of a single toast that scrolls off. Doubles as the
@@ -60,7 +70,7 @@ export function buildDOM(): void {
   });
   refs.screenshotBanner.appendChild(refs.screenshotFullBtn);
   refs.screenshotBanner.appendChild(mkEl("span", "screenshot-banner-hint", "Esc to cancel"));
-  appendGuarded(document.body, refs.screenshotBanner);
+  appendGuarded(refs.lightRoot, refs.screenshotBanner);
 
   // Float container (shadow DOM) — anchor for the arc-menu engine. Zero-size,
   // translated to the bubble center; the engine builds its goo/glow/icon layers
@@ -94,12 +104,14 @@ export function buildDOM(): void {
   const toolBtnDashboard = makeToolBtn("dashboard", ICONS.dashboard);
   refs.toolBtnHide = makeToolBtn("hide", ICONS.eyeOff);
 
-  // Reflect the current theme on the icon + host, and persist it.
+  // Reflect the current theme on the icon + host, and persist it. The theme
+  // attribute goes on our own light-DOM root, never on <html> — mutating the
+  // app's SSR-owned <html> triggers a React hydration mismatch.
   function applyTheme(): void {
     const theme = getState().theme;
     toolBtnTheme.innerHTML = THEME_ICONS[theme];
     refs.hostEl.setAttribute("data-theme", theme);
-    document.documentElement.setAttribute("data-veld-theme", theme === "auto" ? "" : theme);
+    refs.lightRoot.setAttribute("data-veld-theme", theme === "auto" ? "" : theme);
     try { localStorage.setItem("veld-theme", theme); } catch (_) { /* ignore */ }
   }
 

--- a/crates/veld-daemon/frontend/src/feedback-overlay/pins.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/pins.ts
@@ -8,6 +8,7 @@ import {
   hasUnread,
 } from "./helpers";
 import { PREFIX, ICONS } from "./constants";
+import { refs } from "./refs";
 import { deps } from "../shared/registry";
 import type { Thread } from "./types";
 
@@ -51,7 +52,7 @@ export function addPin(thread: Thread): void {
     deps().openThreadInPanel(thread.id);
   });
 
-  const disconnect = appendGuarded(document.body, pin);
+  const disconnect = appendGuarded(refs.lightRoot, pin);
   guards.set(thread.id, disconnect);
   dispatch({ type: "SET_PIN", threadId: thread.id, el: pin });
 }

--- a/crates/veld-daemon/frontend/src/feedback-overlay/refs.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/refs.ts
@@ -23,6 +23,12 @@ export interface DOMRefs {
   moreBtn: HTMLElement;
 
   // Light DOM
+  /** Light-DOM root wrapper (display:contents). All light-DOM overlay
+   *  elements are appended here rather than straight to <body>, and it
+   *  carries the `data-veld-theme` attribute. Keeping the attribute off the
+   *  host page's <html>/<body> avoids React hydration mismatches (those
+   *  elements are owned by the app's SSR tree). */
+  lightRoot: HTMLElement;
   overlay: HTMLElement;
   hoverOutline: HTMLElement;
   componentTraceEl: HTMLElement;
@@ -67,6 +73,7 @@ export function initRefs(shadow: ShadowRoot, hostEl: HTMLElement): void {
     radialButtons: [],
     overflowButtons: [],
     moreBtn: null!,
+    lightRoot: null!,
     overlay: null!,
     hoverOutline: null!,
     componentTraceEl: null!,

--- a/crates/veld-daemon/frontend/src/feedback-overlay/styles.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/styles.ts
@@ -28,7 +28,7 @@ export const LIGHT_CSS = `
     --vfl-border: #d4d4d8;
   }
 }
-:root[data-veld-theme="dark"] {
+.veld-feedback-light-root[data-veld-theme="dark"] {
   --vfl-bg: #0a0a0a;
   --vfl-bg-card: #1e1e24;
   --vfl-text: #f1f5f9;
@@ -37,7 +37,7 @@ export const LIGHT_CSS = `
   --vfl-danger: #ef4444;
   --vfl-border: #2a2a30;
 }
-:root[data-veld-theme="light"] {
+.veld-feedback-light-root[data-veld-theme="light"] {
   --vfl-bg: #f8f8fa;
   --vfl-bg-card: #eeeef2;
   --vfl-text: #1a1a2e;

--- a/crates/veld-daemon/frontend/tests/build-dom.test.ts
+++ b/crates/veld-daemon/frontend/tests/build-dom.test.ts
@@ -27,7 +27,8 @@ describe("buildDOM", () => {
     const required = [
       "toolbarContainer", "fab", "fabBadge", "toolbar", "toolBtnSelect",
       "toolBtnScreenshot", "toolBtnPageComment", "toolBtnComments",
-      "toolBtnHide", "toolbarOverflow", "listeningModule", "moreBtn", "overlay",
+      "toolBtnHide", "toolbarOverflow", "listeningModule", "moreBtn", "lightRoot",
+      "overlay",
       "hoverOutline", "componentTraceEl", "screenshotRect", "panel", "panelBody",
       "panelHeadTitle", "panelBackBtn", "markReadBtn", "segBtnActive",
       "segBtnResolved", "tooltip",
@@ -37,6 +38,24 @@ describe("buildDOM", () => {
     }
     expect(refs.radialButtons.length).toBeGreaterThan(0);
     expect(refs.overflowButtons.length).toBeGreaterThan(0);
+  });
+
+  it("puts the theme attribute on lightRoot, never on <html>", () => {
+    // Regression guard: setting data-veld-theme on document.documentElement
+    // mutated the host app's SSR-owned <html>, causing React hydration
+    // mismatches in Next.js. The attribute must live on our own light root.
+    buildDOM();
+    expect(refs.lightRoot.hasAttribute("data-veld-theme")).toBe(true);
+    expect(document.documentElement.hasAttribute("data-veld-theme")).toBe(false);
+  });
+
+  it("re-parents light-DOM elements under lightRoot, not straight into <body>", () => {
+    buildDOM();
+    // Theme override CSS scopes to `.veld-feedback-light-root[data-veld-theme]`,
+    // so themed light elements must inherit through lightRoot.
+    expect(refs.overlay.parentElement).toBe(refs.lightRoot);
+    expect(refs.screenshotBanner.parentElement).toBe(refs.lightRoot);
+    expect(refs.componentTraceEl.parentElement).toBe(refs.lightRoot);
   });
 
   it("screenshot mode teardown does not throw", async () => {

--- a/crates/veld-daemon/frontend/tests/test-helpers.ts
+++ b/crates/veld-daemon/frontend/tests/test-helpers.ts
@@ -88,6 +88,9 @@ export function setupMockRefs() {
   refs.listeningModule = document.createElement("div");
 
   // Set up light DOM refs
+  refs.lightRoot = document.createElement("div");
+  refs.lightRoot.style.cssText = "display:contents";
+  document.body.appendChild(refs.lightRoot);
   refs.overlay = document.createElement("div");
   refs.hoverOutline = document.createElement("div");
   refs.componentTraceEl = document.createElement("div");

--- a/crates/veld-daemon/frontend/tests/wiring.test.ts
+++ b/crates/veld-daemon/frontend/tests/wiring.test.ts
@@ -44,6 +44,9 @@ function setupState() {
   // Create minimal DOM refs that modules expect
   refs.toolbarContainer = document.createElement("div");
   refs.toolbar = document.createElement("div");
+  refs.lightRoot = document.createElement("div");
+  refs.lightRoot.style.cssText = "display:contents";
+  document.body.appendChild(refs.lightRoot);
   refs.overlay = document.createElement("div");
   refs.hoverOutline = document.createElement("div");
   refs.componentTraceEl = document.createElement("div");

--- a/crates/veld-daemon/src/gc.rs
+++ b/crates/veld-daemon/src/gc.rs
@@ -72,7 +72,7 @@ pub async fn run_gc() -> anyhow::Result<GcSummary> {
     let mut registry_changed = false;
 
     // Phase 1: Process each project's runs -- remove stale entries and kill orphans.
-    for (_project_path, reg_entry) in registry.projects.iter_mut() {
+    for reg_entry in registry.projects.values_mut() {
         let project_root = reg_entry.project_root.clone();
 
         let mut project_state = match ProjectState::load(&project_root) {

--- a/crates/veld/src/commands/feedback.rs
+++ b/crates/veld/src/commands/feedback.rs
@@ -470,7 +470,7 @@ async fn run_ask(name: Option<String>, page: Option<&str>, body: &str) -> i32 {
         return 1;
     }
 
-    output::print_info(&format!("Created thread {} — question posted.", &thread.id));
+    output::print_info(&format!("Created thread {} — question posted.", thread.id));
     0
 }
 
@@ -611,7 +611,7 @@ fn print_thread_context(thread: &Thread, store: &FeedbackStore) {
     }
     println!(
         "  Thread: {} ({} message(s), {})",
-        &thread.id,
+        thread.id,
         thread.messages.len(),
         if thread.status == ThreadStatus::Open {
             "open"
@@ -679,7 +679,7 @@ fn print_thread(thread: &Thread) {
     println!(
         "{} {} [{}] (by {}, {} message(s))",
         output::bold("Thread"),
-        &thread.id,
+        thread.id,
         status,
         origin,
         thread.messages.len(),


### PR DESCRIPTION
## Problem

In a Next.js project the feedback overlay triggered:

> A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. ... `data-veld-theme`

The overlay's `applyTheme()` set `data-veld-theme` on `document.documentElement` at boot. In Next.js app-router (and any SSR framework), `<html>`/`<body>` are owned by the app's hydrated React tree. Mutating `<html>` before/around hydration makes React see an attribute its render didn't produce → mismatch on `<html>` in `RootLayout`.

## Fix

Move the theme attribute off the host page's `<html>` onto a **veld-owned light-DOM root**:

- New `<div class="veld-feedback-light-root" style="display:contents">`, appended to `body` via `appendGuarded` (same self-healing pattern already used for the shadow host).
- All light-DOM overlay elements (frame, overlay, hover-outline, component-trace, screenshot-rect, banner) and pins now parent into it instead of straight into `body`.
- `applyTheme()` sets `data-veld-theme` on this wrapper, never on `<html>`.
- Theme-override CSS selectors move `:root[data-veld-theme=…]` → `.veld-feedback-light-root[data-veld-theme=…]`.

`display:contents` creates no box and no containing block, so fixed/absolute children position exactly as before; CSS custom properties still inherit through the wrapper. The app's SSR-owned `<html>`/`<body>` are never touched.

## Testing

- `npm run typecheck` clean
- `npm test` — 214/214 pass (2 new regression tests: attribute lands on `lightRoot` not `<html>`; light elements re-parent under `lightRoot`)
- `npm run build` clean

## Review

Four-angle adversarial review (counterfactual / what's-missing / assumption / persona) run on the diff — no critical/major findings on the fix. Test-hardening findings applied.

## Known, out of scope

`panel.ts` dock mode sets an inline `margin` on `<html>` to push page content aside. Same class of `<html>` mutation, but it's user-gesture-driven and therefore always post-hydration, so it does not fire the hydration error. Left as-is (moving it would break the reflow feature).