### PR TITLE
fix(ci): extract gateway tarball without naming member

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,8 +243,11 @@ jobs:
         run: |
           VERSION="${{ needs.plan.outputs.new_release_version }}"
           mkdir -p dist/amd64 dist/arm64
-          tar -xzf "artifacts/veld-gateway-${VERSION}-linux-amd64.tar.gz" -C dist/amd64 veld-gateway
-          tar -xzf "artifacts/veld-gateway-${VERSION}-linux-arm64.tar.gz" -C dist/arm64 veld-gateway
+          # The tarballs are packed with `-C dist-gateway .`, so the binary is
+          # stored as `./veld-gateway` — extract everything instead of naming
+          # the member, which GNU tar would reject as "Not found in archive".
+          tar -xzf "artifacts/veld-gateway-${VERSION}-linux-amd64.tar.gz" -C dist/amd64
+          tar -xzf "artifacts/veld-gateway-${VERSION}-linux-arm64.tar.gz" -C dist/arm64
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Problem

The v9.3.0 release run failed in the **Publish veld-gateway image** job:

```
tar: veld-gateway: Not found in archive
tar: Exiting with failure status due to previous errors
```

The gateway tarball is packed with `tar -czf ... -C dist-gateway .`, which stores the binary as `./veld-gateway`. The extract step asked GNU tar for the exact member name `veld-gateway`, which doesn't match.

## Fix

Extract the whole archive instead of naming the member. The tarball contains only the binary, and it still lands at `dist/<arch>/veld-gateway` where the Dockerfile's `TARGETARCH` COPY expects it.

Verified locally against the actual v9.3.0 release asset: extraction without a member name succeeds and produces `dist/amd64/veld-gateway` (ELF x86-64).

## Note

The v9.3.0 image was never published, and re-running the failed job won't help — a re-run uses the workflow file from the original commit. This lands as `fix(ci)` so the next release (9.3.1) publishes the image.