### PR TITLE
feat(sharing)!: declarative relay policy + per-service opt-in (Sharing v2, increment 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4135,7 +4135,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "veld"
-version = "8.0.4"
+version = "8.0.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4155,7 +4155,7 @@ dependencies = [
 
 [[package]]
 name = "veld-core"
-version = "8.0.4"
+version = "8.0.5"
 dependencies = [
  "anyhow",
  "base64",
@@ -4177,7 +4177,7 @@ dependencies = [
 
 [[package]]
 name = "veld-daemon"
-version = "8.0.4"
+version = "8.0.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -4199,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "veld-helper"
-version = "8.0.4"
+version = "8.0.5"
 dependencies = [
  "anyhow",
  "nix",

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ No port numbers. No manual wiring. Just clean, stable, human-readable URLs.
 - **Browser dashboard** — management UI at `https://veld.localhost` with service health, logs, search, stop/restart
 - **Client-side logs** — captures browser `console.log/warn/error`, exceptions, and promise rejections; view with `veld logs --source client`
 - **Internal logs** — liveness probe outcomes (with stderr), recovery decisions, health state transitions; view with `veld logs --source internal`
-- **Peer-to-peer sharing** — share a running environment with a colleague over an encrypted P2P tunnel (`veld share`); they open the same URLs on their own machine. No accounts, no Veld-hosted server.
+- **Peer-to-peer sharing** — share a running environment with a colleague over an encrypted P2P tunnel (`veld share`); they open the same URLs on their own machine. Services opt in explicitly in config, and relays are configurable (public or self-hosted) for compliance. No accounts, no Veld-hosted server.
 
 ## Install
 
@@ -313,6 +313,21 @@ Check extension status with `veld doctor`.
 
 Share a running environment with a colleague so they open the **same** URLs on their own machine, over an encrypted peer-to-peer tunnel (iroh: QUIC with NAT hole-punching and an n0 relay fallback). No accounts, no Veld-hosted server.
 
+**Services must opt in.** A service is shareable only if its variant declares `share.expose` in `veld.json` — `veld share` refuses to expose anything that hasn't. This makes what leaves your machine explicit and auditable:
+
+```json
+{
+  "sharing": { "relays": "public" },
+  "nodes": {
+    "frontend": {
+      "variants": {
+        "local": { "type": "start_server", "command": "npm run dev", "share": { "expose": ["peer"] } }
+      }
+    }
+  }
+}
+```
+
 ```sh
 veld share my-feature        # prints a join URL to send (plus a veld join command)
 ```
@@ -329,7 +344,11 @@ Two gates protect a share: a capability token embedded in the ticket, plus host 
 - **`first`** (default with `--json`) — auto-approves and pins the first token-valid joiner, rejecting the rest
 - **`auto`** — approves any token-valid joiner
 
-Traffic is end-to-end encrypted between the two velds; a relay only forwards sealed bytes and never sees your URLs or content. To use your own iroh-relay instead of n0's public relays, set `VELD_SHARE_RELAY=<https url>` on the daemon.
+Traffic is end-to-end encrypted between the two velds; a relay only forwards sealed bytes and never sees your URLs or content. Relay selection is a config-level compliance control and **must be opted into explicitly** — there is no implicit default, so nothing is ever routed over n0's public relays by accident. Set `sharing.relays` to `"public"` (n0's public relays) or to an array of self-hosted relay URLs to confine share traffic to relays you run (a single Docker container). `veld share` refuses to share a run whose config sets no relay. Config wins over the legacy `VELD_SHARE_RELAY` env var — which is read from the daemon's environment, not your shell, and is not an enforceable floor (a project setting `"relays": "public"` overrides it). The custom-relay guarantee covers the **host's** outbound leg; a consumer joining over the same self-hosted relays should configure them too (or set the env var on their daemon). The daemon binds **one iroh endpoint per relay policy** on demand, so shares on different relays (e.g. one project on public, another on your private relay) run side by side — no conflict, no restart.
+
+`share.expose` is a list of audiences. `peer` (Veld-to-Veld, described here) reproduces the origin URL verbatim. `web` (public browser access via a self-hosted gateway, configured with `sharing.gateway`) is reserved — the gateway ships in a later release; today only `peer` is served.
+
+> **Upgrading:** opt-in is a behavior change. Before, `veld share` exposed every URL-bearing service in a run; now it shares only services whose variant declares `share.expose`, and errors (naming the candidates) if none have opted in. Add `"share": { "expose": ["peer"] }` to the variants you previously relied on sharing.
 
 If the consumer already runs the same environment, the local URL wins — that node is skipped and reported as a warning. Shares live in the daemon's memory: if the daemon stops, shares stop (fail-closed). Stopping the run (`veld stop`) also auto-unshares its shares, and the consumer's join self-tears-down when the tunnel closes. `veld unshare` and `veld leave` take the id optionally, resolving the sole active share/join when omitted. Default TTL is 7200s.
 

--- a/SHARING_V2.md
+++ b/SHARING_V2.md
@@ -1,0 +1,302 @@
+# Sharing v2 — Declarative policy + public web sharing
+
+Status: **Draft RFC** · Owner: Peter · Branch: `sharing-level-two`
+
+This RFC extends Veld's peer-to-peer sharing in two directions:
+
+1. **Declarative, compliant sharing** — relay policy and per-service opt-in move
+   into `veld.json`, so an environment can only ever share what it explicitly
+   allows, over relays the org controls.
+2. **Public web sharing** — a way to expose a shared service to someone who does
+   **not** run Veld (a designer, a coworker, a stakeholder) via a real public
+   URL.
+
+It deliberately keeps these as separate, independently shippable increments.
+
+---
+
+## 1. Where we are today
+
+Sharing is entirely **runtime and imperative**. There is no config surface.
+
+| Concern | Today | File |
+|---|---|---|
+| Relay | n0's **public** relays via `presets::N0`; single override via env `VELD_SHARE_RELAY` | `crates/veld-daemon/src/share/endpoint.rs:63,67-73` |
+| Service selection | `veld share` mints a manifest of **every** URL-bearing node in the run; only runtime `--node` filters it | `crates/veld-daemon/src/share/api.rs:213-237` |
+| Opt-in | **None.** No config flag marks a service shareable | `crates/veld-core/src/config.rs` (no share fields) |
+| URL fidelity | Host ships the **literal** hostname; consumer reproduces the exact URL via Caddy + DNS | `crates/veld-core/src/share.rs:29-45`, `crates/veld-daemon/src/share/manager.rs:405-418` |
+| Audience | **veld ↔ veld only** | — |
+| Access control | Capability bearer token + `ApprovalMode {First, Manual, Auto}` | `crates/veld-core/src/share.rs:16-24,70-95` |
+
+**The load-bearing property:** peer sharing reproduces the origin's hostname
+*verbatim* on the consumer. Redirects, cookies, CORS, and OAuth redirect URIs
+all keep working — precisely because both peers run identical Veld setup
+(same scheme, same port, same fake TLD). Every design decision below is measured
+against whether it preserves or breaks this.
+
+## 2. Goals / non-goals
+
+**Goals**
+- Relay policy is declared in config: `public`, or an explicit list of
+  self-hosted iroh relay URLs. Multi-relay.
+- A service is shareable **only** if config marks it so. `veld share` refuses
+  anything not opted in. This is the compliance story.
+- A shared service can optionally be reachable from a plain browser with no Veld
+  installed, via a real public URL.
+- A Veld user can trivially copy the public URL for what they're looking at
+  (host swapped, path + query preserved) from the overlay toolbar.
+
+**Non-goals (this RFC)**
+- Replacing the capability/approval security model — it stays.
+- Guaranteeing full URL fidelity for public web sharing — `web` rewrites the
+  host; matching the domain to the app is the **operator's** responsibility (§5).
+- Shipping a browser-native iroh viewer (§7 — spike only).
+
+## 3. Config design
+
+Two axes, deliberately **not** conflated: *relay policy* (environment-wide) and
+*shareability* (per service).
+
+### 3.1 Relay policy — central block
+
+```jsonc
+{
+  "sharing": {
+    // Required to share — no implicit default. "public" or a list of relay URLs.
+    "relays": "public",
+    // "relays": ["https://relay.acme.internal", "https://relay2.acme.internal"],
+
+    // Public web gateway this environment points at (only needed for expose: web).
+    "gateway": "https://share.acme.internal"
+  }
+}
+```
+
+- **Explicit opt-in required.** There is no implicit default: `veld share` is
+  refused unless a relay is chosen (config, or the `VELD_SHARE_RELAY` env). This
+  is deliberate — nothing is ever routed over n0's public relays by accident;
+  even public must be named (`"relays": "public"`).
+- `"public"` → `presets::N0`. A list → `RelayMode::custom([...])` with **all**
+  listed relays.
+- `VELD_SHARE_RELAY` remains an override for ad-hoc/testing; config wins when
+  both are present.
+- Asymmetry: the explicit-opt-in requirement applies to **hosting** (`veld
+  share`). The **join** path has no project config and defaults to public (or
+  the env relay) so a bare `veld join <ticket>` keeps working — joining consumes,
+  it doesn't expose.
+
+Self-hosting an iroh relay is a single Docker container, so the compliance ask
+("no traffic through n0's public relays") is cheap to satisfy.
+
+### 3.2 Shareability — per-variant `share` block
+
+Co-located on the variant, matching where `probes` / `recovery` already live.
+**Absence means the service can never be shared.**
+
+```jsonc
+{
+  "nodes": {
+    "frontend": {
+      "variants": {
+        "local": {
+          "share": { "expose": ["peer"] }        // veld ↔ veld, verbatim URL (strong)
+        }
+      }
+    },
+    "api": {
+      "variants": {
+        "local": {
+          "share": { "expose": ["peer", "web"] }  // both audiences at once
+        }
+      }
+    }
+  }
+}
+```
+
+`expose` values:
+
+| Value | Audience | URL fidelity | Mechanism |
+|---|---|---|---|
+| `peer` | Other Veld users | **Verbatim** — exact origin URL reproduced | Today's iroh peer + Caddy/DNS reproduction |
+| `web` | Anyone with a browser | **Best-effort** — rewritten host (see §5) | Public gateway server |
+
+Naming rationale: `peer` vs `web` names the *mechanism and reach*, and — unlike
+`private`/`public` — signals that `web` is a weaker guarantee, so users don't
+expect peer-grade fidelity and get burned.
+
+`expose` is a **list** so one service can serve both a Veld coworker (`peer`)
+and a non-Veld stakeholder (`web`) at once, without re-config to switch
+audiences. Empty list / absent `share` = not shareable.
+
+### 3.3 Enforcement
+
+`build_manifest` (`api.rs:213-237`) changes from "every URL-bearing node" to
+"every node whose active variant has a `share` block permitting the requested
+mode." `veld share` on a service with no `share` block is a hard error with a
+message pointing at the config field. The runtime `--node` filter still narrows
+*within* the opted-in set; it can never widen it.
+
+## 4. Relay wiring change
+
+`bind_endpoint` (`endpoint.rs:62-76`) takes relay policy from resolved config
+instead of reading a single env var:
+
+- `"public"` → `presets::N0` (unchanged).
+- list → `RelayMode::custom([url, url, ...])`, all parsed; invalid entries warn
+  and are dropped; if *all* are invalid, fail loudly rather than silently
+  falling back to public (a silent fallback to n0 would be a compliance
+  violation — the whole point was to avoid public relays).
+
+**One endpoint per relay policy.** The daemon binds a distinct iroh endpoint for
+each relay policy on demand, held in a `Map<RelayChoice, Endpoint>`. Each share /
+join routes to the endpoint matching its policy, so shares on different relays
+(public + a self-hosted relay) run **concurrently** — no single-policy limitation,
+no conflict, no restart.
+- **Node identity:** iroh requires one identity per endpoint. The public endpoint
+  reuses the daemon's persistent key (unchanged behavior + stable identity);
+  each custom-relay endpoint gets a fresh `SecretKey::generate()` per run. Shares
+  are ephemeral (die with the daemon), so a custom endpoint's node id need not
+  survive a restart.
+- **Bookkeeping:** each endpoint runs its own accept loop; the reaper is global
+  (scans all shares) and starts once. Capability matching is per-share and
+  endpoint-agnostic, so auth is unchanged.
+- **Bind race:** `get_or_bind` holds the map lock across the (infrequent) bind so
+  two callers racing on the same policy can't double-bind.
+
+Remaining behavior notes (documented in the error paths + README):
+- The custom-relay guarantee covers the host's outbound leg; the consumer's join
+  binds env-or-public independently and must configure matching relays for
+  end-to-end confinement.
+- `sharing.relays` is resolved from **live** config at share time, not a snapshot
+  from `veld start` — editing it mid-run changes the next share.
+- `VELD_SHARE_RELAY` is read from the daemon's environment (not the caller's
+  shell) and config `"public"` overrides it (not an enforceable floor).
+
+## 5. Public web sharing — one architecture, honest limits
+
+The two shapes floated (a "mirror the fake TLD" proxy vs a "mint a public URL"
+gateway) are the **same server** with different URL strategies:
+
+> A headless Veld peer that `join`s the share over iroh, then reverse-proxies the
+> tunneled service onto a public HTTP endpoint.
+
+The only real question is the public URL, and here is the hard constraint:
+
+**The verbatim-hostname property cannot survive the jump to the public web.**
+
+- **Mirror the fake TLD** — `*.localhost` / fake apex domains cannot resolve on
+  public DNS. Dead end for arbitrary browsers.
+- **Mint a real public URL** — the gateway owns a real wildcard domain and mints
+  `https://<slug>.share.<gateway-domain>` per shared service. Viable — but it
+  **reintroduces the exact host-rewrite problem peer sharing avoids**:
+  - absolute URLs baked into the app point at the origin host,
+  - cookies are scoped to the original host,
+  - CORS allow-lists and OAuth redirect URIs reference the original host.
+
+So **web sharing is a weaker guarantee than peer sharing** — but this is an
+**operator responsibility, not a Veld defect.** Veld provides the tunnel + the
+proxy; the operator is responsible for standing up the gateway on a domain that
+works for their app (right base domain, TLS, CORS, cookie scope, OAuth redirect
+URIs registered against the public host). Apps with relative URLs work out of the
+box; apps with absolute-host assumptions require the operator to configure the
+domain to match. Veld's job is to make host rewriting predictable and to document
+what the operator must own — not to magically preserve verbatim fidelity (that's
+the `peer` mode's job). This is *why* the config uses a different word (`web`).
+
+### 5.1 Gateway server (new binary)
+
+- Config: base public domain, TLS (ACME wildcard), which shares to accept
+  (capability/allow-list), relay policy (shares the same `sharing.relays`
+  contract).
+- On accepting a share: `join` over iroh → mint slug → publish
+  `https://<slug>.share.<domain>` → reverse-proxy with host rewriting → return
+  the public URL to the origin.
+- Runs anywhere reachable: one per org, self-hosted, same Docker-friendly story
+  as the relay.
+- Reuses the browser join-URL scaffolding already present
+  (`manager.rs:737-746`).
+
+### 5.2 Copy-URL UX
+
+The origin Veld user is looking at the app on its fake-TLD URL and cannot paste
+that to a non-Veld user. So:
+
+- The gateway exposes a **stable public URL** per shared service.
+- The overlay toolbar (no longer "just feedback") gets a **Copy public URL**
+  action that translates the *current browser location* → public URL by swapping
+  the host and **keeping path + query** — so a deep link to a specific screen
+  survives the copy.
+
+## 6. Security & compliance
+
+- Peer sharing security model (capability + approval) is unchanged for `peer`.
+- `web` widens the audience to the open internet, so peer sharing's two gates
+  (capability token + host approval of a *Veld peer*) are **not sufficient** —
+  the viewer is an anonymous browser, not an authenticated peer. Web sharing
+  needs its own access layer, evaluated in increment 2. Candidate controls,
+  roughly in order of strength/effort:
+  - **Per-share access token in the URL** — the minted public URL carries an
+    unguessable token; no token, no access. Cheapest; leaks if the URL leaks.
+  - **Share password** — gateway prompts for a password the host sets at share
+    time (sent out-of-band). Simple mental model for non-technical viewers.
+  - **Join approval for web viewers** — the gateway holds each new browser
+    session until the host approves it (mirrors peer `manual` mode, surfaced in
+    the overlay toolbar). Strongest; highest UX cost.
+  - **Defaults** — `web` should default to a stricter posture than `peer`:
+    non-`Auto` approval, a shorter TTL, and a token/password required (never an
+    open URL by default).
+  The exact combination is an increment-2 decision; the config must reserve room
+  for it (e.g. a `share.web` sub-object for password/approval settings) so
+  today's `expose: ["web"]` stays forward-compatible.
+- Gateway-side allow-listing of which shares it will accept, plus explicit
+  `expose: web` in config (never implicit), remain prerequisites.
+- Compliance win is structural: with per-service opt-in + self-hosted relays,
+  an environment provably cannot leak a service that wasn't declared, over a
+  relay the org doesn't run.
+
+## 7. Browser ↔ browser over iroh (deferred spike)
+
+The idea: a non-Veld user's browser speaks iroh directly (WASM), no gateway.
+
+Reality check: a browser cannot hold arbitrary QUIC/UDP; iroh in-browser needs
+WebTransport/WebRTC, and the relay-over-WebSocket path is not a general peer
+transport. Even if the viewer's browser ran an iroh JS client plus a service
+worker acting as a local proxy, it **still hits the same-origin / host-rewrite
+wall** — the browser enforces it. So this does not dodge the fundamental problem
+of §5; it relocates the proxy into the viewer's browser.
+
+Verdict: **research spike only**, after §5 ships. Not on the critical path.
+
+## 8. Sequencing
+
+Three independent increments; ship top-down.
+
+1. **Config surface + enforcement** (compliance win, no new server) — *this PR*
+   - `sharing.relays` (public | list) wired into `bind_endpoint`.
+   - one endpoint per relay policy → concurrent different-relay shares.
+   - per-variant `share.expose` opt-in; `veld share` enforces it.
+   - Docs checklist (README, `docs/configuration.md`, skills, schema).
+2. **Public web gateway** (new binary)
+   - headless peer + reverse proxy + slug minting + host rewriting.
+   - overlay toolbar "Copy public URL".
+   - honest fidelity docs.
+3. **Browser-native viewer** — spike only.
+
+## 9. Decisions & remaining questions
+
+**Decided**
+- `expose` is a **list** (`["peer", "web"]`) — both audiences at once, §3.2.
+- Gateway discovery: origin points at its gateway via `sharing.gateway` URL in
+  config, §3.1. One gateway per environment (an org can point many envs at one
+  shared gateway instance).
+- Config relay policy **wins** over `VELD_SHARE_RELAY`; env stays as an ad-hoc
+  override only when config is silent, §3.1/§4.
+
+**Still open (defer to the relevant increment)**
+1. Should `web` enforce stricter defaults (approval mode, shorter TTL) than
+   `peer`? — settle in increment 2.
+2. Wildcard slug scheme + collision/expiry semantics for public URLs. —
+   increment 2.
+3. Gateway ↔ share trust: how the gateway is allow-listed to accept a share
+   (reuse capability? separate gateway token?). — increment 2.

--- a/crates/veld-core/src/config.rs
+++ b/crates/veld-core/src/config.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
@@ -69,6 +69,11 @@ pub struct VeldConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub env: Option<HashMap<String, String>>,
 
+    /// Environment sharing policy: which relays to use, and where the public
+    /// web gateway lives. Per-service opt-in lives on each variant (`share`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sharing: Option<SharingConfig>,
+
     /// Setup steps that run sequentially before the dependency graph.
     /// If any step exits non-zero, startup is aborted.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -110,6 +115,106 @@ pub struct SetupStep {
 
 fn default_url_template() -> String {
     "{service}.{run}.{project}.localhost".to_owned()
+}
+
+// ---------------------------------------------------------------------------
+// Sharing
+// ---------------------------------------------------------------------------
+
+/// Environment-wide sharing policy. Relay selection is a compliance control:
+/// `public` uses n0's public relays; a custom list confines share traffic to
+/// relays the operator runs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SharingConfig {
+    /// Relay policy. Relays must be opted into explicitly — including public —
+    /// so nothing is routed over public relays by accident. Absent means "unset":
+    /// the daemon then falls back to the `VELD_SHARE_RELAY` env override, and if
+    /// that is also unset, `veld share` is refused. When set, config wins over
+    /// the env var.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub relays: Option<RelayPolicy>,
+
+    /// Base URL of the public web gateway this environment points at. Only
+    /// needed for services that `expose` `web`. Example:
+    /// `https://share.acme.internal`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gateway: Option<String>,
+}
+
+/// Which iroh relays to route share traffic through. Serializes as either the
+/// string `"public"` or an array of relay URLs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RelayPolicy {
+    /// n0's public relay set (only via an explicit `"public"` opt-in).
+    Public,
+    /// Self-hosted relays. Share traffic is confined to these.
+    Custom(Vec<String>),
+}
+
+impl Serialize for RelayPolicy {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        match self {
+            RelayPolicy::Public => s.serialize_str("public"),
+            RelayPolicy::Custom(urls) => urls.serialize(s),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for RelayPolicy {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        use serde::de::Error as _;
+        let value = serde_json::Value::deserialize(d)?;
+        match value {
+            serde_json::Value::String(s) if s == "public" => Ok(RelayPolicy::Public),
+            serde_json::Value::String(s) => Err(D::Error::custom(format!(
+                "relays must be \"public\" or an array of relay URLs, got \"{s}\""
+            ))),
+            serde_json::Value::Array(arr) => {
+                let urls: Vec<String> = arr
+                    .into_iter()
+                    .map(|v| {
+                        v.as_str().map(str::to_owned).ok_or_else(|| {
+                            D::Error::custom("relays array must contain URL strings")
+                        })
+                    })
+                    .collect::<Result<_, _>>()?;
+                if urls.is_empty() {
+                    return Err(D::Error::custom(
+                        "relays array must not be empty; use \"public\" for public relays",
+                    ));
+                }
+                Ok(RelayPolicy::Custom(urls))
+            }
+            _ => Err(D::Error::custom(
+                "relays must be \"public\" or an array of relay URLs",
+            )),
+        }
+    }
+}
+
+/// Per-variant sharing opt-in.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SharePolicy {
+    /// Audiences this service may be exposed to. Empty means not shareable.
+    #[serde(default)]
+    pub expose: Vec<ExposeMode>,
+}
+
+impl SharePolicy {
+    /// Whether this policy permits the given audience.
+    pub fn allows(&self, mode: ExposeMode) -> bool {
+        self.expose.contains(&mode)
+    }
+}
+
+/// A sharing audience.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ExposeMode {
+    /// Other Veld users. The origin URL is reproduced verbatim on the consumer.
+    Peer,
+    /// Any browser, via the public web gateway. Best-effort URL fidelity.
+    Web,
 }
 
 // ---------------------------------------------------------------------------
