### PR TITLE
fix(gateway): drop Origin on WebSocket upgrades so dev-server HMR works

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4250,7 +4250,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "veld"
-version = "9.4.0"
+version = "9.5.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "veld-core"
-version = "9.4.0"
+version = "9.5.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -4292,7 +4292,7 @@ dependencies = [
 
 [[package]]
 name = "veld-daemon"
-version = "9.4.0"
+version = "9.5.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4316,7 +4316,7 @@ dependencies = [
 
 [[package]]
 name = "veld-gateway"
-version = "9.4.0"
+version = "9.5.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4347,7 +4347,7 @@ dependencies = [
 
 [[package]]
 name = "veld-helper"
-version = "9.4.0"
+version = "9.5.0"
 dependencies = [
  "anyhow",
  "nix",
@@ -4363,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "veld-share"
-version = "9.4.0"
+version = "9.5.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/SHARING_V2.md
+++ b/SHARING_V2.md
@@ -640,7 +640,12 @@ Three independent increments; ship top-down.
 **Settled while implementing (review-driven)**
 - Upstream `Host` is rewritten to the **origin** hostname, and `Origin` +
   `Referer` are rewritten in lockstep, so an Origin-checking dev server sees a
-  coherent same-origin request. `X-Forwarded-*`/`Forwarded` are stripped
+  coherent same-origin request. Exception: on **upgrade requests** (WebSocket
+  HMR) `Origin` is dropped, not rewritten — Next's dev server allow-lists WS
+  origins against `localhost`/`allowedDevOrigins` only (its own hostname
+  doesn't pass) and destroys the socket on mismatch, while an absent Origin is
+  accepted; the local helper Caddy strips Origin for the same reason.
+  `X-Forwarded-*`/`Forwarded` are stripped
   inbound and set authoritatively (the gateway is the public trust boundary);
   `Referrer-Policy: no-referrer` is emitted so the slug doesn't leak.
 - Relay confinement on the gateway is an **allow-list** with tokens resolved

--- a/crates/veld-gateway/src/proxy.rs
+++ b/crates/veld-gateway/src/proxy.rs
@@ -9,7 +9,11 @@
 //! host allow-lists and already accept their own `*.localhost` hostname, so
 //! this makes the flagship case work zero-config. `Origin` and `Referer` are
 //! rewritten to the origin in lockstep with `Host`, so an Origin-checking dev
-//! server sees a coherent same-origin request. The public host travels in
+//! server sees a coherent same-origin request — except on **upgrade requests**,
+//! where `Origin` is dropped instead: Next's HMR WebSocket allow-lists origins
+//! against `localhost`/`allowedDevOrigins` (its own hostname doesn't pass) and
+//! destroys the socket on mismatch, while an absent Origin is accepted. The
+//! public host travels in
 //! `X-Forwarded-Host` (`X-Forwarded-*`/`Forwarded` from the client are stripped
 //! — the gateway is the public trust boundary). On the way back: `Location`
 //! redirects and `Access-Control-Allow-Origin` values naming origin hostnames
@@ -257,12 +261,21 @@ fn build_upstream_request(
     // host would manufacture a cross-origin request that Origin-checking dev
     // servers (Next Server Actions, Vite's DNS-rebinding guard) reject — the
     // dev server must see a coherent same-origin request.
+    //
+    // EXCEPT on upgrade requests: Origin is DROPPED there, never rewritten.
+    // Next's dev server (webpack/turbopack HMR) allow-lists WS origins against
+    // `localhost` + `allowedDevOrigins` — its own serving hostname does NOT
+    // pass, so a rewritten Origin gets the socket destroyed without a response
+    // (surfacing as a 502 and dead HMR). Dev servers accept an absent Origin
+    // (non-browser clients), and the local helper Caddy has stripped Origin
+    // for exactly this reason since `aed79c9` — this mirrors that proven
+    // behavior on the gateway's upgrade path.
     headers.insert(
         header::HOST,
         HeaderValue::from_str(origin_hostname)
             .map_err(|_| (StatusCode::BAD_GATEWAY, "invalid origin hostname"))?,
     );
-    if parts.headers.contains_key(header::ORIGIN) {
+    if !is_upgrade && parts.headers.contains_key(header::ORIGIN) {
         if let Ok(v) = HeaderValue::from_str(origin) {
             headers.insert(header::ORIGIN, v);
         }
@@ -831,6 +844,59 @@ mod tests {
         )
         .unwrap();
         assert!(out.headers().get(header::COOKIE).is_none());
+    }
+
+    #[test]
+    fn upgrade_requests_drop_origin_instead_of_rewriting() {
+        // Regression (Next.js HMR): the dev server allow-lists WS origins
+        // against localhost/allowedDevOrigins — its own hostname does NOT
+        // pass — and destroys the socket on mismatch. The upgrade path must
+        // send NO Origin at all; the non-upgrade path keeps the rewrite.
+        let req = axum::http::Request::builder()
+            .method("GET")
+            .uri("/_next/webpack-hmr?id=abc")
+            .header("host", "abc.share.example")
+            .header("origin", "https://abc.share.example")
+            .header("connection", "keep-alive, Upgrade")
+            .header("upgrade", "websocket")
+            .body(Body::empty())
+            .unwrap();
+        let (parts, _) = req.into_parts();
+        let out = build_upstream_request(
+            &parts,
+            "app.demo.p.localhost",
+            "https://app.demo.p.localhost",
+            "abc.share.example",
+            None,
+            true,
+        )
+        .unwrap();
+        assert!(out.headers().get(header::ORIGIN).is_none());
+        assert_eq!(out.headers().get(header::UPGRADE).unwrap(), "websocket");
+        assert_eq!(out.headers().get(header::CONNECTION).unwrap(), "upgrade");
+
+        // Same request, non-upgrade: Origin is rewritten to the origin.
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/action")
+            .header("host", "abc.share.example")
+            .header("origin", "https://abc.share.example")
+            .body(Body::empty())
+            .unwrap();
+        let (parts, _) = req.into_parts();
+        let out = build_upstream_request(
+            &parts,
+            "app.demo.p.localhost",
+            "https://app.demo.p.localhost",
+            "abc.share.example",
+            None,
+            false,
+        )
+        .unwrap();
+        assert_eq!(
+            out.headers().get(header::ORIGIN).unwrap(),
+            "https://app.demo.p.localhost"
+        );
     }
 
     #[test]

--- a/crates/veld-gateway/src/proxy.rs
+++ b/crates/veld-gateway/src/proxy.rs
@@ -123,7 +123,17 @@ pub async fn handle(state: AppState, target: SlugTarget, req: Request) -> Respon
         {
             Ok(Ok(r)) => r,
             Ok(Err(e)) => {
-                debug!(error = %e, hostname = %target.hostname, "upstream request failed");
+                // On the upgrade path this is the signature of a dev server
+                // destroying the handshake socket without a response (Next's
+                // dev-origin gate did exactly that before the Origin drop) —
+                // warn with the classification so a recurrence is diagnosable
+                // from the gateway logs alone.
+                if is_upgrade {
+                    warn!(error = %e, hostname = %target.hostname,
+                        "upstream closed the upgrade handshake without responding");
+                } else {
+                    debug!(error = %e, hostname = %target.hostname, "upstream request failed");
+                }
                 return (
                     StatusCode::BAD_GATEWAY,
                     "the shared service did not respond",
@@ -131,7 +141,7 @@ pub async fn handle(state: AppState, target: SlugTarget, req: Request) -> Respon
                     .into_response();
             }
             Err(_) => {
-                debug!(hostname = %target.hostname, "upstream response timed out");
+                debug!(hostname = %target.hostname, is_upgrade, "upstream response timed out");
                 return (
                     StatusCode::GATEWAY_TIMEOUT,
                     "the shared service did not respond in time",
@@ -142,6 +152,14 @@ pub async fn handle(state: AppState, target: SlugTarget, req: Request) -> Respon
 
     if upstream_resp.status() == StatusCode::SWITCHING_PROTOCOLS {
         return splice_upgrade(upstream_resp, client_upgrade, &target.hostname);
+    }
+    if is_upgrade {
+        // The client asked to upgrade but the origin answered with a normal
+        // response (e.g. a 4xx from an origin-gating dev server): pass it
+        // through, but leave a trace — this is the first thing to look for
+        // when someone reports "HMR doesn't work through the share".
+        debug!(status = %upstream_resp.status(), hostname = %target.hostname,
+            "upgrade request answered without 101; relaying as plain response");
     }
 
     let (mut resp_parts, resp_body) = upstream_resp.into_parts();
@@ -187,6 +205,13 @@ fn forwarded_for_value(
 }
 
 /// True when the request asks to switch protocols (WebSockets, HMR).
+///
+/// This detects HTTP/1.1 upgrade semantics only. An HTTP/2 WebSocket (RFC
+/// 8441 extended CONNECT: `:method=CONNECT` + `:protocol=websocket`, no
+/// Upgrade/Connection headers) is intentionally unsupported — the server
+/// never enables h2 connect-protocol, so browsers fall back to a separate
+/// HTTP/1.1 socket for WS. If connect-protocol is ever enabled, this
+/// detection (and the splice path) must learn the h2 shape first.
 fn wants_upgrade(headers: &HeaderMap) -> bool {
     headers.contains_key(header::UPGRADE)
         && headers
@@ -268,8 +293,16 @@ fn build_upstream_request(
     // pass, so a rewritten Origin gets the socket destroyed without a response
     // (surfacing as a 502 and dead HMR). Dev servers accept an absent Origin
     // (non-browser clients), and the local helper Caddy has stripped Origin
-    // for exactly this reason since `aed79c9` — this mirrors that proven
-    // behavior on the gateway's upgrade path.
+    // for exactly this reason since `aed79c9`. (Origin-REQUIRED WS gates —
+    // Rails ActionCable, Django Channels, strict Phoenix check_origin —
+    // reject an absent Origin, but those are already broken through the
+    // local Caddy for the same reason; the invariant is "works locally
+    // implies works shared", and the flagship WS use case is browser HMR.) NOTE the deliberate divergence:
+    // Caddy deletes Origin on ALL requests (a local browser's Origin already
+    // matches Host, so nothing is lost), while the gateway drops it ONLY on
+    // upgrades — non-upgrade requests keep the rewrite above because Next
+    // Server Actions require a coherent Origin/Host pair. Don't "align" the
+    // two by deleting unconditionally here.
     headers.insert(
         header::HOST,
         HeaderValue::from_str(origin_hostname)
@@ -365,11 +398,25 @@ fn splice_upgrade(
     };
 
     // Mirror the origin's 101 response head to the client (minus hop-by-hop
-    // noise hyper re-adds itself).
+    // noise hyper re-adds itself). This path deliberately BYPASSES
+    // `rewrite_response_headers` — Location/ACAO/Referrer-Policy/cache
+    // rewrites are meaningless on a 101 — so any guard that must hold on
+    // every response needs mirroring here. Today that is exactly one rule:
+    // the upstream must never (re)set the gateway's own session cookie
+    // (same reasoning as in `rewrite_response_headers`).
     let mut client_resp = Response::builder().status(StatusCode::SWITCHING_PROTOCOLS);
     if let Some(headers) = client_resp.headers_mut() {
         for (name, value) in upstream_resp.headers() {
             if name == header::CONNECTION {
+                continue;
+            }
+            if name == header::SET_COOKIE
+                && value.to_str().is_ok_and(|s| {
+                    s.trim_start()
+                        .strip_prefix(crate::auth::SESSION_COOKIE)
+                        .is_some_and(|rest| rest.trim_start().starts_with('='))
+                })
+            {
                 continue;
             }
             headers.append(name.clone(), value.clone());

--- a/crates/veld-gateway/src/server.rs
+++ b/crates/veld-gateway/src/server.rs
@@ -55,10 +55,7 @@ pub async fn run(config: GatewayConfig) -> Result<()> {
         limiter: Arc::new(crate::auth::RateLimiter::default()),
     };
 
-    let app = Router::new()
-        .fallback(dispatch)
-        .with_state(state.clone())
-        .into_make_service_with_connect_info::<std::net::SocketAddr>();
+    let app = router(state.clone()).into_make_service_with_connect_info::<std::net::SocketAddr>();
 
     let handle = axum_server::Handle::new();
     tokio::spawn(shutdown_on_signal(handle.clone()));
@@ -101,6 +98,12 @@ fn harden<A>(server: &mut axum_server::Server<A>) {
         // a timer ("timeout `header_read_timeout` set, but no timer set").
         .timer(hyper_util::rt::TokioTimer::new())
         .header_read_timeout(HEADER_READ_TIMEOUT);
+}
+
+/// The gateway's routing service: every request (any host, any path) enters
+/// [`dispatch`]. Public so integration tests can serve the real router.
+pub fn router(state: AppState) -> Router {
+    Router::new().fallback(dispatch).with_state(state)
 }
 
 /// Route a request by the viewer's host: apex → registration API,

--- a/crates/veld-gateway/tests/loopback.rs
+++ b/crates/veld-gateway/tests/loopback.rs
@@ -46,6 +46,88 @@ async fn spawn_origin() -> u16 {
     port
 }
 
+/// Minimal WebSocket-ish origin: completes the HTTP/1.1 upgrade handshake
+/// (101), then echoes every raw byte back. We are testing the proxy plumbing
+/// (upgrade detection → tunnel → splice), not the WebSocket protocol, so no
+/// real frame parsing or Sec-WebSocket-Accept hashing is needed — the test
+/// client doesn't validate it.
+async fn spawn_ws_echo_origin() -> u16 {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        while let Ok((mut sock, _)) = listener.accept().await {
+            tokio::spawn(async move {
+                // Read the request head.
+                let mut head = Vec::new();
+                let mut buf = [0u8; 1024];
+                while !head.windows(4).any(|w| w == b"\r\n\r\n") {
+                    let n = sock.read(&mut buf).await.unwrap_or(0);
+                    if n == 0 {
+                        return;
+                    }
+                    head.extend_from_slice(&buf[..n]);
+                }
+                let req = String::from_utf8_lossy(&head).to_ascii_lowercase();
+                if !(req.contains("upgrade: websocket") && req.contains("connection: upgrade")) {
+                    let _ = sock
+                        .write_all(b"HTTP/1.1 400 Bad Request\r\ncontent-length: 0\r\n\r\n")
+                        .await;
+                    return;
+                }
+                // Mimic Next's dev-origin gate: an upgrade carrying ANY
+                // Origin header (the gateway must drop it) gets the socket
+                // destroyed without an HTTP response — exactly what Next 15+/16
+                // does when the origin isn't localhost/allowedDevOrigins.
+                if req.contains("\r\norigin:") {
+                    return;
+                }
+                let _ = sock
+                    .write_all(
+                        b"HTTP/1.1 101 Switching Protocols\r\n\
+                          upgrade: websocket\r\n\
+                          connection: Upgrade\r\n\
+                          sec-websocket-accept: test-not-validated\r\n\r\n",
+                    )
+                    .await;
+                // Echo raw bytes until the peer closes.
+                loop {
+                    match sock.read(&mut buf).await {
+                        Ok(0) | Err(_) => return,
+                        Ok(n) => {
+                            if sock.write_all(&buf[..n]).await.is_err() {
+                                return;
+                            }
+                        }
+                    }
+                }
+            });
+        }
+    });
+    port
+}
+
+/// Serve `share` (the daemon's host half) on `host_ep` until the test ends.
+fn serve_host(host_ep: iroh::Endpoint, share: Arc<HostShare>) {
+    tokio::spawn(async move {
+        while let Some(incoming) = host_ep.accept().await {
+            let share = Arc::clone(&share);
+            tokio::spawn(async move {
+                if let Ok(conn) = incoming.await {
+                    let Ok((req, send, recv)) = host::read_control(&conn).await else {
+                        return;
+                    };
+                    drop(recv);
+                    if req.capability.ct_eq(&share.capability) {
+                        let _ = host::accept_and_serve(conn, send, share).await;
+                    } else {
+                        host::deny(send, "invalid token").await;
+                    }
+                }
+            });
+        }
+    });
+}
+
 #[tokio::test]
 #[ignore = "requires network; manual cross-crate drift check"]
 async fn gateway_proxies_through_daemon_host_half() {
@@ -175,4 +257,146 @@ async fn gateway_proxies_through_daemon_host_half() {
     // Host=hostname straight through), exercising the transport round-trip —
     // NOT proxy::handle's Host rewrite, which is covered by proxy.rs unit tests.
     assert_eq!(body, format!("host={hostname}"));
+}
+
+/// Full-stack WebSocket upgrade (Next.js HMR shape): raw client → real
+/// gateway HTTP listener → dispatch → proxy::handle upgrade path → tunnel →
+/// daemon host half → local origin, then bidirectional bytes over the spliced
+/// connection. Guards the whole 101 plumbing end-to-end.
+#[tokio::test]
+#[ignore = "requires network; manual cross-crate drift check"]
+async fn gateway_splices_websocket_upgrade_end_to_end() {
+    let origin_port = spawn_ws_echo_origin().await;
+    let hostname = "app.demo.p.localhost".to_string();
+
+    // Host side — exactly what the daemon runs.
+    let capability = Capability::generate();
+    let manifest = ShareManifest {
+        run_id: uuid::Uuid::new_v4(),
+        run: "demo".into(),
+        project: "p".into(),
+        nodes: vec![SharedNode {
+            node: "app".into(),
+            variant: "local".into(),
+            hostname: hostname.clone(),
+            url: format!("https://{hostname}"),
+            upstream_port: origin_port,
+        }],
+        created_at: 0,
+        expires_at: i64::MAX,
+    };
+    let mut upstreams = HashMap::new();
+    upstreams.insert(hostname.clone(), origin_port);
+    let share = Arc::new(HostShare {
+        capability: capability.clone(),
+        upstreams,
+        manifest,
+    });
+
+    let host_ep = bind_endpoint(SecretKey::generate(), &RelayChoice::Public)
+        .await
+        .unwrap();
+    host_ep.online().await;
+    let ticket = ShareTicket {
+        iroh_ticket: iroh_tickets::endpoint::EndpointTicket::new(host_ep.addr()).to_string(),
+        capability,
+        relay_tokens: Default::default(),
+    };
+    serve_host(host_ep.clone(), share);
+
+    // Gateway side: registry + real HTTP listener serving the real router.
+    let registry = veld_gateway::registry::Registry::new(
+        "share.example".into(),
+        std::time::Duration::from_secs(90),
+        veld_gateway::registry::RelayAllowList::Unconfined,
+        SecretKey::generate(),
+        512,
+    );
+    // Link access: the slug itself is the credential — no password gate in
+    // the way of the upgrade request.
+    let mut access_nodes = std::collections::BTreeMap::new();
+    access_nodes.insert(hostname.clone(), veld_core::config::WebAccessMode::Link);
+    let policy = veld_core::share::GatewayAccessPolicy {
+        password: None,
+        nodes: access_nodes,
+    };
+    let info = registry
+        .register(&ticket, Some(&policy))
+        .await
+        .expect("register");
+    let slug = info.nodes[0].slug.clone();
+
+    let config = veld_gateway::config::GatewayConfig {
+        domain: "share.example".into(),
+        listen: "127.0.0.1:0".parse().unwrap(),
+        tls: None,
+        auth_token: veld_core::config::SecretSource::Literal("test-token".into()),
+        relays: None,
+        lease: std::time::Duration::from_secs(90),
+        state_dir: None,
+        max_registrations: 512,
+        trust_forwarded_headers: false,
+        trust_forwarded_host: false,
+    };
+    let state = veld_gateway::state::AppState {
+        config: Arc::new(config),
+        registry,
+        auth_token: "test-token".into(),
+        limiter: Arc::new(veld_gateway::auth::RateLimiter::default()),
+    };
+    let app = veld_gateway::server::router(state)
+        .into_make_service_with_connect_info::<std::net::SocketAddr>();
+    let handle = axum_server::Handle::new();
+    let server = axum_server::bind("127.0.0.1:0".parse().unwrap()).handle(handle.clone());
+    tokio::spawn(server.serve(app));
+    let addr = handle.listening().await.expect("gateway bound");
+
+    // Raw HTTP/1.1 WebSocket handshake, browser/Next-HMR shape — including
+    // the Origin header a browser always sends, which the gateway must DROP
+    // (the origin above kills the socket if it sees one).
+    let mut client = tokio::net::TcpStream::connect(addr).await.unwrap();
+    let handshake = format!(
+        "GET /_next/webpack-hmr?id=abc123 HTTP/1.1\r\n\
+         Host: {slug}.share.example\r\n\
+         Connection: keep-alive, Upgrade\r\n\
+         Upgrade: websocket\r\n\
+         Sec-WebSocket-Version: 13\r\n\
+         Sec-WebSocket-Key: x3JJHMbDL1EzLkh9GBhXDw==\r\n\
+         Origin: https://{slug}.share.example\r\n\r\n"
+    );
+    client.write_all(handshake.as_bytes()).await.unwrap();
+
+    // Read the response head.
+    let mut head = Vec::new();
+    let mut buf = [0u8; 1024];
+    while !head.windows(4).any(|w| w == b"\r\n\r\n") {
+        let n = tokio::time::timeout(std::time::Duration::from_secs(30), client.read(&mut buf))
+            .await
+            .expect("response head within 30s")
+            .expect("read response head");
+        assert!(n > 0, "connection closed before a response head");
+        head.extend_from_slice(&buf[..n]);
+    }
+    let head_end = head.windows(4).position(|w| w == b"\r\n\r\n").unwrap() + 4;
+    let head_str = String::from_utf8_lossy(&head[..head_end]).to_string();
+    assert!(
+        head_str.starts_with("HTTP/1.1 101"),
+        "expected 101 Switching Protocols, got:\n{head_str}"
+    );
+    let lower = head_str.to_ascii_lowercase();
+    assert!(lower.contains("upgrade: websocket"), "got:\n{head_str}");
+
+    // Bidirectional bytes over the spliced connection (echo origin).
+    let mut echoed: Vec<u8> = head[head_end..].to_vec();
+    client.write_all(b"hmr-ping").await.unwrap();
+    while echoed.len() < b"hmr-ping".len() {
+        let n = tokio::time::timeout(std::time::Duration::from_secs(30), client.read(&mut buf))
+            .await
+            .expect("echo within 30s")
+            .expect("read echo");
+        assert!(n > 0, "connection closed before the echo");
+        echoed.extend_from_slice(&buf[..n]);
+    }
+    assert_eq!(&echoed, b"hmr-ping");
+    handle.shutdown();
 }

--- a/crates/veld-gateway/tests/loopback.rs
+++ b/crates/veld-gateway/tests/loopback.rs
@@ -74,18 +74,26 @@ async fn spawn_ws_echo_origin() -> u16 {
                         .await;
                     return;
                 }
-                // Mimic Next's dev-origin gate: an upgrade carrying ANY
-                // Origin header (the gateway must drop it) gets the socket
-                // destroyed without an HTTP response — exactly what Next 15+/16
-                // does when the origin isn't localhost/allowedDevOrigins.
+                // Mimic Next's dev-origin gate, tightened to a strict
+                // superset: destroy the socket on ANY Origin header without
+                // an HTTP response. (Real Next 15+/16 kills only origins
+                // outside localhost/allowedDevOrigins — rejecting all origins
+                // here pins the gateway's chosen strategy, dropping the
+                // header, rather than any rewrite.)
                 if req.contains("\r\norigin:") {
                     return;
                 }
+                // The forged Set-Cookie mimics a hostile upstream trying to
+                // (re)set the gateway's own session cookie on the 101 — the
+                // splice path must strip it (it bypasses
+                // rewrite_response_headers).
                 let _ = sock
                     .write_all(
                         b"HTTP/1.1 101 Switching Protocols\r\n\
                           upgrade: websocket\r\n\
                           connection: Upgrade\r\n\
+                          set-cookie: __Host-veld_gw_sess=forged; Path=/\r\n\
+                          set-cookie: app_ws=legit; Path=/\r\n\
                           sec-websocket-accept: test-not-validated\r\n\r\n",
                     )
                     .await;
@@ -385,6 +393,17 @@ async fn gateway_splices_websocket_upgrade_end_to_end() {
     );
     let lower = head_str.to_ascii_lowercase();
     assert!(lower.contains("upgrade: websocket"), "got:\n{head_str}");
+    // The 101 path bypasses rewrite_response_headers, but must still strip an
+    // upstream attempt to (re)set the gateway's own session cookie — while
+    // passing the app's own cookies through.
+    assert!(
+        !lower.contains("__host-veld_gw_sess"),
+        "gateway session cookie must not cross the splice path:\n{head_str}"
+    );
+    assert!(
+        lower.contains("set-cookie: app_ws=legit"),
+        "app cookies must pass through on the 101:\n{head_str}"
+    );
 
     // Bidirectional bytes over the spliced connection (echo origin).
     let mut echoed: Vec<u8> = head[head_end..].to_vec();

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -131,7 +131,10 @@ File form (all fields optional, `SecretSource` accepted for secrets):
   share capability)` — 26 lowercase base32 chars, unguessable (the URL is the
   baseline access control), stable across gateway restarts, new per share.
 - **Proxying**: one tunnel stream per HTTP request; WebSocket upgrades
-  (dev-server HMR) are spliced through. The origin service sees its own
+  (dev-server HMR) are spliced through, with the `Origin` header dropped on
+  the upgrade — dev servers (Next.js HMR) only accept `localhost`-ish origins
+  on WebSockets and kill the socket otherwise, while an absent Origin passes.
+  The origin service sees its own
   hostname in `Host` (dev-server allow-lists pass); the public host is in
   `X-Forwarded-Host`. `Location` redirects to shared sibling hostnames are
   rewritten to their public URLs; `Set-Cookie` `Domain` attributes naming

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -169,11 +169,12 @@ Two consequences to know before sharing a non-trivial app:
   allow-list must add the public origin itself. A `Content-Security-Policy`
   that names origin hostnames is **not** rewritten (it's a body-adjacent
   allow-list); relax it or trust the public host if you ship a strict CSP in
-  dev. And because each request's `Host`/`Origin` is rewritten to the *target*
-  service's origin, a service that inspects the calling service's `Origin` for
-  its own CORS/CSRF decisions sees same-origin rather than the caller — fine
-  for the single-service flagship, a fidelity gap for tightly-coupled
-  multi-service shares.
+  dev. And because each non-upgrade request's `Host`/`Origin` is rewritten to
+  the *target* service's origin (upgrade requests drop `Origin` entirely, see
+  above), a service that inspects the calling service's `Origin` for its own
+  CORS/CSRF decisions sees same-origin — or, on WebSockets, no origin — rather
+  than the caller — fine for the single-service flagship, a fidelity gap for
+  tightly-coupled multi-service shares.
 - **Tunnel transport is logged.** On registration the gateway logs
   `share tunnel established` with `transport=direct|relayed` and `via=<addr>`,
   and ~15 s later `share tunnel path settled` with the post-hole-punching


### PR DESCRIPTION
## Problem

Public web shares of a Next.js dev app broke HMR: every browser WebSocket to `/_next/webpack-hmr` failed, killing live reload (and with it the app in dev mode).

## Root cause

The gateway rewrote `Origin` to the origin hostname in lockstep with `Host` on **all** requests. Next 15+/16 dev servers (webpack and turbopack) allow-list WebSocket origins against `localhost` + `allowedDevOrigins` — their own serving hostname does **not** pass — and destroy the handshake socket without a response. The gateway surfaced that as `502 the shared service did not respond`. Non-browser clients send no `Origin`, so `curl` worked and masked the failure.

Confirmed live, layer by layer:
- Full public chain (CloudFront → LB → gateway → tunnel → origin) splices upgrades correctly with a plain echo origin — infra ruled out.
- A real Next 16 turbopack share: handshake **with** `Origin` → 502; **without** → 101 + turbopack frames stream.
- Direct against Next dev: `Origin: https://<own hostname>` → raw `Unauthorized` + socket destroy; absent Origin → 101.

## Fix

Drop `Origin` on upgrade requests instead of rewriting it (dev servers accept an absent Origin). This mirrors the local helper Caddy, which has deleted `Origin` since `aed79c9` for the same reason — with one deliberate divergence, documented in code: non-upgrade requests keep the lockstep rewrite because Next Server Actions require a coherent `Origin`/`Host` pair.

## Hardening (five-angle review round, zero blocking findings)

- A dev server killing the upgrade handshake is now `warn!`-logged with classification; an upgrade answered without a 101 leaves a `debug!` trace.
- `splice_upgrade` documents that it bypasses `rewrite_response_headers` and strips an upstream attempt to (re)set the gateway session cookie on the 101.
- h1-only upgrade detection pinned (RFC 8441 h2 extended CONNECT intentionally unsupported); absent-Origin assumption documented.
- Docs updated (SHARING_V2.md §settled, docs/gateway.md proxying + fidelity limits).

## Tests

- CI-run unit test: upgrade drops `Origin` + re-adds `Upgrade`/`Connection`; non-upgrade keeps the rewrite.
- New full-stack WS e2e (`#[ignore]`, network): real gateway listener → dispatch → proxy → tunnel → daemon host half → origin that mimics Next's dev-origin gate (kills any `Origin`-bearing upgrade, sends a forged gateway session cookie on the 101); asserts 101, bidirectional bytes, forged cookie stripped, app cookie passed.
- `server::router()` exposed for integration tests.

## Deploy note

Takes effect only after the gateway image is redeployed.