### PR TITLE
feat(feedback): 'Currently running' lane — show the thread the agent is working now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4135,7 +4135,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "veld"
-version = "8.0.4"
+version = "8.0.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4155,7 +4155,7 @@ dependencies = [
 
 [[package]]
 name = "veld-core"
-version = "8.0.4"
+version = "8.0.5"
 dependencies = [
  "anyhow",
  "base64",
@@ -4177,7 +4177,7 @@ dependencies = [
 
 [[package]]
 name = "veld-daemon"
-version = "8.0.4"
+version = "8.0.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -4199,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "veld-helper"
-version = "8.0.4"
+version = "8.0.5"
 dependencies = [
  "anyhow",
  "nix",

--- a/crates/veld-core/src/feedback.rs
+++ b/crates/veld-core/src/feedback.rs
@@ -162,6 +162,13 @@ pub struct Session {
     /// from `status`/`last_heartbeat`, which track agent liveness.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ended_at: Option<DateTime<Utc>>,
+    /// The thread `next` last handed to the agent — session-level observability
+    /// (same class as `last_heartbeat`), NOT claiming: it never affects what
+    /// `next` returns, needs no release, and dies with the session. Cleared by
+    /// the agent's `reply`/`resolve` on that thread and on session stop/end, so
+    /// while set it marks the thread the agent is working right now.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_thread_id: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -532,6 +539,7 @@ impl FeedbackStore {
             status: SessionStatus::Idle,
             last_heartbeat: Utc::now(),
             ended_at: None,
+            current_thread_id: None,
         });
         mutate(&mut session);
 
@@ -549,6 +557,24 @@ impl FeedbackStore {
         self.modify_session(|s| {
             s.status = SessionStatus::Listening;
             s.last_heartbeat = Utc::now();
+        })
+    }
+
+    /// Record the thread `next` just handed to the agent. Overwritten by the
+    /// next delivery — no release step exists or is needed.
+    pub fn set_current_thread(&self, thread_id: &str) -> anyhow::Result<()> {
+        let id = thread_id.to_owned();
+        self.modify_session(move |s| s.current_thread_id = Some(id))
+    }
+
+    /// Clear the delivery marker, but only if it still points at `thread_id` —
+    /// a reply to an older thread must not wipe a newer delivery.
+    pub fn clear_current_thread(&self, thread_id: &str) -> anyhow::Result<()> {
+        let id = thread_id.to_owned();
+        self.modify_session(move |s| {
+            if s.current_thread_id.as_deref() == Some(id.as_str()) {
+                s.current_thread_id = None;
+            }
         })
     }
 
@@ -578,6 +604,28 @@ impl FeedbackStore {
         }
     }
 
+    /// The thread the agent is working right now, if any: the delivery marker,
+    /// readable while the session is Listening and the heartbeat is younger
+    /// than `threshold_secs`. Callers pass a threshold well above the 60s
+    /// liveness window — the heartbeat naturally lapses while the agent edits
+    /// code between `next` and `reply` — it exists only so a crashed agent
+    /// can't pin a thread as "running" forever.
+    pub fn current_thread(&self, threshold_secs: u64) -> anyhow::Result<Option<String>> {
+        match self.get_session()? {
+            Some(session) if session.status == SessionStatus::Listening => {
+                let elapsed = Utc::now()
+                    .signed_duration_since(session.last_heartbeat)
+                    .num_seconds();
+                if elapsed >= 0 && (elapsed as u64) < threshold_secs {
+                    Ok(session.current_thread_id)
+                } else {
+                    Ok(None)
+                }
+            }
+            _ => Ok(None),
+        }
+    }
+
     /// Explicitly end the session — the human clicked "Done".
     ///
     /// Sets `ended_at`, which `is_ended` reads. When the agent's queue drains,
@@ -591,6 +639,7 @@ impl FeedbackStore {
             s.status = SessionStatus::Idle;
             s.last_heartbeat = now;
             s.ended_at = Some(now);
+            s.current_thread_id = None;
         })
     }
 
