### PR TITLE
fix(gateway): set hyper timer so header_read_timeout doesn't panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4240,7 +4240,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "veld"
-version = "9.2.0"
+version = "9.3.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "veld-core"
-version = "9.2.0"
+version = "9.3.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -4282,7 +4282,7 @@ dependencies = [
 
 [[package]]
 name = "veld-daemon"
-version = "9.2.0"
+version = "9.3.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -4306,7 +4306,7 @@ dependencies = [
 
 [[package]]
 name = "veld-gateway"
-version = "9.2.0"
+version = "9.3.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -4335,7 +4335,7 @@ dependencies = [
 
 [[package]]
 name = "veld-helper"
-version = "9.2.0"
+version = "9.3.1"
 dependencies = [
  "anyhow",
  "nix",
@@ -4351,7 +4351,7 @@ dependencies = [
 
 [[package]]
 name = "veld-share"
-version = "9.2.0"
+version = "9.3.1"
 dependencies = [
  "anyhow",
  "dirs",

--- a/crates/veld-gateway/src/server.rs
+++ b/crates/veld-gateway/src/server.rs
@@ -96,6 +96,9 @@ fn harden<A>(server: &mut axum_server::Server<A>) {
     server
         .http_builder()
         .http1()
+        // hyper panics on every connection if a timeout is configured without
+        // a timer ("timeout `header_read_timeout` set, but no timer set").
+        .timer(hyper_util::rt::TokioTimer::new())
         .header_read_timeout(HEADER_READ_TIMEOUT);
 }
 
@@ -224,5 +227,28 @@ mod tests {
         assert_eq!(host_without_port("a.example:8443"), "a.example");
         assert_eq!(host_without_port("a.example"), "a.example");
         assert_eq!(host_without_port("[::1]:8080"), "::1");
+    }
+
+    /// Regression: `header_read_timeout` without an explicit timer makes hyper
+    /// panic on every connection ("timeout `header_read_timeout` set, but no
+    /// timer set"), so a hardened server answered nothing. A request through
+    /// the hardened listener must succeed.
+    #[tokio::test]
+    async fn hardened_server_answers_requests() {
+        let app = axum::Router::new()
+            .route("/healthz", axum::routing::get(|| async { "ok" }))
+            .into_make_service();
+
+        let handle = axum_server::Handle::new();
+        let mut server = axum_server::bind("127.0.0.1:0".parse().unwrap()).handle(handle.clone());
+        harden(&mut server);
+        tokio::spawn(server.serve(app));
+
+        let addr = handle.listening().await.expect("server bound");
+        let resp = reqwest::get(format!("http://{addr}/healthz"))
+            .await
+            .expect("hardened server must answer, not panic the connection task");
+        assert_eq!(resp.status(), 200);
+        handle.shutdown();
     }
 }


### PR DESCRIPTION
## Problem

Deploying the veld-gateway container, every incoming connection crashed with:

```
thread 'tokio-rt-worker' panicked at hyper-1.8.1/src/common/time.rs:80:32:
timeout `header_read_timeout` set, but no timer set
```

so the gateway never answered a single request — `veld share --web` got `502 Bad Gateway … (503 Service Unavailable): upstream connect error` from the platform's edge proxy.

## Cause

`harden()` (added in #138 as a slowloris guard) configures `header_read_timeout` on hyper's connection builder. hyper 1.x does not know how to sleep on its own: any configured timeout requires an explicit runtime timer, otherwise it panics on first use — i.e. on **every accepted connection**. The panic killed each connection task; the process stayed "healthy" while serving nothing.

It slipped through because the loopback test drives `tunnel::connect` directly and never goes through the hardened listener.

## Fix

Set `TokioTimer` on the http1 builder before the timeout (`crates/veld-gateway/src/server.rs`).

## Test

New regression test `hardened_server_answers_requests` binds a hardened server and sends a real HTTP request through it. Verified it fails with the exact production panic when the `.timer(...)` line is removed, and passes with it.

`Cargo.lock` hunk is just the workspace crate version sync to 9.3.1.