@@ -293,6 +398,12 @@ pub struct VariantConfig {
     /// Overrides node-level `cwd`. Supports variable substitution.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cwd: Option<String>,
+
+    /// Sharing opt-in for this variant. Absent (or an empty `expose` list) means
+    /// this service can never be shared — `veld share` refuses it. This is the
+    /// explicit, per-service consent that makes sharing auditable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub share: Option<SharePolicy>,
 }
 
 // ---------------------------------------------------------------------------
@@ -1225,5 +1336,98 @@ mod tests {
         let v: VariantConfig = serde_json::from_str(json).unwrap();
         let probe = v.readiness_probe().unwrap();
         assert_eq!(probe.check_type, "http");
+    }
+
+    // -- Sharing config tests -------------------------------------------------
+
+    #[test]
+    fn test_relay_policy_public_string() {
+        let p: RelayPolicy = serde_json::from_str(r#""public""#).unwrap();
+        assert_eq!(p, RelayPolicy::Public);
+        // round-trips back to the string form
+        assert_eq!(serde_json::to_string(&p).unwrap(), r#""public""#);
+    }
+
+    #[test]
+    fn test_relay_policy_custom_list() {
+        let p: RelayPolicy = serde_json::from_str(r#"["https://relay.example.com"]"#).unwrap();
+        assert_eq!(
+            p,
+            RelayPolicy::Custom(vec!["https://relay.example.com".into()])
+        );
+        assert_eq!(
+            serde_json::to_string(&p).unwrap(),
+            r#"["https://relay.example.com"]"#
+        );
+    }
+
+    #[test]
+    fn test_relay_policy_rejects_empty_list() {
+        assert!(serde_json::from_str::<RelayPolicy>("[]").is_err());
+    }
+
+    #[test]
+    fn test_relay_policy_rejects_unknown_string() {
+        assert!(serde_json::from_str::<RelayPolicy>(r#""private""#).is_err());
+    }
+
+    #[test]
+    fn test_share_policy_allows() {
+        let json = r#"{ "expose": ["peer", "web"] }"#;
+        let s: SharePolicy = serde_json::from_str(json).unwrap();
+        assert!(s.allows(ExposeMode::Peer));
+        assert!(s.allows(ExposeMode::Web));
+    }
+
+    #[test]
+    fn test_share_policy_empty_expose_allows_nothing() {
+        let s: SharePolicy = serde_json::from_str(r#"{ "expose": [] }"#).unwrap();
+        assert!(!s.allows(ExposeMode::Peer));
+        assert!(!s.allows(ExposeMode::Web));
+    }
+
+    #[test]
+    fn test_variant_share_defaults_to_none() {
+        let v: VariantConfig =
+            serde_json::from_str(r#"{ "type": "start_server", "command": "x" }"#).unwrap();
+        assert!(v.share.is_none());
+    }
+
+    #[test]
+    fn test_sharing_config_parses_on_veld_config() {
+        let json = r#"{
+            "schemaVersion": "2",
+            "name": "demo",
+            "sharing": {
+                "relays": ["https://relay.acme.internal"],
+                "gateway": "https://share.acme.internal"
+            },
+            "nodes": {
+                "web": {
+                    "variants": {
+                        "local": {
+                            "type": "start_server",
+                            "command": "npm start",
+                            "share": { "expose": ["peer"] }
+                        }
+                    }
+                }
+            }
+        }"#;
+        let cfg: VeldConfig = serde_json::from_str(json).unwrap();
+        let sharing = cfg.sharing.unwrap();
+        assert_eq!(
+            sharing.relays,
+            Some(RelayPolicy::Custom(vec![
+                "https://relay.acme.internal".into()
+            ]))
+        );
+        assert_eq!(
+            sharing.gateway.as_deref(),
+            Some("https://share.acme.internal")
+        );
+        let share = cfg.nodes["web"].variants["local"].share.as_ref().unwrap();
+        assert!(share.allows(ExposeMode::Peer));
+        assert!(!share.allows(ExposeMode::Web));
     }
 }

--- a/crates/veld-core/src/graph.rs
+++ b/crates/veld-core/src/graph.rs
@@ -488,6 +488,7 @@ mod tests {
             client_log_levels: None,
             features: None,
             cwd: None,
+            share: None,
         };
         let api_variant = VariantConfig {
             step_type: StepType::StartServer,
@@ -506,6 +507,7 @@ mod tests {
             client_log_levels: None,
             features: None,
             cwd: None,
+            share: None,
         };
         let frontend_variant = VariantConfig {
             step_type: StepType::StartServer,
@@ -524,6 +526,7 @@ mod tests {
             client_log_levels: None,
             features: None,
             cwd: None,
+            share: None,
         };
 
         VeldConfig {
@@ -535,6 +538,7 @@ mod tests {
             client_log_levels: None,
             features: None,
             env: None,
+            sharing: None,
             setup: None,
             teardown: None,
             nodes: HashMap::from([

--- a/crates/veld-core/src/share.rs
+++ b/crates/veld-core/src/share.rs
@@ -162,7 +162,8 @@ impl ShareTicket {
 pub struct StartShareRequest {
     /// Run name to share. `None` means "the only run", resolved by the daemon.
     pub run: Option<String>,
-    /// Node names to share; `None` shares all of the run's URL-bearing nodes.
+    /// Node names to share; `None` shares all of the run's `peer`-opted-in
+    /// URL-bearing nodes. A filter narrows within that opted-in set.
     pub nodes: Option<Vec<String>>,
     /// Lifetime in seconds; defaults applied by the daemon.
     pub ttl_secs: Option<i64>,
@@ -181,6 +182,11 @@ pub struct StartShareResponse {
     pub join_url: String,
     pub nodes: Vec<String>,
     pub expires_at: i64,
+    /// Non-fatal notes — e.g. URL-bearing services excluded from this share
+    /// because their variant did not opt into `peer` sharing. Surfaced so a
+    /// partial share doesn't silently under-expose.
+    #[serde(default)]
+    pub warnings: Vec<String>,
 }
 
 /// `POST /api/shares/join` — join a shared environment.

--- a/crates/veld-daemon/src/share/api.rs
+++ b/crates/veld-daemon/src/share/api.rs
@@ -13,12 +13,14 @@ use axum::routing::{delete, get, post};
 use axum::{Json, response::IntoResponse};
 use chrono::Utc;
 use uuid::Uuid;
+use veld_core::config::{ExposeMode, SharePolicy, VeldConfig, load_config};
 use veld_core::share::{
     ApprovalMode, Capability, JoinRequest, JoinResponse, ShareManifest, SharedNode, SharesList,
     StartShareRequest, StartShareResponse,
 };
 use veld_core::state::{GlobalRegistry, ProjectState};
 
+use super::endpoint::RelayChoice;
 use super::manager::ShareManager;
 
 const DEFAULT_TTL_SECS: i64 = 2 * 60 * 60;
@@ -61,13 +63,17 @@ async fn start(
 ) -> Result<Json<StartShareResponse>, ApiError> {
     check_csrf(&headers)?;
 
-    let manifest = build_manifest(req.run.as_deref(), req.nodes.as_deref(), req.ttl_secs)?;
+    let ResolvedShare {
+        manifest,
+        relay,
+        warnings,
+    } = build_manifest(req.run.as_deref(), req.nodes.as_deref(), req.ttl_secs)?;
     let node_names: Vec<String> = manifest.nodes.iter().map(|n| n.node.clone()).collect();
     let expires_at = manifest.expires_at;
 
     let capability = Capability::generate();
     let (share_id, ticket) = manager
-        .start_share(manifest, capability, req.approve.unwrap_or_default())
+        .start_share(manifest, capability, req.approve.unwrap_or_default(), relay)
         .await
         .map_err(internal)?;
     let token = ticket.encode().map_err(internal)?;
@@ -79,6 +85,7 @@ async fn start(
         join_url,
         nodes: node_names,
         expires_at,
+        warnings,
     }))
 }
 
@@ -184,12 +191,28 @@ async fn deny(
     Ok(StatusCode::NO_CONTENT)
 }
 
-/// Resolve a run to a shareable manifest by reading persisted state.
+/// A manifest plus the relay policy the origin project declared, resolved
+/// together from the same config so the share is both scoped (only opted-in
+/// services) and routed (over the operator's relays).
+struct ResolvedShare {
+    manifest: ShareManifest,
+    /// The relay this share routes over, resolved from an explicit opt-in.
+    relay: RelayChoice,
+    /// URL-bearing services excluded from the share (not opted into `peer`),
+    /// surfaced as warnings so a partial share isn't silently under-exposed.
+    warnings: Vec<String>,
+}
+
+/// Resolve a run to a shareable manifest by reading persisted state and the
+/// project's config. Only services whose active variant opts into `peer`
+/// sharing (`share.expose` contains `peer`) are included; this is the explicit
+/// consent gate. The runtime `--node` filter narrows *within* the opted-in set
+/// — it can never widen it.
 fn build_manifest(
     run: Option<&str>,
     nodes_filter: Option<&[String]>,
     ttl_secs: Option<i64>,
-) -> Result<ShareManifest, ApiError> {
+) -> Result<ResolvedShare, ApiError> {
     let registry = GlobalRegistry::load().map_err(internal)?;
 
     let run_name = match run {
@@ -210,15 +233,42 @@ fn build_manifest(
         .get(&run_name)
         .ok_or((StatusCode::NOT_FOUND, format!("run '{run_name}' not found")))?;
 
+    let config = load_config(&project_root.join("veld.json")).map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("could not load veld.json for run '{run_name}': {e}"),
+        )
+    })?;
+
+    // Track why URL-bearing nodes were excluded, so the error can point the user
+    // at the opt-in they are missing rather than a bare "nothing to share".
+    // `node:variant` labels because `peer_opt_in` checks the *live* variant, and a
+    // multi-variant node needs the opt-in on the running one specifically.
+    let mut had_url_bearing = false;
+    let mut not_opted_in: Vec<String> = Vec::new();
+    let mut web_only: Vec<String> = Vec::new();
     let mut nodes = Vec::new();
     for ns in run_state.nodes.values() {
         let (Some(url), Some(port)) = (ns.url.as_ref(), ns.port) else {
             continue;
         };
+        had_url_bearing = true;
         if let Some(filter) = nodes_filter {
             if !filter.iter().any(|n| n == &ns.node_name) {
                 continue;
             }
+        }
+        let share = variant_share(&config, &ns.node_name, &ns.variant);
+        if !share.is_some_and(|s| s.allows(ExposeMode::Peer)) {
+            let label = format!("{}:{}", ns.node_name, ns.variant);
+            // A `web`-only opt-in is a deliberate choice, not a missing one — call
+            // it out distinctly instead of telling the user to "add peer".
+            if share.is_some_and(|s| s.allows(ExposeMode::Web)) {
+                web_only.push(label);
+            } else {
+                not_opted_in.push(label);
+            }
+            continue;
         }
         nodes.push(SharedNode {
             node: ns.node_name.clone(),
@@ -232,20 +282,108 @@ fn build_manifest(
     if nodes.is_empty() {
         return Err((
             StatusCode::BAD_REQUEST,
-            format!("run '{run_name}' has no shareable (URL-bearing) nodes"),
+            share_exclusion_message(&run_name, had_url_bearing, &mut not_opted_in, &mut web_only),
         ));
     }
 
+    // Partial share: some URL-bearing services were excluded. Warn rather than
+    // silently under-expose (the excluded set is otherwise invisible to the user).
+    not_opted_in.sort();
+    not_opted_in.dedup();
+    web_only.sort();
+    web_only.dedup();
+    let mut warnings = Vec::new();
+    if !not_opted_in.is_empty() {
+        warnings.push(format!(
+            "not shared (no `peer` opt-in): {}",
+            not_opted_in.join(", ")
+        ));
+    }
+    if !web_only.is_empty() {
+        warnings.push(format!(
+            "not shared (`web` is reserved until the gateway ships): {}",
+            web_only.join(", ")
+        ));
+    }
+
+    // Relays must be opted into explicitly — including public — so share traffic
+    // is never routed over n0's public relays by accident.
+    let relay_policy = config.sharing.and_then(|s| s.relays);
+    let relay = RelayChoice::resolve(relay_policy.as_ref()).ok_or((
+        StatusCode::BAD_REQUEST,
+        format!(
+            "run '{run_name}' cannot be shared: no relay is configured. Set `sharing.relays` \
+             in veld.json to \"public\" or a list of self-hosted relay URLs — relays must be \
+             opted into explicitly."
+        ),
+    ))?;
+
     let now = Utc::now().timestamp();
     let ttl = ttl_secs.unwrap_or(DEFAULT_TTL_SECS);
-    Ok(ShareManifest {
-        run_id: run_state.run_id,
-        run: run_name.clone(),
-        project: run_state.project.clone(),
-        nodes,
-        created_at: now,
-        expires_at: now + ttl,
+    Ok(ResolvedShare {
+        manifest: ShareManifest {
+            run_id: run_state.run_id,
+            run: run_name.clone(),
+            project: run_state.project.clone(),
+            nodes,
+            created_at: now,
+            expires_at: now + ttl,
+        },
+        relay,
+        warnings,
     })
+}
+
+/// The share policy of a node's specific variant, if any.
+fn variant_share<'a>(config: &'a VeldConfig, node: &str, variant: &str) -> Option<&'a SharePolicy> {
+    config
+        .nodes
+        .get(node)
+        .and_then(|n| n.variants.get(variant))
+        .and_then(|v| v.share.as_ref())
+}
+
+/// Build the "nothing to share" error from the reasons URL-bearing nodes were
+/// excluded. `not_opted_in` are `node:variant`s with no (peer) `share`;
+/// `web_only` opted into `web` but not `peer`. Both are sorted+deduped in place
+/// for a deterministic message.
+fn share_exclusion_message(
+    run_name: &str,
+    had_url_bearing: bool,
+    not_opted_in: &mut Vec<String>,
+    web_only: &mut Vec<String>,
+) -> String {
+    if !had_url_bearing {
+        return format!("run '{run_name}' has no shareable (URL-bearing) nodes");
+    }
+    not_opted_in.sort();
+    not_opted_in.dedup();
+    web_only.sort();
+    web_only.dedup();
+
+    let mut parts: Vec<String> = Vec::new();
+    if !not_opted_in.is_empty() {
+        parts.push(format!(
+            "Add `\"share\": {{ \"expose\": [\"peer\"] }}` to the variant(s) you want to \
+             share (candidates: {}).",
+            not_opted_in.join(", ")
+        ));
+    }
+    if !web_only.is_empty() {
+        parts.push(format!(
+            "These opt into `web` only, which is reserved until the public gateway ships — \
+             add `peer` to share Veld-to-Veld today: {}.",
+            web_only.join(", ")
+        ));
+    }
+    if parts.is_empty() {
+        // URL-bearing nodes existed but the --node filter excluded them all.
+        return format!("run '{run_name}' has no shareable services matching the requested nodes");
+    }
+    format!(
+        "run '{run_name}' has no services opted into peer sharing. {}",
+        parts.join(" ")
+    )
 }
 
 /// When no run is named, use the only running one; error if ambiguous.
@@ -300,5 +438,83 @@ mod tests {
     fn share_routes_build_without_conflict() {
         let mgr = Arc::new(ShareManager::new(iroh::SecretKey::generate()));
         let _ = routes(mgr);
+    }
+
+    fn config_with_variant(share_json: &str) -> VeldConfig {
+        let json = format!(
+            r#"{{
+                "schemaVersion": "2",
+                "name": "demo",
+                "nodes": {{
+                    "web": {{ "variants": {{
+                        "local": {{ "type": "start_server", "command": "x"{share_json} }},
+                        "prod":  {{ "type": "start_server", "command": "x" }}
+                    }} }}
+                }}
+            }}"#
+        );
+        serde_json::from_str(&json).unwrap()
+    }
+
+    #[test]
+    fn variant_share_resolves_the_live_variant_only() {
+        let cfg = config_with_variant(r#", "share": { "expose": ["peer"] }"#);
+        // `local` opts in; `prod` (same node, no share) does not.
+        assert!(variant_share(&cfg, "web", "local").is_some_and(|s| s.allows(ExposeMode::Peer)));
+        assert!(variant_share(&cfg, "web", "prod").is_none());
+        // Unknown node / variant → None, never a panic.
+        assert!(variant_share(&cfg, "missing", "local").is_none());
+        assert!(variant_share(&cfg, "web", "missing").is_none());
+    }
+
+    #[test]
+    fn variant_share_web_only_does_not_allow_peer() {
+        let cfg = config_with_variant(r#", "share": { "expose": ["web"] }"#);
+        let s = variant_share(&cfg, "web", "local").unwrap();
+        assert!(!s.allows(ExposeMode::Peer));
+        assert!(s.allows(ExposeMode::Web));
+    }
+
+    #[test]
+    fn exclusion_message_no_url_bearing() {
+        let msg = share_exclusion_message("r", false, &mut vec![], &mut vec![]);
+        assert!(msg.contains("no shareable (URL-bearing) nodes"), "{msg}");
+    }
+
+    #[test]
+    fn exclusion_message_not_opted_in_lists_node_variant() {
+        let msg = share_exclusion_message("r", true, &mut vec!["web:local".into()], &mut vec![]);
+        assert!(msg.contains("no services opted into peer sharing"), "{msg}");
+        assert!(msg.contains("web:local"), "{msg}");
+        assert!(msg.contains("expose"), "{msg}");
+    }
+
+    #[test]
+    fn exclusion_message_web_only_is_called_out_distinctly() {
+        let msg = share_exclusion_message("r", true, &mut vec![], &mut vec!["api:local".into()]);
+        assert!(
+            msg.contains("reserved until the public gateway ships"),
+            "{msg}"
+        );
+        assert!(msg.contains("api:local"), "{msg}");
+    }
+
+    #[test]
+    fn exclusion_message_filtered_out_all() {
+        // URL-bearing nodes existed but the --node filter excluded every one.
+        let msg = share_exclusion_message("r", true, &mut vec![], &mut vec![]);
+        assert!(msg.contains("matching the requested nodes"), "{msg}");
+    }
+
+    #[test]
+    fn exclusion_message_is_deterministic() {
+        let msg = share_exclusion_message(
+            "r",
+            true,
+            &mut vec!["z:local".into(), "a:local".into(), "a:local".into()],
+            &mut vec![],
+        );
+        // sorted + deduped
+        assert!(msg.contains("a:local, z:local"), "{msg}");
     }
 }

--- a/crates/veld-daemon/src/share/endpoint.rs
+++ b/crates/veld-daemon/src/share/endpoint.rs
@@ -4,19 +4,88 @@
 //! directory so the node's public key (its `EndpointId`) is stable across daemon
 //! restarts. Everything else about a share is ephemeral in-memory state.
 
+use std::fmt;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use iroh::endpoint::presets;
 use iroh::{Endpoint, RelayMode, RelayUrl, SecretKey};
 use tracing::warn;
+use veld_core::config::RelayPolicy;
 
 /// ALPN protocol identifier for veld's share tunnels.
 pub const ALPN: &[u8] = b"veld/share/1";
 
 /// Env var to point the endpoint at a self-hosted relay instead of n0's public
-/// relays (e.g. `VELD_SHARE_RELAY=https://relay.example.com`).
+/// relays (e.g. `VELD_SHARE_RELAY=https://relay.example.com`). Only consulted
+/// when a project does not declare `sharing.relays` in its config.
 const RELAY_ENV: &str = "VELD_SHARE_RELAY";
+
+/// The concrete relay decision an endpoint is bound with. Derived from a
+/// project's `sharing.relays` policy, falling back to the `VELD_SHARE_RELAY`
+/// env override, or `None` when nothing is opted in (relays are never chosen
+/// implicitly). Used as the key of the daemon's per-policy endpoint map (see
+/// `ShareManager`), so each distinct choice gets its own endpoint.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum RelayChoice {
+    /// n0's public relays (only via an explicit `"public"` opt-in).
+    Public,
+    /// Self-hosted relay URLs, sorted for a stable identity/comparison.
+    Custom(Vec<String>),
+}
+
+impl RelayChoice {
+    /// Resolve the effective relay choice, or `None` if no relay is opted into.
+    /// Relays must be chosen explicitly — including public — so nothing is ever
+    /// routed over n0's public relays by accident. Config policy wins; when
+    /// absent, the `VELD_SHARE_RELAY` env override applies; otherwise `None`.
+    ///
+    /// The env var is read from the *daemon* process's environment at bind time,
+    /// not the shell that ran `veld share` — a long-lived daemon won't see an
+    /// export made after it started. Prefer `sharing.relays` in config.
+    pub fn resolve(policy: Option<&RelayPolicy>) -> Option<Self> {
+        Self::resolve_with_env(policy, std::env::var(RELAY_ENV).ok())
+    }
+
+    /// Core of `resolve`, with the env override injected so it can be unit-tested
+    /// without mutating the process environment (which would be a data race under
+    /// multithreaded `cargo test`).
+    fn resolve_with_env(policy: Option<&RelayPolicy>, env: Option<String>) -> Option<Self> {
+        match policy {
+            Some(RelayPolicy::Public) => Some(RelayChoice::Public),
+            Some(RelayPolicy::Custom(urls)) => Some(RelayChoice::custom(urls.clone())),
+            None => match env {
+                Some(raw) if !raw.trim().is_empty() => {
+                    Some(RelayChoice::custom(vec![raw.trim().to_owned()]))
+                }
+                _ => None,
+            },
+        }
+    }
+
+    fn custom(urls: Vec<String>) -> Self {
+        // Normalize (trim + drop a trailing slash) before sort/dedup so the
+        // choice has a stable identity: it keys the per-policy endpoint map, so
+        // `https://r` and `https://r/` must map to the same endpoint. Case and
+        // default-port differences are left as-is.
+        let mut urls: Vec<String> = urls
+            .into_iter()
+            .map(|u| u.trim().trim_end_matches('/').to_owned())
+            .collect();
+        urls.sort();
+        urls.dedup();
+        RelayChoice::Custom(urls)
+    }
+}
+
+impl fmt::Display for RelayChoice {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RelayChoice::Public => write!(f, "public"),
+            RelayChoice::Custom(urls) => write!(f, "[{}]", urls.join(", ")),
+        }
+    }
+}
 
 /// Path to the persistent node key: `<data_dir>/veld/node.key`.
 pub fn key_path() -> Option<PathBuf> {
@@ -56,21 +125,141 @@ fn restrict_permissions(path: &Path) {
 #[cfg(not(unix))]
 fn restrict_permissions(_path: &Path) {}
 
-/// Bind an iroh endpoint using n0's default relays + discovery, advertising the
-/// veld share ALPN. The endpoint accepts inbound share connections and can dial
-/// out to peers.
-pub async fn bind_endpoint(secret_key: SecretKey) -> Result<Endpoint> {
+/// Bind an iroh endpoint advertising the veld share ALPN, routing through the
+/// relays named by `choice`. The endpoint accepts inbound share connections and
+/// can dial out to peers.
+///
+/// For a custom relay choice, every URL that fails to parse is dropped with a
+/// warning; if *no* URL survives, binding fails rather than silently falling
+/// back to public relays — a silent fallback would violate the compliance
+/// intent of pinning relays.
+pub async fn bind_endpoint(secret_key: SecretKey, choice: &RelayChoice) -> Result<Endpoint> {
     let mut builder = Endpoint::builder(presets::N0)
         .secret_key(secret_key)
         .alpns(vec![ALPN.to_vec()]);
 
-    // Optional self-hosted relay override (teams / privacy).
-    if let Ok(raw) = std::env::var(RELAY_ENV) {
-        match raw.parse::<RelayUrl>() {
-            Ok(url) => builder = builder.relay_mode(RelayMode::custom([url])),
-            Err(e) => warn!(error = %e, value = %raw, "ignoring invalid {RELAY_ENV}"),
+    if let RelayChoice::Custom(urls) = choice {
+        let parsed: Vec<RelayUrl> = urls
+            .iter()
+            .filter_map(|raw| match raw.parse::<RelayUrl>() {
+                Ok(url) => Some(url),
+                Err(e) => {
+                    warn!(error = %e, value = %raw, "ignoring invalid share relay URL");
+                    None
+                }
+            })
+            .collect();
+        if parsed.is_empty() {
+            bail!(
+                "no valid relay URLs to bind ({}); set via sharing.relays in veld.json or \
+                 the VELD_SHARE_RELAY env var. Refusing to fall back to public relays.",
+                urls.join(", ")
+            );
         }
+        builder = builder.relay_mode(RelayMode::custom(parsed));
     }
 
     builder.bind().await.context("binding iroh endpoint")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_public_policy() {
+        assert_eq!(
+            RelayChoice::resolve(Some(&RelayPolicy::Public)),
+            Some(RelayChoice::Public)
+        );
+    }
+
+    #[test]
+    fn resolve_custom_policy_sorts_and_dedups() {
+        let policy = RelayPolicy::Custom(vec![
+            "https://b.example".into(),
+            "https://a.example".into(),
+            "https://b.example".into(),
+        ]);
+        assert_eq!(
+            RelayChoice::resolve(Some(&policy)),
+            Some(RelayChoice::Custom(vec![
+                "https://a.example".into(),
+                "https://b.example".into()
+            ]))
+        );
+    }
+
+    #[test]
+    fn custom_choices_compare_regardless_of_input_order() {
+        let a = RelayChoice::resolve(Some(&RelayPolicy::Custom(vec![
+            "https://x".into(),
+            "https://y".into(),
+        ])));
+        let b = RelayChoice::resolve(Some(&RelayPolicy::Custom(vec![
+            "https://y".into(),
+            "https://x".into(),
+        ])));
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn custom_normalizes_trailing_slash_and_whitespace() {
+        let a = RelayChoice::resolve(Some(&RelayPolicy::Custom(vec![
+            "https://relay.example/".into(),
+        ])));
+        let b = RelayChoice::resolve(Some(&RelayPolicy::Custom(vec![
+            " https://relay.example ".into(),
+        ])));
+        assert_eq!(a, b);
+        assert_eq!(
+            a,
+            Some(RelayChoice::Custom(vec!["https://relay.example".into()]))
+        );
+    }
+
+    #[test]
+    fn config_policy_wins_over_env_var() {
+        let env = Some("https://env-relay.example".to_owned());
+        // A `Some(..)` policy never consults the env, so config always wins.
+        assert_eq!(
+            RelayChoice::resolve_with_env(Some(&RelayPolicy::Public), env.clone()),
+            Some(RelayChoice::Public)
+        );
+        assert_eq!(
+            RelayChoice::resolve_with_env(
+                Some(&RelayPolicy::Custom(vec!["https://cfg.example".into()])),
+                env.clone()
+            ),
+            Some(RelayChoice::Custom(vec!["https://cfg.example".into()]))
+        );
+        // With no config policy, the env override is consulted.
+        assert_eq!(
+            RelayChoice::resolve_with_env(None, env),
+            Some(RelayChoice::Custom(vec![
+                "https://env-relay.example".into()
+            ]))
+        );
+    }
+
+    #[test]
+    fn resolve_requires_explicit_opt_in() {
+        // No config policy and no env override → nothing is opted in; never
+        // falls back to public relays implicitly.
+        assert_eq!(RelayChoice::resolve_with_env(None, None), None);
+        // Blank / whitespace-only env is ignored, not treated as an opt-in.
+        assert_eq!(
+            RelayChoice::resolve_with_env(None, Some("   ".into())),
+            None
+        );
+    }
+
+    #[test]
+    fn display_renders_choice() {
+        assert_eq!(RelayChoice::Public.to_string(), "public");
+        assert_eq!(
+            RelayChoice::Custom(vec!["https://a".into(), "https://b".into()]).to_string(),
+            "[https://a, https://b]"
+        );
+    }
 }

--- a/crates/veld-daemon/src/share/manager.rs
+++ b/crates/veld-daemon/src/share/manager.rs
@@ -1,9 +1,11 @@
-//! In-memory manager for active shares and joins, plus the single iroh endpoint
-//! the daemon uses for all P2P traffic.
+//! In-memory manager for active shares and joins, plus the iroh endpoints the
+//! daemon uses for P2P traffic — one endpoint per relay policy, bound on demand,
+//! so shares on different relays run concurrently.
 //!
 //! State is intentionally ephemeral: if the daemon stops, shares and joins stop
-//! with it (fail-closed; a consumer then gets a clean connection error). Only
-//! the node keypair persists, giving the daemon a stable identity.
+//! with it (fail-closed; a consumer then gets a clean connection error). The
+//! persistent node keypair backs the public endpoint (stable identity);
+//! custom-relay endpoints get a fresh per-run identity.
 
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -38,7 +40,7 @@ const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 /// before returning a clean error instead of hanging the HTTP request.
 const DIAL_TIMEOUT: Duration = Duration::from_secs(75);
 
-use super::endpoint::bind_endpoint;
+use super::endpoint::{RelayChoice, bind_endpoint};
 use super::host::{self, HostShare};
 use super::join;
 
@@ -52,6 +54,11 @@ struct ShareEntry {
     ticket: String,
     /// Unix seconds after which the reaper removes this share.
     expires_at: i64,
+    /// The relay policy (endpoint) this share is served on. An inbound
+    /// connection is matched to this share only if it arrived on the *same*
+    /// endpoint — so a custom-relay share is never served over the public
+    /// endpoint, keeping relay confinement airtight.
+    relay: RelayChoice,
 }
 
 /// A join parked awaiting the host's manual approval.
@@ -83,10 +90,19 @@ struct JoinEntry {
     warnings: Vec<String>,
 }
 
-/// Owns the iroh endpoint and all live shares/joins.
+/// Owns the iroh endpoints and all live shares/joins.
 pub struct ShareManager {
     secret_key: SecretKey,
-    endpoint: OnceCell<Endpoint>,
+    /// One iroh endpoint per relay policy, bound on demand. The daemon can host
+    /// concurrent shares on different relays (e.g. public + a self-hosted relay)
+    /// by routing each share/join to the endpoint matching its policy. The
+    /// public endpoint reuses the daemon's persistent identity; custom-relay
+    /// endpoints get a fresh per-run identity (shares are ephemeral, so their
+    /// node id need not survive a restart).
+    endpoints: Mutex<HashMap<RelayChoice, Endpoint>>,
+    /// The reaper scans all shares regardless of endpoint, so it runs once —
+    /// started on the first endpoint bind.
+    reaper: OnceCell<()>,
     shares: Mutex<HashMap<String, ShareEntry>>,
     joins: Mutex<HashMap<String, JoinEntry>>,
     /// Join requests awaiting manual approval, keyed by request id.
@@ -102,7 +118,8 @@ impl ShareManager {
     pub fn new(secret_key: SecretKey) -> Self {
         Self {
             secret_key,
-            endpoint: OnceCell::new(),
+            endpoints: Mutex::new(HashMap::new()),
+            reaper: OnceCell::new(),
             shares: Mutex::new(HashMap::new()),
             joins: Mutex::new(HashMap::new()),
             pending: Mutex::new(HashMap::new()),
@@ -111,28 +128,56 @@ impl ShareManager {
         }
     }
 
-    /// Lazily bind the endpoint on first use and start the accept loop that
-    /// routes inbound connections to the matching share by capability.
-    async fn endpoint(self: &Arc<Self>) -> Result<Endpoint> {
-        let ep = self
-            .endpoint
-            .get_or_try_init(|| async {
-                let ep = bind_endpoint(self.secret_key.clone()).await?;
-                info!(node_id = %ep.id(), "iroh share endpoint bound");
-                self.clone().spawn_accept_loop(ep.clone());
-                self.clone().spawn_reaper();
-                Ok::<_, anyhow::Error>(ep)
-            })
-            .await?;
-        Ok(ep.clone())
+    /// Endpoint for the join (consumer) side. Joining is *consuming*, not
+    /// exposing, and the join path has no project config — so unlike hosting
+    /// (which requires an explicit relay opt-in), a join uses `VELD_SHARE_RELAY`
+    /// if set and otherwise falls back to public relays so a bare
+    /// `veld join <ticket>` keeps working.
+    async fn endpoint_join(self: &Arc<Self>) -> Result<Endpoint> {
+        let choice = RelayChoice::resolve(None).unwrap_or(RelayChoice::Public);
+        self.get_or_bind(&choice).await
+    }
+
+    /// The secret key (node identity) for an endpoint on `choice`. The public
+    /// endpoint reuses the daemon's persistent key; each custom-relay endpoint
+    /// gets its own fresh key so no two live endpoints share a node id (iroh
+    /// requires one identity per endpoint).
+    fn key_for(&self, choice: &RelayChoice) -> SecretKey {
+        match choice {
+            RelayChoice::Public => self.secret_key.clone(),
+            RelayChoice::Custom(_) => SecretKey::generate(),
+        }
+    }
+
+    /// Get (or bind on demand) the endpoint for `requested`, starting its accept
+    /// loop, and the global reaper on the first bind of any endpoint.
+    async fn get_or_bind(self: &Arc<Self>, requested: &RelayChoice) -> Result<Endpoint> {
+        // Hold the map lock across bind so two callers racing on the same policy
+        // can't bind two endpoints for it (binds are infrequent).
+        let mut endpoints = self.endpoints.lock().await;
+        if let Some(ep) = endpoints.get(requested) {
+            return Ok(ep.clone());
+        }
+        let ep = bind_endpoint(self.key_for(requested), requested).await?;
+        info!(node_id = %ep.id(), relays = %requested, "iroh share endpoint bound");
+        self.clone()
+            .spawn_accept_loop(ep.clone(), requested.clone());
+        endpoints.insert(requested.clone(), ep.clone());
+        drop(endpoints);
+
+        if self.reaper.set(()).is_ok() {
+            self.clone().spawn_reaper();
+        }
+        Ok(ep)
     }
 
     /// Accept inbound connections and dispatch each to the share whose
     /// capability the peer presents.
-    fn spawn_accept_loop(self: Arc<Self>, endpoint: Endpoint) {
+    fn spawn_accept_loop(self: Arc<Self>, endpoint: Endpoint, relay: RelayChoice) {
         tokio::spawn(async move {
             while let Some(incoming) = endpoint.accept().await {
                 let mgr = Arc::clone(&self);
+                let relay = relay.clone();
                 tokio::spawn(async move {
                     // Bounded handshake: a peer that completes the QUIC connect
                     // but never sends its control frame (e.g. a leaked link)
@@ -150,11 +195,17 @@ impl ShareManager {
                     };
                     drop(recv);
 
+                    // Match the capability only against shares served on THIS
+                    // endpoint's relay policy. A share minted on a custom relay
+                    // must never be served over the public endpoint (and vice
+                    // versa), or relay confinement would leak.
                     let matched = {
                         let shares = mgr.shares.lock().await;
                         shares
                             .values()
-                            .find(|s| s.host_share.capability.ct_eq(&req.capability))
+                            .find(|s| {
+                                s.relay == relay && s.host_share.capability.ct_eq(&req.capability)
+                            })
                             .map(|s| (s.id.clone(), s.approve_mode, Arc::clone(&s.host_share)))
                     };
 
@@ -247,8 +298,10 @@ impl ShareManager {
         manifest: ShareManifest,
         capability: Capability,
         approve_mode: ApprovalMode,
+        relay: RelayChoice,
     ) -> Result<(String, ShareTicket)> {
-        let endpoint = self.endpoint().await?;
+        let choice = relay;
+        let endpoint = self.get_or_bind(&choice).await?;
 
         // Wait (bounded) for the endpoint to learn its addresses/relay so the
         // ticket is dialable; proceed with whatever we have on timeout.
@@ -285,6 +338,7 @@ impl ShareManager {
                 approve_mode,
                 ticket: token,
                 expires_at,
+                relay: choice,
             },
         );
         info!(share_id = %id, ?approve_mode, "share started");
@@ -294,7 +348,7 @@ impl ShareManager {
     /// Join a shared environment: dial the host, then materialise each shared
     /// URL locally as a Caddy route tunnelled over the connection.
     pub async fn join(self: &Arc<Self>, ticket_str: &str, label: &str) -> Result<JoinResponse> {
-        let endpoint = self.endpoint().await?;
+        let endpoint = self.endpoint_join().await?;
         let ticket = ShareTicket::decode(ticket_str).context("decoding ticket")?;
 
         // Idempotent for a *successful* join: opening the same link again returns
@@ -821,6 +875,7 @@ mod tests {
                 approve_mode: ApprovalMode::Manual,
                 ticket: "veldshare_x".to_string(),
                 expires_at: i64::MAX,
+                relay: RelayChoice::Public,
             },
         );
         let (tx, rx) = oneshot::channel();

--- a/crates/veld-daemon/src/share/mod.rs
+++ b/crates/veld-daemon/src/share/mod.rs
@@ -29,7 +29,7 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires network; manual transport check"]
     async fn full_tunnel_echoes_over_iroh() {
-        use super::endpoint::bind_endpoint;
+        use super::endpoint::{RelayChoice, bind_endpoint};
         use super::{host::HostShare, join};
         use iroh::SecretKey;
         use std::collections::HashMap;
@@ -54,8 +54,12 @@ mod tests {
             }
         });
 
-        let host_ep = bind_endpoint(SecretKey::generate()).await.unwrap();
-        let client_ep = bind_endpoint(SecretKey::generate()).await.unwrap();
+        let host_ep = bind_endpoint(SecretKey::generate(), &RelayChoice::Public)
+            .await
+            .unwrap();
+        let client_ep = bind_endpoint(SecretKey::generate(), &RelayChoice::Public)
+            .await
+            .unwrap();
         host_ep.online().await;
         let host_addr = host_ep.addr();
 

--- a/crates/veld/src/commands/share.rs
+++ b/crates/veld/src/commands/share.rs
@@ -49,6 +49,9 @@ pub async fn share(
                     "Sharing {} node(s) over peer-to-peer.",
                     resp.nodes.len()
                 ));
+                for w in &resp.warnings {
+                    println!("  {}", output::dim(&format!("note: {w}")));
+                }
                 println!();
                 println!("  Send this link (opens in their browser):");
                 println!("    {}", output::cyan(&resp.join_url));

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,6 +41,7 @@ All relative paths in the configuration resolve relative to the directory contai
 | `client_log_levels` | array  | No       | Browser log levels to capture (see [Client-Side Log Levels]) |
 | `features`          | object | No       | Feature toggles (see [Features](#features))       |
 | `env`               | object | No       | Global environment variables inherited by all nodes |
+| `sharing`           | object | No       | Sharing policy: relays and public gateway (see [Sharing](#sharing)) |
 | `setup`             | array  | No       | Lifecycle steps that run before the graph (see [Setup & Teardown]) |
 | `teardown`          | array  | No       | Lifecycle steps that run after all nodes stop (see [Setup & Teardown]) |
 | `nodes`             | object | Yes      | The dependency graph nodes                        |
@@ -333,6 +334,7 @@ A variant defines how a node behaves in a given context. The same node might be 
 | `skip_if`           | string           | No       | `command` only    | Idempotency check — skip if exits 0 (alias: `verify`)|
 | `client_log_levels` | array of strings | No       | `start_server` | Browser log levels override for this variant          |
 | `features`          | object           | No       | `start_server` | Feature toggles override for this variant             |
+| `share`             | object           | No       | any (inert on `command`) | Sharing opt-in for this variant (see [Sharing](#sharing)) |
 
 ### `type`
 
@@ -651,6 +653,62 @@ If the `on_stop` command fails (non-zero exit code or execution error), Veld log
   "health_check": { "type": "port" }
 }
 ```
+
+---
+
+## Sharing
+
+Sharing has two config surfaces: an environment-wide `sharing` block (relays and the public gateway) and a per-variant `share` opt-in. A service is shareable **only** if its variant declares `share` — `veld share` refuses any service that hasn't opted in. This makes what leaves your machine explicit and auditable.
+
+> **Behavior change:** earlier versions shared every URL-bearing service in a run. Now nothing is shared until its variant declares `share.expose`; `veld share` errors (listing the candidate `node:variant`s) until you opt one in.
+
+```json
+{
+  "sharing": {
+    "relays": ["https://relay.acme.internal"],
+    "gateway": "https://share.acme.internal"
+  },
+  "nodes": {
+    "frontend": {
+      "variants": {
+        "local": {
+          "type": "start_server",
+          "command": "npm run dev",
+          "share": { "expose": ["peer"] }
+        }
+      }
+    }
+  }
+}
+```
+
+### `sharing.relays`
+
+Which iroh relays share traffic routes through — a compliance control. Relays forward only sealed, end-to-end-encrypted bytes; they never see URLs or content. **Relays must be opted into explicitly — including public.** There is no implicit default, so nothing is routed over public relays by accident; `veld share` refuses a run whose config sets no relay (and no `VELD_SHARE_RELAY` env override is present).
+
+- `"public"` — n0's public relays (an explicit opt-in, not a default).
+- An array of relay URLs — confine traffic to relays you self-host (a single Docker container). Must be non-empty; use `"public"` for public relays.
+
+When set here, config wins over the legacy `VELD_SHARE_RELAY` env var (read from the daemon's process environment, not your shell, and not an enforceable floor — `"relays": "public"` overrides it). The custom-relay guarantee covers the host's outbound leg; a consumer joining over the same self-hosted relays should configure them on their side too. The daemon binds **one iroh endpoint per relay policy** on demand, each with its own node identity (the public endpoint reuses the daemon's persistent identity; custom-relay endpoints get a fresh per-run one), so shares on different relays run concurrently without conflict.
+
+### `sharing.gateway`
+
+Base URL of the public web gateway this environment points at, e.g. `"https://share.acme.internal"`. Only needed by services that `expose` `web`. The gateway is a self-hosted server that joins the share and reverse-proxies it onto a public URL. **Reserved:** the gateway ships in a later release; today only `peer` sharing is served.
+
+### `share.expose`
+
+The audiences a variant may be shared to. A list; an empty list (or an absent `share` block) means the service is never shareable.
+
+| Value  | Audience          | URL fidelity                       | Status         |
+|--------|-------------------|------------------------------------|----------------|
+| `peer` | Other Veld users  | Verbatim — exact origin URL reproduced | Available      |
+| `web`  | Any browser       | Best-effort (rewritten host, operator-configured domain) | Reserved (gateway ships later) |
+
+```json
+"share": { "expose": ["peer", "web"] }
+```
+
+Sharing only ever exposes services with a URL, so `share` is meaningful on `start_server` variants; on a `command` variant it is accepted but inert (nothing to share). A `web`-only opt-in (no `peer`) is not yet shareable — `veld share` reports it distinctly and points you at `peer`.
 
 ---
 

--- a/schema/v2/veld.schema.json
+++ b/schema/v2/veld.schema.json
@@ -59,6 +59,10 @@
       "$ref": "#/$defs/EnvMap",
       "description": "Global environment variables inherited by all node variants. Overridable at node and variant level."
     },
+    "sharing": {
+      "$ref": "#/$defs/SharingConfig",
+      "description": "Environment-wide sharing policy: which relays to route share traffic through, and the public web gateway URL. Per-service opt-in lives on each variant (share)."
+    },
     "setup": {
       "type": "array",
       "description": "Steps that run sequentially before the dependency graph executes. If any step exits non-zero, startup is aborted. Not nodes \u2014 no variants, no health checks, no dependency graph participation.",
@@ -261,6 +265,10 @@
         "cwd": {
           "type": "string",
           "description": "Working directory for this variant. Relative paths are resolved from the project root. Overrides node-level cwd. Supports Veld variable substitution."
+        },
+        "share": {
+          "$ref": "#/$defs/SharePolicy",
+          "description": "Sharing opt-in for this variant. Absent (or an empty expose list) means the service can never be shared — veld share refuses it."
         }
       },
       "allOf": [
@@ -473,6 +481,50 @@
       "description": "A map of environment variable names to values. Values support Veld variable substitution (e.g. ${veld.port}, ${nodes.backend.url}).",
       "additionalProperties": {
         "type": "string"
+      }
+    },
+    "SharingConfig": {
+      "type": "object",
+      "description": "Environment-wide sharing policy.",
+      "additionalProperties": false,
+      "properties": {
+        "relays": {
+          "description": "Which iroh relays to route share traffic through. Must be opted into explicitly (no implicit default) — veld share is refused if unset and no VELD_SHARE_RELAY env override is present. \"public\" uses n0's public relays; an array of URLs confines traffic to self-hosted relays. When set, config wins over the VELD_SHARE_RELAY env override.",
+          "oneOf": [
+            {
+              "const": "public"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1
+            }
+          ]
+        },
+        "gateway": {
+          "type": "string",
+          "description": "Base URL of the public web gateway this environment points at (e.g. https://share.acme.internal). Only needed for services that expose \"web\"."
+        }
+      }
+    },
+    "SharePolicy": {
+      "type": "object",
+      "description": "Per-variant sharing opt-in.",
+      "additionalProperties": false,
+      "properties": {
+        "expose": {
+          "type": "array",
+          "description": "Audiences this service may be exposed to. Empty means not shareable. \"peer\" = other Veld users (verbatim URL). \"web\" = any browser via the public gateway (reserved; ships in a later release).",
+          "items": {
+            "type": "string",
+            "enum": [
+              "peer",
+              "web"
+            ]
+          }
+        }
       }
     },
     "HealthCheck": {

--- a/skills/veld/SKILL.md
+++ b/skills/veld/SKILL.md
@@ -123,6 +123,10 @@ Share a running environment with a colleague so they open the **same** URLs on
 their own machine, over an encrypted P2P tunnel (iroh: QUIC + NAT hole-punching
 + n0 relay fallback). No accounts, no Veld-hosted server.
 
+**Opt-in is required.** A service is shareable only if its variant declares
+`share.expose` in `veld.json`; `veld share` errors on anything that hasn't opted
+in. Add `"share": { "expose": ["peer"] }` to the variant(s) you want to share.
+
 ```sh
 veld share my-feature                       # print a join URL to send (plus a veld join command)
 veld share my-feature --node frontend       # share only specific nodes (repeatable)
@@ -154,10 +158,15 @@ Approval modes: `manual` (host approves each join via the dashboard — which op
 automatically — or `veld approve`), `first` (auto-approve + pin the first
 token-valid joiner, reject the rest), `auto` (approve any token-valid joiner).
 Traffic is end-to-end encrypted; a relay only forwards sealed bytes and never
-sees URLs or content. Set `VELD_SHARE_RELAY=<https url>` on the daemon to use a
-self-hosted iroh-relay instead of n0's public relays. Stopping the run
-(`veld stop`) auto-unshares its shares, and a consumer's join self-tears-down when
-the tunnel closes.
+sees URLs or content. Relay selection is a config compliance control and must be
+opted into explicitly (no implicit default): set `sharing.relays` to `"public"`
+or an array of self-hosted relay URLs, else `veld share` is refused. Config wins
+over the legacy `VELD_SHARE_RELAY` env var (read from the daemon's env, not your
+shell; not an enforceable floor). The daemon binds one iroh endpoint per relay
+policy on demand, so shares on different relays run concurrently. `share.expose` also accepts `web` (public browser access via a
+`sharing.gateway` server) but that gateway ships later; today only `peer` is
+served. Stopping the run (`veld stop`) auto-unshares its shares, and a consumer's
+join self-tears-down when the tunnel closes.
 
 ## Editing veld.json
 

--- a/skills/veld/reference/config.md
+++ b/skills/veld/reference/config.md
@@ -170,3 +170,26 @@ Note: `${VAR}` (braces) is parsed by Veld, so use `$VAR` (no braces) for plain s
 | `skip_if` | variant (`command` only) | Idempotency check — skip step if exits 0. Alias: `verify`. |
 | `probes` | variant | `{readiness?: HealthCheck, liveness?: LivenessProbe}`. Available for both node types. |
 | `actions` | node | Named shell commands exposed via `veld action`/dashboard buttons. See [Actions](#actions). |
+| `sharing` | project | `{relays?: "public" \| [url,...], gateway?: url}`. Relay policy (compliance) + public gateway URL. Config wins over `VELD_SHARE_RELAY`. See [Sharing](#sharing). |
+| `share` | variant | `{expose: ["peer" \| "web", ...]}`. Per-service opt-in — absent/empty = not shareable. See [Sharing](#sharing). |
+
+## Sharing
+
+A service is shareable only if its variant declares `share.expose` — `veld share` refuses anything that hasn't opted in.
+
+```json
+{
+  "sharing": { "relays": "public" },
+  "nodes": {
+    "frontend": {
+      "variants": {
+        "local": { "type": "start_server", "command": "npm run dev", "share": { "expose": ["peer"] } }
+      }
+    }
+  }
+}
+```
+
+- `sharing.relays` — **must be opted into explicitly (no default):** `"public"` (n0's relays) or an array of self-hosted relay URLs (confines share traffic for compliance). `veld share` is refused if unset (and no `VELD_SHARE_RELAY` env). Config wins over the env var. The daemon binds one iroh endpoint per relay policy, so shares on different relays run concurrently (no restart).
+- `sharing.gateway` — base URL of the public web gateway (for `web` exposure). **Reserved:** gateway ships later.
+- `share.expose` — `peer` (Veld-to-Veld, verbatim URL; available now) and/or `web` (any browser via gateway; reserved). Empty list or absent = not shareable.

--- a/website/llms-full.txt
+++ b/website/llms-full.txt
@@ -192,6 +192,8 @@ This makes veld uniquely suited for agentic workflows where AI agents build UI a
 
 Share a running environment with a colleague so they open the **same** URLs on their own machine, over an encrypted peer-to-peer tunnel. No accounts, no Veld-hosted server. The tunnel uses iroh (QUIC with NAT hole-punching and an n0 relay fallback).
 
+Services opt in explicitly: a service is shareable only if its variant declares `share.expose` in `veld.json` (`"share": { "expose": ["peer"] }`), and `veld share` refuses anything that hasn't opted in — so what leaves your machine is explicit and auditable.
+
 ### How it works
 
 1. The host runs `veld share <run>` and gets a **join URL** to send to a colleague: `https://veld.localhost/join#<ticket>` (or `:18443` in unprivileged mode), plus a `veld join <ticket>` command as an alternative (`--json` adds a `join_url` field)
@@ -215,7 +217,7 @@ Two gates protect every share: a capability token embedded in the ticket, plus h
 - **`first`** (default with `--json`) — auto-approves and pins the first token-valid joiner, rejecting the rest
 - **`auto`** — approves any token-valid joiner
 
-Traffic is end-to-end encrypted between the two velds; a relay only forwards sealed bytes and never sees URLs or content. To use a self-hosted relay instead of n0's public relays, set `VELD_SHARE_RELAY=<https url>` on the daemon.
+Traffic is end-to-end encrypted between the two velds; a relay only forwards sealed bytes and never sees URLs or content. Relay selection is a config compliance control and must be opted into explicitly — there is no implicit default, so nothing is routed over n0's public relays by accident: set `sharing.relays` in `veld.json` to `"public"` (n0's relays) or to an array of self-hosted relay URLs to keep share traffic on relays you run. `veld share` is refused if no relay is configured. Config wins over the legacy `VELD_SHARE_RELAY` env var (read from the daemon's process environment, not your shell, and not an enforceable floor). The custom-relay guarantee covers the host's outbound leg; a joining consumer should configure the same relays. The daemon binds one iroh endpoint per relay policy on demand, so shares on different relays (e.g. public and a self-hosted relay) run concurrently without conflict. (`share.expose` also accepts `web` for public browser access via a self-hosted `sharing.gateway`, but the gateway ships in a later release; today only `peer` is served.)
 
 ### Behavior
 


### PR DESCRIPTION
## What

Increment 1 of **Sharing v2** (RFC: `SHARING_V2.md`). Moves sharing from an all-or-nothing runtime action into an auditable, config-declared policy. Public **web** sharing (the gateway) is a later increment; its config surface (`gateway`, `expose: web`) is reserved here so configs stay forward-compatible.

## Changes

- **`sharing.relays`** — `"public"` or an array of self-hosted iroh relay URLs. **Must be opted into explicitly (including public)** — no implicit default, so nothing is ever routed over n0's public relays by accident; `veld share` refuses a run with no relay configured. Config wins over `VELD_SHARE_RELAY`.
- **`sharing.gateway`** — reserved base URL for the future public web gateway.
- **Per-variant `share.expose`** (`peer` / `web`) — a service is shareable only if it opts into `peer`. `veld share` refuses non-opted-in services (candidates named as `node:variant`); a partial share warns which services were excluded.
- **One iroh endpoint per relay policy** — bound on demand, so shares on different relays run concurrently, no restart. Each share is scoped to its endpoint (a custom-relay share is never served over the public endpoint). Join keeps an env-or-public default so bare `veld join <ticket>` still works (joining consumes, doesn't expose).
- Docs, JSON schema, skills updated per the AGENTS.md checklist.

## ⚠️ Breaking change

`veld share` now requires two explicit opt-ins that didn't exist before: each service's `share.expose`, and the run's `sharing.relays`. Missing either → a `BAD_REQUEST` naming the fix. Signalled via `feat(sharing)!:` / `BREAKING CHANGE:` so semantic-release cuts a major + migration note.

## Review

Self-run four-angle adversarial review (`docs/agentic-review.md`), four rounds — R1/R2 on the initial design (misleading remedy, missing tests, breaking signposting, an env-test data race), R3 caught a confinement leak (per-endpoint accept loops matched the global share set → fixed by scoping each share to its endpoint), R4 on the explicit-relay-opt-in change (verified no host bypass; join asymmetry is not a hole — a custom-relay host is unreachable via public relays; fixed one stale doc). All addressed. `cargo fmt`/`clippy`/`test` clean (192 pass).

## Design decisions (with you)

- **Relays explicit, no implicit public** — compliance.
- **Multi-endpoint** — concurrent different-relay shares, no restart.
- **`peer` vs `web`** naming; **`expose` is a list**.

## Not verified locally

Full two-peer-over-relay e2e (daemon/launchd + network gated; tunnel test is `#[ignore]`). Enforcement, relay resolution/opt-in, normalization, message-building, and share→endpoint scoping are unit-tested + adversarially reviewed.