@@ -604,6 +653,7 @@ impl FeedbackStore {
         self.modify_session(|s| {
             s.status = SessionStatus::Idle;
             s.ended_at = None;
+            s.current_thread_id = None;
         })
     }
 
@@ -934,6 +984,40 @@ mod tests {
         assert!(!store.is_listening(60).unwrap());
         let session = store.get_session().unwrap().unwrap();
         assert_eq!(session.status, SessionStatus::Idle);
+    }
+
+    #[test]
+    fn test_current_thread_marker() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp);
+
+        // Nothing running without a session.
+        assert!(store.current_thread(1800).unwrap().is_none());
+
+        // Delivery sets the marker; readable while listening.
+        store.heartbeat().unwrap();
+        store.set_current_thread("t-1").unwrap();
+        assert_eq!(store.current_thread(1800).unwrap().as_deref(), Some("t-1"));
+
+        // A clear for a different thread must not wipe a newer delivery.
+        store.clear_current_thread("t-0").unwrap();
+        assert_eq!(store.current_thread(1800).unwrap().as_deref(), Some("t-1"));
+
+        // A matching clear (reply/resolve on that thread) removes it.
+        store.clear_current_thread("t-1").unwrap();
+        assert!(store.current_thread(1800).unwrap().is_none());
+
+        // Session end clears an in-flight marker.
+        store.set_current_thread("t-2").unwrap();
+        store.end_session().unwrap();
+        assert!(store.get_session().unwrap().unwrap().current_thread_id.is_none());
+        assert!(store.current_thread(1800).unwrap().is_none());
+
+        // mark_stopped clears it too (agent exiting mid-thread).
+        store.heartbeat().unwrap();
+        store.set_current_thread("t-3").unwrap();
+        store.mark_stopped().unwrap();
+        assert!(store.current_thread(1800).unwrap().is_none());
     }
 
     #[test]

--- a/crates/veld-daemon/frontend/dev/index.html
+++ b/crates/veld-daemon/frontend/dev/index.html
@@ -260,9 +260,9 @@
         if (/\/events/.test(path)) {
           return _mockJson([]);
         }
-        // GET /session (listen status)
+        // GET /session (listen status + the thread `next` handed the agent)
         if (/\/session/.test(path)) {
-          return _mockJson({ listening: true });
+          return _mockJson({ listening: true, current_thread_id: "thread-3" });
         }
         // POST /client-logs
         if (/\/client-logs/.test(path)) {

--- a/crates/veld-daemon/frontend/src/feedback-overlay.css
+++ b/crates/veld-daemon/frontend/src/feedback-overlay.css
@@ -646,6 +646,21 @@
   text-align: center; opacity: .8;
 }
 
+/* --- "Currently running" lane (live agent work, derived from the queue head) --- */
+.veld-feedback-panel-section-running .veld-feedback-panel-section-heading {
+  color: var(--vf-accent); border-bottom-color: var(--vf-accent);
+}
+.veld-feedback-panel-section-running .veld-feedback-thread-card {
+  border-left: 3px solid var(--vf-accent); padding-left: 9px;
+}
+.veld-feedback-panel-section-running .veld-feedback-panel-section-icon {
+  animation: veld-feedback-running-blink 1.6s ease-in-out infinite;
+}
+@keyframes veld-feedback-running-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: .35; }
+}
+
 /* --- Thread card (compact) --- */
 .veld-feedback-thread-card {
   background: var(--vf-bg-card); border-radius: 8px;

--- a/crates/veld-daemon/frontend/src/feedback-overlay/constants.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/constants.ts
@@ -22,6 +22,7 @@ export const ICONS = {
   back: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>',
   copy: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>',
   person: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>',
+  activity: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>',
   dashboard: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>',
   panelSide: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="7 16 3 12 7 8"/><polyline points="17 16 21 12 17 8"/></svg>',
   dock: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="15" y1="3" x2="15" y2="21"/></svg>',

--- a/crates/veld-daemon/frontend/src/feedback-overlay/listening.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/listening.ts
@@ -4,6 +4,7 @@ import { PREFIX } from "./constants";
 import { api } from "./api";
 import { toast } from "./toast";
 import { positionRadialButtons } from "./toolbar";
+import { deps } from "../shared/registry";
 
 export function updateListeningModule(): void {
   if (refs.fab) {
@@ -11,6 +12,9 @@ export function updateListeningModule(): void {
   }
   // Recompute radial layout since listening dot visibility changed
   positionRadialButtons();
+  // The "Currently running" lane derives from listening state — keep an open
+  // panel in sync when the agent session starts or stops.
+  if (getState().panelOpen) deps().renderPanel();
 }
 
 export function sendAllGood(): void {

--- a/crates/veld-daemon/frontend/src/feedback-overlay/panel.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/panel.ts
@@ -348,13 +348,27 @@ function renderActiveThreads(): void {
   // (or none yet) is in the agent's queue ("With the agent"). Both lanes always
   // render — with a count and an empty state when there's nothing in them.
   const yourTurn = active.filter(function (t) { return lastMessageAuthor(t) === "agent"; }).sort(byRecency);
-  const withAgent = active.filter(function (t) { return lastMessageAuthor(t) !== "agent"; }).sort(byRecency);
+  let withAgent = active.filter(function (t) { return lastMessageAuthor(t) !== "agent"; }).sort(byRecency);
+
+  // "Currently running": the thread `next` actually handed the agent (from
+  // /session), not a client-side guess — the agent's reply/resolve clears it
+  // server-side. Shown whenever a delivery is in flight; while the agent is
+  // merely listening with nothing delivered, the lane shows as idle. Hidden
+  // entirely when no agent session is live.
+  const currentId = getState().currentThreadId;
+  const running = currentId
+    ? active.filter(function (t) { return t.id === currentId; })
+    : [];
+  if (running.length || getState().agentListening) {
+    withAgent = withAgent.filter(function (t) { return t.id !== currentId; });
+    renderLane("Currently running", ICONS.activity, running, "Agent is live — picking up the next thread.", "panel-section-running");
+  }
   renderLane("Your turn", ICONS.person, yourTurn, "Nothing needs your reply.");
   renderLane("With the agent", ICONS.robot, withAgent, "Nothing waiting on the agent.");
 }
 
-function renderLane(label: string, icon: string, threads: Thread[], emptyText: string): void {
-  const section = mkEl("div", "panel-section");
+function renderLane(label: string, icon: string, threads: Thread[], emptyText: string, extraClass?: string): void {
+  const section = mkEl("div", "panel-section" + (extraClass ? " " + extraClass : ""));
   const heading = mkEl("div", "panel-section-heading");
   const iconEl = mkEl("span", "panel-section-icon");
   iconEl.innerHTML = icon;

--- a/crates/veld-daemon/frontend/src/feedback-overlay/polling.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/polling.ts
@@ -51,10 +51,19 @@ let announcedListening = false;
 
 export function pollListenStatus(): void {
   api("GET", "/session").then(function (raw) {
-    const data = raw as { listening?: boolean } | null;
+    const data = raw as { listening?: boolean; current_thread_id?: string | null } | null;
     const wasListening = getState().agentListening;
     const nowListening = !!(data && data.listening);
     dispatch({ type: "SET_LISTENING", listening: nowListening });
+    // The thread `next` last handed the agent — drives the panel's
+    // "Currently running" lane. Re-render on change so the lane follows the
+    // agent from thread to thread without waiting for a message event.
+    const wasCurrent = getState().currentThreadId;
+    const nowCurrent = (data && data.current_thread_id) || null;
+    if (nowCurrent !== wasCurrent) {
+      dispatch({ type: "SET_CURRENT_THREAD", threadId: nowCurrent });
+      if (getState().panelOpen) deps().renderPanel();
+    }
     if (nowListening !== wasListening) updateListeningModule();
     if (listeningPrimed && !wasListening && nowListening) notifyAgentListening();
     listeningPrimed = true;

--- a/crates/veld-daemon/frontend/src/feedback-overlay/store.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/store.ts
@@ -7,6 +7,8 @@ export interface Store {
   threads: Thread[];
   lastEventSeq: number;
   agentListening: boolean;
+  /** Thread `next` last handed the agent (from /session) — null when idle. */
+  currentThreadId: string | null;
 
   // UI state
   panelOpen: boolean;
@@ -57,6 +59,7 @@ export type Action =
   | { type: "SET_HOVERED"; el: Element | null }
   | { type: "SET_LOCKED"; el: Element | null }
   | { type: "SET_LISTENING"; listening: boolean }
+  | { type: "SET_CURRENT_THREAD"; threadId: string | null }
   | { type: "SET_CAPTURE_STREAM"; stream: MediaStream | null }
   | { type: "SET_PIN"; threadId: string; el: HTMLElement }
   | { type: "REMOVE_PIN"; threadId: string }
@@ -105,6 +108,8 @@ function reduce(s: Store, action: Action): Store {
       return { ...s, lockedEl: action.el };
     case "SET_LISTENING":
       return { ...s, agentListening: action.listening };
+    case "SET_CURRENT_THREAD":
+      return { ...s, currentThreadId: action.threadId };
     case "SET_CAPTURE_STREAM":
       return { ...s, captureStream: action.stream };
     case "SET_PIN": {
@@ -174,6 +179,7 @@ function createInitial(): Store {
     threads: [],
     lastEventSeq: 0,
     agentListening: false,
+    currentThreadId: null,
     panelOpen: false,
     panelSide: readPanelSide(),
     panelMode: readPanelMode(),

--- a/crates/veld-daemon/frontend/tests/panel.test.ts
+++ b/crates/veld-daemon/frontend/tests/panel.test.ts
@@ -154,6 +154,70 @@ describe("renderPanel — list view", () => {
     const cards = refs.panelBody.querySelectorAll("." + PREFIX + "thread-card");
     expect(cards.length).toBe(1);
   });
+
+  it("shows no 'Currently running' lane when no agent session is live", () => {
+    dispatch({
+      type: "SET_THREADS",
+      threads: [makeThread({ id: "t1", messages: [makeMessage({ author: "human" })] })],
+    });
+    dispatch({ type: "SET_PANEL_TAB", tab: "active" });
+    renderPanel();
+    expect(refs.panelBody.textContent).not.toContain("Currently running");
+    const sections = refs.panelBody.querySelectorAll("." + PREFIX + "panel-section");
+    expect(sections.length).toBe(2);
+  });
+
+  it("shows the thread `next` handed the agent under 'Currently running'", () => {
+    dispatch({
+      type: "SET_THREADS",
+      threads: [
+        // Delivered to the agent via `next` → currently running.
+        makeThread({ id: "t-running", messages: [makeMessage({ author: "human" })] }),
+        // Waiting — stays in the agent's queue.
+        makeThread({ id: "t-queued", messages: [makeMessage({ author: "human" })] }),
+      ],
+    });
+    dispatch({ type: "SET_CURRENT_THREAD", threadId: "t-running" });
+    dispatch({ type: "SET_PANEL_TAB", tab: "active" });
+    renderPanel();
+
+    expect(refs.panelBody.textContent).toContain("Currently running (1)");
+    expect(refs.panelBody.textContent).toContain("With the agent (1)");
+    const running = refs.panelBody.querySelector("." + PREFIX + "panel-section-running");
+    expect(running).not.toBeNull();
+    const runningCard = running!.querySelector("." + PREFIX + "thread-card") as HTMLElement;
+    expect(runningCard.dataset.threadId).toBe("t-running");
+  });
+
+  it("shows an idle 'Currently running' lane while listening with nothing delivered", () => {
+    dispatch({ type: "SET_LISTENING", listening: true });
+    dispatch({
+      type: "SET_THREADS",
+      threads: [makeThread({ id: "t1", messages: [makeMessage({ author: "agent" })] })],
+    });
+    dispatch({ type: "SET_PANEL_TAB", tab: "active" });
+    renderPanel();
+
+    expect(refs.panelBody.textContent).toContain("Currently running (0)");
+    const sections = refs.panelBody.querySelectorAll("." + PREFIX + "panel-section");
+    expect(sections.length).toBe(3);
+  });
+
+  it("drops a running thread from the lane once it is resolved", () => {
+    // Session still live, but the delivered thread got resolved (e.g. by the
+    // human) before the marker cleared — it must not linger as "running".
+    dispatch({ type: "SET_LISTENING", listening: true });
+    dispatch({
+      type: "SET_THREADS",
+      threads: [makeThread({ id: "t-done", status: "resolved", messages: [makeMessage({ author: "human" })] })],
+    });
+    dispatch({ type: "SET_CURRENT_THREAD", threadId: "t-done" });
+    dispatch({ type: "SET_PANEL_TAB", tab: "active" });
+    renderPanel();
+    const running = refs.panelBody.querySelector("." + PREFIX + "panel-section-running");
+    expect(running).not.toBeNull();
+    expect(running!.querySelector("." + PREFIX + "thread-card")).toBeNull();
+  });
 });
 
 describe("renderPanel — detail view", () => {

--- a/crates/veld-daemon/frontend/tests/polling.test.ts
+++ b/crates/veld-daemon/frontend/tests/polling.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { showAgentReplyToast, loadThreads } from "../src/feedback-overlay/polling";
+import { showAgentReplyToast, loadThreads, pollListenStatus } from "../src/feedback-overlay/polling";
 import { refs } from "../src/feedback-overlay/refs";
 import { dispatch, getState } from "../src/feedback-overlay/store";
 import { PREFIX } from "../src/feedback-overlay/constants";
@@ -99,5 +99,36 @@ describe("loadThreads", () => {
     await new Promise((r) => setTimeout(r, 10));
     // State unchanged
     expect(getState().threads).toEqual([]);
+  });
+});
+
+describe("pollListenStatus", () => {
+  let fakeDeps: ReturnType<typeof setupMockRefs>["deps"];
+
+  beforeEach(() => {
+    fakeDeps = setupMockRefs().deps;
+    mockApi.mockReset();
+  });
+
+  it("stores current_thread_id from /session and re-renders an open panel", async () => {
+    dispatch({ type: "SET_PANEL_OPEN", open: true });
+    mockApi.mockResolvedValueOnce({ listening: true, current_thread_id: "t-x" });
+
+    pollListenStatus();
+    await vi.waitFor(() => {
+      expect(getState().currentThreadId).toBe("t-x");
+    });
+    expect(getState().agentListening).toBe(true);
+    expect(fakeDeps.renderPanel).toHaveBeenCalled();
+  });
+
+  it("clears the current thread when the session reports none", async () => {
+    dispatch({ type: "SET_CURRENT_THREAD", threadId: "t-x" });
+    mockApi.mockResolvedValueOnce({ listening: false });
+
+    pollListenStatus();
+    await vi.waitFor(() => {
+      expect(getState().currentThreadId).toBeNull();
+    });
   });
 });

--- a/crates/veld-daemon/src/feedback_server.rs
+++ b/crates/veld-daemon/src/feedback_server.rs
@@ -630,14 +630,30 @@ async fn get_session(
 
     // Don't report "listening" once the reviewer clicked Done — even while the
     // agent drains the last items — so the FAB doesn't re-pulse after Done.
+    let ended = store
+        .is_ended()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     let listening = store
         .is_listening(60)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-        && !store
-            .is_ended()
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        && !ended;
 
-    Ok(Json(serde_json::json!({ "listening": listening })))
+    // The thread `next` last handed the agent — the overlay's "Currently
+    // running" lane. Read with a 30-minute window rather than the 60s
+    // liveness one: the heartbeat naturally lapses while the agent edits code
+    // between `next` and `reply`, and the marker is cleared by reply/resolve
+    // anyway; the cap only stops a crashed agent pinning a thread forever.
+    let current_thread_id = if ended {
+        None
+    } else {
+        store
+            .current_thread(1800)
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    };
+
+    Ok(Json(
+        serde_json::json!({ "listening": listening, "current_thread_id": current_thread_id }),
+    ))
 }
 
 async fn end_session(

--- a/crates/veld/src/commands/feedback.rs
+++ b/crates/veld/src/commands/feedback.rs
@@ -289,6 +289,10 @@ async fn run_next(name: Option<String>, wait: bool, timeout: u64, json: bool) ->
     loop {
         match store.next_waiting_thread() {
             Ok(Some(thread)) => {
+                // Record the delivery so the overlay can show this thread as
+                // "currently running". Session metadata only (like the
+                // heartbeat) — the queue itself stays a pure read.
+                let _ = store.set_current_thread(&thread.id);
                 emit_next("item", Some(&thread), &store, json);
                 let _ = store.heartbeat();
                 return 0;
@@ -391,6 +395,8 @@ async fn run_reply(name: Option<String>, thread_id: &str, body: &str) -> i32 {
     // Keep the session alive while the agent works items, so `is_listening`
     // doesn't lapse between `next` calls and flap the "listening" indicator.
     let _ = store.heartbeat();
+    // The reply blocks the thread — it is no longer the one being worked.
+    let _ = store.clear_current_thread(&thread_id);
 
     output::print_info(&format!(
         "Replied to thread {thread_id} — now waiting on the reviewer."
@@ -431,6 +437,7 @@ async fn run_resolve(name: Option<String>, thread_id: &str) -> i32 {
     }
 
     let _ = store.heartbeat();
+    let _ = store.clear_current_thread(&thread_id);
     output::print_info(&format!("Resolved thread {thread_id}."));
     0
 }


### PR DESCRIPTION
## What

The overlay's Threads panel gets a third lane above "Your turn" / "With the agent": **"Currently running"** — the thread the agent is working on *right now*. Feedback lifecycle becomes: with the agent → **currently running** → your turn → resolved, so the reviewer can see live where their feedback stands.

## Design — a delivery beacon, not claiming

I know §9 of FEEDBACK_REDESIGN deleted claiming, so to be explicit about why this isn't that: `next` already writes session liveness on every call (heartbeat + `AgentListening`). This PR records alongside it **which head it handed out** — `Session.current_thread_id`. It's observability in the same class as the heartbeat:

- **`next` queue semantics stay a pure read** — the marker never affects what `next` returns, to anyone.
- **No release ceremony** — the agent's own `reply`/`resolve` clears it (only-if-match, so a late reply can't wipe a newer delivery); `end_session`/`mark_stopped` clear it too.
- **Crash-safe** — a dead agent's marker is capped by a 30-minute read window on the daemon side; the thread itself was never blocked from re-delivery.

Why not derive it client-side (queue head while listening)? Because the 60s heartbeat window lapses exactly while the agent edits code between `next` and `reply` — the indicator would vanish precisely when work is happening. Hence the persisted marker with a wider read window.

## Changes

- **core**: `Session.current_thread_id` (additive, serde-default — old files parse fine), `set_current_thread` / `clear_current_thread` / `current_thread(ttl)`.
- **cli**: `next` records the delivered thread; `reply`/`resolve` clear it.
- **daemon**: `/session` response gains `current_thread_id` (30-min window, suppressed after Done).
- **overlay**: accent-styled "Currently running" lane with a pulsing activity icon; the running thread is pulled out of "With the agent"; idle state while listening with nothing delivered; the lane disappears when no agent session is live.

## Testing

- Core: marker lifecycle test (set, mismatched clear, matching clear, end/stop clears).
- Overlay: 6 new cases across `panel.test.ts` / `polling.test.ts` — 220 pass, `tsc --noEmit` clean.
- E2E with the compiled CLI against a scratch store: `next` → `session.json` carries the id → `reply` → cleared.

## Open questions

1. Is 30 min the right crash cap for the `/session` read window, or would you rather key it off something else?
2. Should the browser also get a push signal (event) on delivery, or is the existing `/session` poll cadence fine? (I kept it poll-only to stay additive.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
