### PR TITLE
feat(gateway): branded index/404/login/error pages + liveness & readiness endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,15 @@ If the change is purely internal (refactor, bugfix with no new surface area), th
 ## Key Conventions
 
 - **Any user-supplied command executed by a daemon must inherit the user's login-shell `PATH`.** The daemon (launchd), gateway (systemd), and helper run with a bare service `PATH`, so a raw `sh -c` cannot find user-installed CLIs (`op`, `vault`, `pg_isready`, version-manager shims) even though the same command works in the user's terminal. Resolve the PATH with `veld_core::user_path::resolve_user_path()` and pass it via `.env("PATH", …)` — as liveness probes (`veld-daemon/src/monitor.rs`) and `SecretSource::Command` token resolution (`veld-share/src/endpoint.rs`) already do. Never spawn a config-declared command on a daemon without this. Scope: the rule covers daemon/gateway/helper spawns only — commands the `veld` CLI itself spawns (orchestrator `command`/`start_server` steps, setup checks, actions) already inherit the terminal's `PATH` and are exempt. Only `PATH` is inherited, never the rest of the shell environment.
+- **Every user-facing HTML surface carries the Veld brand.** Any HTML a Veld
+  binary serves to a browser — management UI, gateway pages (index, login,
+  404), overlays, error pages, and every future surface — must follow
+  [docs/branding.md](docs/branding.md): embedded `veld.` wordmark (accent-green
+  dot), the dark product token palette, self-contained assets (inline CSS,
+  data-URI favicon, no external requests), and no enumerable share/run
+  metadata on anonymous pages. Never ship an unbranded, system-default-styled
+  page; when adding one to an existing binary, reuse its page shell (e.g.
+  `veld-gateway`'s `pages::shell`) instead of writing bespoke HTML.
 - Domain: `veld.oss.life.li` (not `veld.dev`)
 - Install URL: `https://veld.oss.life.li/get`
 - URL templates use `{variable}` (single braces); commands/env use `${variable}`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4250,7 +4250,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "veld"
-version = "9.5.1"
+version = "9.5.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "veld-core"
-version = "9.5.1"
+version = "9.5.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -4292,7 +4292,7 @@ dependencies = [
 
 [[package]]
 name = "veld-daemon"
-version = "9.5.1"
+version = "9.5.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -4316,7 +4316,7 @@ dependencies = [
 
 [[package]]
 name = "veld-gateway"
-version = "9.5.1"
+version = "9.5.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -4347,7 +4347,7 @@ dependencies = [
 
 [[package]]
 name = "veld-helper"
-version = "9.5.1"
+version = "9.5.2"
 dependencies = [
  "anyhow",
  "nix",
@@ -4363,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "veld-share"
-version = "9.5.1"
+version = "9.5.2"
 dependencies = [
  "anyhow",
  "dirs",

--- a/crates/veld-gateway/Dockerfile
+++ b/crates/veld-gateway/Dockerfile
@@ -15,7 +15,9 @@
 #     -e VELD_GATEWAY_RELAYS=https://relay.acme.internal \
 #     ghcr.io/prosperity-solutions/veld-gateway:latest
 #
-# Health endpoint: GET /healthz (any Host). Runs as a non-root user. The image
+# Health endpoints: GET /livez (liveness) and GET /readyz (readiness), both
+# answering on any Host; /healthz remains as a legacy liveness alias.
+# Runs as a non-root user. The image
 # sets VELD_GATEWAY_STATE_DIR, so a mounted volume there gives a stable iroh
 # identity (and public URLs) across restarts — but the volume must be writable
 # by the `veld` user or startup fails loudly (a root-owned mount is the usual

--- a/crates/veld-gateway/src/api.rs
+++ b/crates/veld-gateway/src/api.rs
@@ -22,9 +22,6 @@ use crate::state::AppState;
 pub fn router() -> Router<AppState> {
     Router::new()
         .route("/", get(index))
-        .route("/healthz", get(livez))
-        .route("/livez", get(livez))
-        .route("/readyz", get(readyz))
         .route("/api/v1/shares", post(register))
         .route("/api/v1/shares/{id}", delete(unregister))
         .fallback(fallback_not_found)
@@ -38,19 +35,27 @@ async fn fallback_not_found() -> impl IntoResponse {
     crate::pages::not_found(crate::pages::NotFound::Generic)
 }
 
-/// Liveness (also the legacy `/healthz` alias): the process is up and the
-/// listener answers. A failing liveness probe should restart the container.
-pub async fn livez() -> &'static str {
-    "ok"
-}
-
-/// Readiness: safe to route traffic here. The gateway has no warm-up phase or
-/// external dependency to await — the registry is in-memory and tunnels are
-/// dialed per registration — so readiness equals liveness today. Kept as a
-/// distinct endpoint so orchestrators (Kubernetes `readinessProbe`) have a
-/// stable target if that ever changes.
-pub async fn readyz() -> &'static str {
-    "ok"
+/// Answer container/LB health probes — the single source of truth for the
+/// probe paths. `server::dispatch` consults this for the apex domain and for
+/// unknown hosts alike (probes address the pod by IP or an internal name, so
+/// the paths must answer on any Host); slug hosts never reach it — their
+/// paths belong to the proxied app. Add or retire a probe path HERE, nowhere
+/// else.
+///
+/// - `/livez` (and its legacy alias `/healthz`): liveness — the process is up
+///   and answering. A failing liveness probe should restart the container.
+/// - `/readyz`: readiness — safe to route traffic here. The gateway has no
+///   warm-up phase or external dependency to await (the registry is
+///   in-memory, tunnels are dialed per registration), so readiness equals
+///   liveness today; it stays `ok` through the SIGTERM drain as well, where
+///   traffic shedding is handled by the listener refusing new connections.
+///   Kept as a distinct endpoint so orchestrator probe configs have a stable
+///   target if that ever changes.
+pub fn health_response(path: &str) -> Option<axum::response::Response> {
+    match path {
+        "/healthz" | "/livez" | "/readyz" => Some("ok".into_response()),
+        _ => None,
+    }
 }
 
 type ApiError = (StatusCode, String);

--- a/crates/veld-gateway/src/api.rs
+++ b/crates/veld-gateway/src/api.rs
@@ -21,12 +21,35 @@ use crate::state::AppState;
 
 pub fn router() -> Router<AppState> {
     Router::new()
-        .route("/healthz", get(healthz))
+        .route("/", get(index))
+        .route("/healthz", get(livez))
+        .route("/livez", get(livez))
+        .route("/readyz", get(readyz))
         .route("/api/v1/shares", post(register))
         .route("/api/v1/shares/{id}", delete(unregister))
+        .fallback(fallback_not_found)
 }
 
-pub async fn healthz() -> &'static str {
+async fn index() -> impl IntoResponse {
+    crate::pages::index()
+}
+
+async fn fallback_not_found() -> impl IntoResponse {
+    crate::pages::not_found(crate::pages::NotFound::Generic)
+}
+
+/// Liveness (also the legacy `/healthz` alias): the process is up and the
+/// listener answers. A failing liveness probe should restart the container.
+pub async fn livez() -> &'static str {
+    "ok"
+}
+
+/// Readiness: safe to route traffic here. The gateway has no warm-up phase or
+/// external dependency to await — the registry is in-memory and tunnels are
+/// dialed per registration — so readiness equals liveness today. Kept as a
+/// distinct endpoint so orchestrators (Kubernetes `readinessProbe`) have a
+/// stable target if that ever changes.
+pub async fn readyz() -> &'static str {
     "ok"
 }
 
@@ -117,12 +140,6 @@ async fn unregister(
     // may have expired before the origin's DELETE arrived).
     state.registry.unregister(&id).await;
     Ok(StatusCode::NO_CONTENT)
-}
-
-/// Shared 404 for unmatched hosts/paths — deliberately content-free so probes
-/// of the public surface learn nothing.
-pub async fn not_found() -> impl IntoResponse {
-    (StatusCode::NOT_FOUND, "not found")
 }
 
 #[cfg(test)]

--- a/crates/veld-gateway/src/auth.rs
+++ b/crates/veld-gateway/src/auth.rs
@@ -108,7 +108,7 @@ pub async fn gate(state: &AppState, target: &SlugAuth, req: Request) -> Gate {
         if path == AUTH_PATH {
             return Gate::Respond(handle_auth(state, target, req).await);
         }
-        return Gate::Respond((StatusCode::NOT_FOUND, "not found").into_response());
+        return Gate::Respond(crate::pages::not_found(crate::pages::NotFound::Generic));
     }
 
     let now = chrono::Utc::now().timestamp();
@@ -484,14 +484,17 @@ impl RateLimiter {
 // Login page
 // ---------------------------------------------------------------------------
 
-/// Render the self-contained login page. Deliberately generic: no share
-/// metadata (project/run/hostnames) is leaked to an unauthenticated viewer.
+/// Render the self-contained login page (branded via [`crate::pages::shell`]).
+/// Deliberately generic: no share metadata (project/run/hostnames) is leaked
+/// to an unauthenticated viewer.
 fn login_page(status: StatusCode, next: &str, error: Option<&str>) -> Response {
     let next_attr = html_escape(&safe_next(Some(next)));
     let error_html = error
         .map(|e| format!("<p class=\"err\">{}</p>", html_escape(e)))
         .unwrap_or_default();
-    let page = LOGIN_PAGE
+    // Shell placeholders expand first; the viewer-influenced values go in
+    // last and are brace-escaped, so they can never re-trigger a placeholder.
+    let page = crate::pages::shell("Password required", LOGIN_BODY)
         .replace("{next}", &next_attr)
         .replace("{error}", &error_html);
     (
@@ -519,34 +522,12 @@ fn html_escape(s: &str) -> String {
         .replace('}', "&#125;")
 }
 
-/// Self-contained (CSP-friendly, no external assets). The inline script
+/// The login form + one-link script, rendered inside the branded page shell
+/// (self-contained, CSP-friendly, no external assets). The inline script
 /// implements the one-link flow: a `#veld-key=…` fragment auto-fills and
 /// submits the form, then strips itself from the URL — the fragment never
 /// reaches the server or its logs.
-const LOGIN_PAGE: &str = r#"<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="robots" content="noindex">
-<title>Password required</title>
-<style>
-  body { font-family: system-ui, sans-serif; display: flex; min-height: 100vh;
-         margin: 0; align-items: center; justify-content: center; background: #f5f5f4; }
-  form { background: #fff; padding: 2rem 2.5rem; border-radius: 12px;
-         box-shadow: 0 1px 4px rgba(0,0,0,.12); max-width: 22rem; }
-  h1 { font-size: 1.1rem; margin: 0 0 .5rem; }
-  p { color: #555; font-size: .9rem; margin: 0 0 1rem; }
-  .err { color: #b91c1c; }
-  .hint { color: #999; font-size: .78rem; margin: .9rem 0 0; }
-  input[type=password] { width: 100%; box-sizing: border-box; padding: .5rem .75rem;
-         font-size: 1rem; border: 1px solid #ccc; border-radius: 8px; margin-bottom: 1rem; }
-  button { width: 100%; padding: .55rem; font-size: 1rem; border: 0; border-radius: 8px;
-         background: #1d4ed8; color: #fff; cursor: pointer; }
-</style>
-</head>
-<body>
-<form id="f" method="post" action="/__veld_gateway__/auth" autocomplete="off">
+const LOGIN_BODY: &str = r#"<form id="f" method="post" action="/__veld_gateway__/auth" autocomplete="off">
   <h1>Password required</h1>
   <p>This preview is protected. Enter the password you were given.</p>
   {error}
@@ -575,10 +556,7 @@ const LOGIN_PAGE: &str = r#"<!doctype html>
   history.replaceState(null, '', location.pathname + location.search + (rest ? '#' + rest : ''));
   document.getElementById('f').submit();
 })();
-</script>
-</body>
-</html>
-"#;
+</script>"#;
 
 #[cfg(test)]
 mod tests {

--- a/crates/veld-gateway/src/auth.rs
+++ b/crates/veld-gateway/src/auth.rs
@@ -27,6 +27,7 @@ use hmac::{Hmac, Mac};
 use sha2::Sha256;
 use veld_core::share::Capability;
 
+use crate::pages::html_escape;
 use crate::registry::SlugTarget;
 use crate::state::AppState;
 
@@ -507,19 +508,6 @@ fn login_page(status: StatusCode, next: &str, error: Option<&str>) -> Response {
         page,
     )
         .into_response()
-}
-
-/// Escape for HTML text/attribute contexts. `{`/`}` are escaped too: the page
-/// is assembled by ordered `{next}`/`{error}` string replacement, so braces
-/// surviving into an earlier substitution's VALUE (e.g. a viewer-supplied
-/// `next` of literally `/{error}`) must never be re-expanded by a later pass.
-fn html_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('{', "&#123;")
-        .replace('}', "&#125;")
 }
 
 /// The login form + one-link script, rendered inside the branded page shell
@@ -1020,7 +1008,10 @@ mod tests {
             panic!("expected a response");
         };
         assert_eq!(resp.status(), StatusCode::OK);
-        assert!(body_string(resp).await.contains("<form"));
+        let body = body_string(resp).await;
+        assert!(body.contains("<form"), "{body}");
+        // The login page must carry the brand (rendered via pages::shell).
+        assert!(body.contains("class=\"wordmark\""), "{body}");
 
         let del = Request::builder()
             .method("DELETE")

--- a/crates/veld-gateway/src/lib.rs
+++ b/crates/veld-gateway/src/lib.rs
@@ -8,6 +8,7 @@
 //! - [`config`] — env-var-first configuration
 //! - [`registry`] — join engine, slug routing table, lease bookkeeping
 //! - [`api`] — Bearer-gated registration API (apex domain)
+//! - [`pages`] — branded HTML pages (index, not-found, login shell)
 //! - [`proxy`] — the HTTP front for slug hosts (incl. WebSocket upgrades)
 //! - [`tunnel`] — HTTP/1.1 client connections over iroh tunnel streams
 //! - [`slug`] — deterministic, unguessable public-URL slugs
@@ -17,6 +18,7 @@
 pub mod api;
 pub mod auth;
 pub mod config;
+pub mod pages;
 pub mod proxy;
 pub mod registry;
 pub mod server;

--- a/crates/veld-gateway/src/pages.rs
+++ b/crates/veld-gateway/src/pages.rs
@@ -141,12 +141,15 @@ pub fn not_found(kind: NotFound) -> Response {
     html_response(StatusCode::NOT_FOUND, shell(title, body))
 }
 
-/// A branded error page for viewer-facing failures (dead tunnel, upstream
-/// timeout…). `title` and `message` must be trusted constants — never echo
-/// request data here. Machine-facing responses (the registration API, abuse
-/// guards like 405/413, upgrade-path failures) stay plain text by design;
-/// see docs/branding.md.
-pub fn error(status: StatusCode, title: &str, message: &str) -> Response {
+/// A branded error page for viewer-facing failures (dead tunnel,
+/// unresponsive or timed-out upstream — upgrade requests included).
+/// `title` and `message` are `&'static str` ON PURPOSE: it makes "trusted
+/// constants only — never echo request data" a compile-time guarantee
+/// instead of a doc-comment plea (a `&format!(…{host}…)` caller does not
+/// compile). Machine-facing responses (the registration API, abuse guards
+/// like 405/413, the pre-101 splice guard) stay plain text by design; see
+/// docs/branding.md.
+pub fn error(status: StatusCode, title: &'static str, message: &'static str) -> Response {
     let body = format!("<h1>{title}</h1><p>{message}</p>");
     html_response(status, shell(title, &body))
 }
@@ -200,6 +203,27 @@ mod tests {
             assert!(body.contains(marker), "{body}");
             assert!(body.contains("class=\"wordmark\""), "{body}");
         }
+    }
+
+    #[tokio::test]
+    async fn error_pages_are_branded_with_matching_status() {
+        let resp = error(
+            StatusCode::BAD_GATEWAY,
+            "Share disconnected",
+            "This share is no longer connected.",
+        );
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "text/html; charset=utf-8"
+        );
+        assert_eq!(
+            resp.headers().get(header::CACHE_CONTROL).unwrap(),
+            "no-store"
+        );
+        let body = body_string(resp).await;
+        assert!(body.contains("<h1>Share disconnected</h1>"), "{body}");
+        assert!(body.contains("class=\"wordmark\""), "{body}");
     }
 
     #[test]

--- a/crates/veld-gateway/src/pages.rs
+++ b/crates/veld-gateway/src/pages.rs
@@ -23,7 +23,8 @@ const WORDMARK_SVG: &str = r#"<svg class="wordmark" viewBox="0 0 3837 1463" fill
 </svg>"#;
 
 /// Page skeleton. Assembled by ordered literal replacement (`{title}`, then
-/// `{body}`) rather than `format!` so the CSS braces need no escaping. Both
+/// `{wordmark}`, then `{body}`) rather than `format!` so the CSS braces need
+/// no escaping. Both
 /// substituted values are trusted constants at every call site; anything
 /// viewer-controlled is escaped (braces included) before it can reach a page
 /// — see `html_escape` in `auth.rs`.
@@ -74,12 +75,27 @@ button:hover{filter:brightness(1.06)}
 "#;
 
 /// Wrap `body` in the branded page shell. Both arguments must be trusted
-/// HTML/text — no escaping happens here.
+/// HTML/text — no escaping happens here. Run anything viewer-controlled
+/// through [`html_escape`] before it gets anywhere near a page.
 pub fn shell(title: &str, body: &str) -> String {
     SHELL
         .replace("{title}", title)
         .replace("{wordmark}", WORDMARK_SVG)
         .replace("{body}", body)
+}
+
+/// Escape for HTML text/attribute contexts. `{`/`}` are escaped too: pages
+/// are assembled by ordered string replacement (see [`shell`] and the login
+/// page's `{next}`/`{error}` passes in `auth.rs`), so braces surviving into
+/// an earlier substitution's VALUE (e.g. a viewer-supplied `next` of
+/// literally `/{error}`) must never be re-expanded by a later pass.
+pub fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('{', "&#123;")
+        .replace('}', "&#125;")
 }
 
 /// Which flavor of 404 to render — a slug host whose share is gone reads
@@ -123,6 +139,16 @@ pub fn not_found(kind: NotFound) -> Response {
         ),
     };
     html_response(StatusCode::NOT_FOUND, shell(title, body))
+}
+
+/// A branded error page for viewer-facing failures (dead tunnel, upstream
+/// timeout…). `title` and `message` must be trusted constants — never echo
+/// request data here. Machine-facing responses (the registration API, abuse
+/// guards like 405/413, upgrade-path failures) stay plain text by design;
+/// see docs/branding.md.
+pub fn error(status: StatusCode, title: &str, message: &str) -> Response {
+    let body = format!("<h1>{title}</h1><p>{message}</p>");
+    html_response(status, shell(title, &body))
 }
 
 /// Assemble an HTML response with the headers every gateway page shares.

--- a/crates/veld-gateway/src/pages.rs
+++ b/crates/veld-gateway/src/pages.rs
@@ -1,0 +1,198 @@
+//! Branded gateway pages — the small set of HTML responses the gateway
+//! serves itself (apex index, not-found, and the login shell used by
+//! [`crate::auth`]).
+//!
+//! All pages follow the Veld brand (docs/branding.md): the dark token
+//! palette and embedded wordmark of the daemon's management UI
+//! (`crates/veld-daemon/assets/management-ui.html`), fully self-contained
+//! (inline CSS, data-URI favicon, no external assets) so they render under
+//! any CSP and leak no requests. Deliberately static: no share metadata, no
+//! counts, nothing an anonymous viewer can enumerate.
+
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Response};
+
+/// The `veld.` wordmark (same paths as the management UI header). Colored by
+/// the shell CSS: letters `var(--text)`, the dot `var(--accent)`.
+const WORDMARK_SVG: &str = r#"<svg class="wordmark" viewBox="0 0 3837 1463" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="veld">
+<path d="M383 1463L0 423H183L470 1278H474L762 423H943L561 1463H383Z"/>
+<path d="M1507 1463C1407.67 1463 1322.17 1441 1250.5 1397C1178.83 1353 1123.83 1290.83 1085.5 1210.5C1047.17 1130.17 1028 1035.67 1028 927V926C1028 818.667 1047.33 724.167 1086 642.5C1124.67 560.833 1179 497.167 1249 451.5C1319 405.833 1401.33 383 1496 383C1590.67 383 1672.17 404.833 1740.5 448.5C1808.83 492.167 1861.33 553.333 1898 632C1934.67 710.667 1953 802 1953 906V970H1115V834H1867L1779 960V893C1779 812.333 1766.83 745.667 1742.5 693C1718.17 640.333 1684.67 601.167 1642 575.5C1599.33 549.833 1550.33 537 1495 537C1439.67 537 1390 550.5 1346 577.5C1302 604.5 1267.33 644.5 1242 697.5C1216.67 750.5 1204 815.667 1204 893V960C1204 1033.33 1216.5 1096 1241.5 1148C1266.5 1200 1302 1239.83 1348 1267.5C1394 1295.17 1448.33 1309 1511 1309C1555 1309 1594.33 1302.33 1629 1289C1663.67 1275.67 1692.67 1257.33 1716 1234C1739.33 1210.67 1756 1184 1766 1154L1769 1145H1940L1938 1155C1929.33 1197.67 1912.83 1237.67 1888.5 1275C1864.17 1312.33 1833 1345.17 1795 1373.5C1757 1401.83 1713.67 1423.83 1665 1439.5C1616.33 1455.17 1563.67 1463 1507 1463Z"/>
+<path d="M2137 1463V20H2311V1463H2137Z"/>
+<path d="M2937 1463C2848.33 1463 2770.83 1440.83 2704.5 1396.5C2638.17 1352.17 2586.67 1289.5 2550 1208.5C2513.33 1127.5 2495 1032.33 2495 923V922C2495 812.667 2513.5 717.667 2550.5 637C2587.5 556.333 2639 493.833 2705 449.5C2771 405.167 2847.33 383 2934 383C2983.33 383 3029.17 390.833 3071.5 406.5C3113.83 422.167 3151.67 444.5 3185 473.5C3218.33 502.5 3245.67 537 3267 577H3271V0H3445V1443H3271V1267H3267C3245.67 1307.67 3218.67 1342.5 3186 1371.5C3153.33 1400.5 3116.17 1423 3074.5 1439C3032.83 1455 2987 1463 2937 1463ZM2971 1309C3029.67 1309 3081.67 1293 3127 1261C3172.33 1229 3207.83 1184 3233.5 1126C3259.17 1068 3272 1000.33 3272 923V922C3272 844.667 3259 777.167 3233 719.5C3207 661.833 3171.5 617 3126.5 585C3081.5 553 3029.67 537 2971 537C2909.67 537 2856.67 552.667 2812 584C2767.33 615.333 2733 659.667 2709 717C2685 774.333 2673 842.667 2673 922V923C2673 1002.33 2685 1071 2709 1129C2733 1187 2767.33 1231.5 2812 1262.5C2856.67 1293.5 2909.67 1309 2971 1309Z"/>
+<path d="M3757 1463C3801.18 1463 3837 1427.18 3837 1383C3837 1338.82 3801.18 1303 3757 1303C3712.82 1303 3677 1338.82 3677 1383C3677 1427.18 3712.82 1463 3757 1463Z"/>
+</svg>"#;
+
+/// Page skeleton. Assembled by ordered literal replacement (`{title}`, then
+/// `{body}`) rather than `format!` so the CSS braces need no escaping. Both
+/// substituted values are trusted constants at every call site; anything
+/// viewer-controlled is escaped (braces included) before it can reach a page
+/// — see `html_escape` in `auth.rs`.
+const SHELL: &str = r#"<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'><path d='M40 0H8C3.58 0 0 3.58 0 8V40C0 44.42 3.58 48 8 48H40C44.42 48 48 44.42 48 40V8C48 3.58 44.42 0 40 0Z' fill='%230f1117'/><path d='M21.1 36L11.9 12H16.3L23.6 31.8H23.7L31 12H35.4L26.2 36H21.1Z' fill='white'/><path d='M32.5 36C33.88 36 35 34.88 35 33.5C35 32.12 33.88 31 32.5 31C31.12 31 30 32.12 30 33.5C30 34.88 31.12 36 32.5 36Z' fill='%23C4F56A'/></svg>">
+<title>{title}</title>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --bg:#0f1117;--surface:#181a24;--surface2:#1f2233;--border:#2a2d3e;
+  --text:#e0e0e6;--text2:#8b8fa3;
+  --accent:#C4F56A;--blue:#6c8cff;--red:#f06060;--dim:#555870;
+}
+html{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;font-size:15px}
+body{min-height:100vh;display:flex;align-items:center;justify-content:center;background:var(--bg);color:var(--text);padding:24px}
+.card{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:36px 40px;max-width:26rem;width:100%}
+header{display:flex;align-items:baseline;gap:10px;margin-bottom:22px}
+.wordmark{height:20px;width:auto;flex-shrink:0;position:relative;top:2px}
+.wordmark path{fill:var(--text)}
+.wordmark path:last-child{fill:var(--accent)}
+.sep{color:var(--dim);font-weight:300;font-size:18px}
+.subtitle{color:var(--text2);font-size:14px}
+h1{font-size:1.1rem;font-weight:600;margin:0 0 10px}
+p{color:var(--text2);font-size:.9rem;line-height:1.6;margin:0 0 12px}
+p:last-child{margin-bottom:0}
+a{color:var(--blue);text-decoration:none}
+a:hover{text-decoration:underline}
+.err{color:var(--red)}
+.hint{color:var(--dim);font-size:.78rem;margin:14px 0 0}
+input[type=password]{width:100%;padding:.55rem .75rem;font-size:1rem;color:var(--text);background:var(--surface2);border:1px solid var(--border);border-radius:8px;margin-bottom:12px;font-family:inherit}
+input[type=password]:focus{outline:none;border-color:var(--accent)}
+button{width:100%;padding:.6rem;font-size:.95rem;font-weight:600;border:0;border-radius:8px;background:var(--accent);color:var(--bg);cursor:pointer;font-family:inherit}
+button:hover{filter:brightness(1.06)}
+</style>
+</head>
+<body>
+<main class="card">
+<header>{wordmark}<span class="sep">/</span><span class="subtitle">Gateway</span></header>
+{body}
+</main>
+</body>
+</html>
+"#;
+
+/// Wrap `body` in the branded page shell. Both arguments must be trusted
+/// HTML/text — no escaping happens here.
+pub fn shell(title: &str, body: &str) -> String {
+    SHELL
+        .replace("{title}", title)
+        .replace("{wordmark}", WORDMARK_SVG)
+        .replace("{body}", body)
+}
+
+/// Which flavor of 404 to render — a slug host whose share is gone reads
+/// differently from a path that never existed.
+#[derive(Clone, Copy)]
+pub enum NotFound {
+    /// A slug subdomain with no live registration behind it.
+    Share,
+    /// Anything else (apex fallback, unknown hosts, reserved paths).
+    Generic,
+}
+
+/// The apex index page: says what this server is, links to the project.
+/// Static on purpose — an anonymous viewer learns the gateway's identity
+/// (that is the point of branding it) but nothing about its shares.
+pub fn index() -> Response {
+    let body = "<h1>This is a Veld gateway</h1>\
+        <p>It publishes temporary preview links for <a href=\"https://veld.oss.life.li\">Veld</a> \
+        development environments. Every share lives on its own subdomain and disappears \
+        when the developer stops sharing.</p>\
+        <p>There is nothing to browse here &mdash; if someone sent you a preview link, \
+        open that link directly.</p>";
+    html_response(StatusCode::OK, shell("Veld Gateway", body))
+}
+
+/// A branded 404. Still deliberately vague: neither variant confirms whether
+/// a share ever existed at the address.
+pub fn not_found(kind: NotFound) -> Response {
+    let (title, body) = match kind {
+        NotFound::Share => (
+            "Share not found",
+            "<h1>Share not found</h1>\
+             <p>There is no active share at this address. The preview may have expired \
+             or been stopped by its owner.</p>\
+             <p>Ask whoever sent you the link for a fresh one.</p>",
+        ),
+        NotFound::Generic => (
+            "Not found",
+            "<h1>Not found</h1>\
+             <p>Nothing lives at this address.</p>",
+        ),
+    };
+    html_response(StatusCode::NOT_FOUND, shell(title, body))
+}
+
+/// Assemble an HTML response with the headers every gateway page shares.
+/// `no-store` keeps intermediaries from pinning a 404 (or a stale index)
+/// onto an address a share may occupy moments later.
+fn html_response(status: StatusCode, page: String) -> Response {
+    (
+        status,
+        [
+            (header::CONTENT_TYPE, "text/html; charset=utf-8"),
+            (header::CACHE_CONTROL, "no-store"),
+        ],
+        page,
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn index_is_branded_and_html() {
+        let resp = index();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "text/html; charset=utf-8"
+        );
+        let body = body_string(resp).await;
+        assert!(body.contains("Veld gateway"), "{body}");
+        assert!(body.contains("class=\"wordmark\""), "{body}");
+        assert!(body.contains("noindex"), "{body}");
+    }
+
+    #[tokio::test]
+    async fn not_found_variants_are_404_and_leak_nothing_dynamic() {
+        for (kind, marker) in [
+            (NotFound::Share, "Share not found"),
+            (NotFound::Generic, "Nothing lives at this address"),
+        ] {
+            let resp = not_found(kind);
+            assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+            assert_eq!(
+                resp.headers().get(header::CACHE_CONTROL).unwrap(),
+                "no-store"
+            );
+            let body = body_string(resp).await;
+            assert!(body.contains(marker), "{body}");
+            assert!(body.contains("class=\"wordmark\""), "{body}");
+        }
+    }
+
+    #[test]
+    fn shell_substitutes_title_and_body_and_keeps_css_braces() {
+        let page = shell("T&lt;itle", "<h1>Hello</h1>");
+        assert!(page.contains("<title>T&lt;itle</title>"));
+        assert!(page.contains("<h1>Hello</h1>"));
+        // The CSS survived the literal replacements.
+        assert!(page.contains("--accent:#C4F56A"));
+        // No unexpanded placeholders remain.
+        assert!(
+            !page.contains("{title}") && !page.contains("{body}") && !page.contains("{wordmark}")
+        );
+    }
+
+    async fn body_string(resp: Response) -> String {
+        let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+            .await
+            .unwrap();
+        String::from_utf8_lossy(&bytes).into_owned()
+    }
+}

--- a/crates/veld-gateway/src/proxy.rs
+++ b/crates/veld-gateway/src/proxy.rs
@@ -58,7 +58,12 @@ pub async fn handle(state: AppState, target: SlugTarget, req: Request) -> Respon
     let reg = &target.registration;
     if reg.conn.close_reason().is_some() {
         // The watcher will unpublish this slug momentarily; answer honestly.
-        return (StatusCode::BAD_GATEWAY, "share is no longer connected").into_response();
+        return crate::pages::error(
+            StatusCode::BAD_GATEWAY,
+            "Share disconnected",
+            "This share is no longer connected. The developer may have stopped \
+             sharing &mdash; ask them for a fresh link.",
+        );
     }
 
     let is_upgrade = wants_upgrade(req.headers());
@@ -105,11 +110,11 @@ pub async fn handle(state: AppState, target: SlugTarget, req: Request) -> Respon
         Ok(s) => s,
         Err(e) => {
             warn!(error = %format!("{e:#}"), hostname = %target.hostname, "tunnel stream failed");
-            return (
+            return crate::pages::error(
                 StatusCode::BAD_GATEWAY,
-                "could not reach the shared service",
-            )
-                .into_response();
+                "Could not reach the shared service",
+                "The tunnel to the shared service failed. Try again in a moment.",
+            );
         }
     };
 
@@ -134,19 +139,21 @@ pub async fn handle(state: AppState, target: SlugTarget, req: Request) -> Respon
                 } else {
                     debug!(error = %e, hostname = %target.hostname, "upstream request failed");
                 }
-                return (
+                return crate::pages::error(
                     StatusCode::BAD_GATEWAY,
-                    "the shared service did not respond",
-                )
-                    .into_response();
+                    "The shared service did not respond",
+                    "The service behind this share closed the connection without \
+                     answering. Try again in a moment.",
+                );
             }
             Err(_) => {
                 debug!(hostname = %target.hostname, is_upgrade, "upstream response timed out");
-                return (
+                return crate::pages::error(
                     StatusCode::GATEWAY_TIMEOUT,
-                    "the shared service did not respond in time",
-                )
-                    .into_response();
+                    "The shared service timed out",
+                    "The service behind this share did not respond in time. \
+                     Try again in a moment.",
+                );
             }
         };
 

--- a/crates/veld-gateway/src/server.rs
+++ b/crates/veld-gateway/src/server.rs
@@ -325,6 +325,19 @@ mod tests {
                 assert_eq!(body_string(resp).await, "ok", "{host}{path}");
             }
         }
+        // Deliberately method-agnostic (probes are GET/HEAD, but the paths
+        // are reserved wholesale — pinned so a change is a conscious one).
+        let post = Request::builder()
+            .method("POST")
+            .uri("/livez")
+            .header(header::HOST, "share.example")
+            .body(Body::empty())
+            .unwrap();
+        let resp = match router(test_state()).oneshot(post).await {
+            Ok(resp) => resp,
+            Err(never) => match never {},
+        };
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/crates/veld-gateway/src/server.rs
+++ b/crates/veld-gateway/src/server.rs
@@ -2,10 +2,11 @@
 //! two audiences, split by `Host`:
 //!
 //! - the **apex domain** answers the Bearer-gated registration API that origin
-//!   daemons drive;
+//!   daemons drive, plus a branded index page on `/`;
 //! - **slug subdomains** are proxied to the registered share over its tunnel;
-//! - anything else is a content-free 404 (except `/healthz`, answered for any
-//!   host so container/LB probes work without knowing the domain).
+//! - anything else is a branded 404 (except the health endpoints `/healthz`,
+//!   `/livez`, and `/readyz`, answered for any host so container/LB probes
+//!   work without knowing the domain).
 
 use std::sync::Arc;
 
@@ -106,8 +107,8 @@ pub fn router(state: AppState) -> Router {
     Router::new().fallback(dispatch).with_state(state)
 }
 
-/// Route a request by the viewer's host: apex → registration API,
-/// `<slug>.<domain>` → proxy, anything else → `/healthz` or a content-free 404.
+/// Route a request by the viewer's host: apex → registration API + index page,
+/// `<slug>.<domain>` → proxy, anything else → health endpoints or a branded 404.
 async fn dispatch(State(state): State<AppState>, req: Request) -> Response {
     let host = viewer_host(req.headers(), state.config.trust_forwarded_host)
         .map(host_without_port)
@@ -132,15 +133,16 @@ async fn dispatch(State(state): State<AppState>, req: Request) -> Response {
                 crate::auth::Gate::Respond(resp) => resp,
             };
         }
-        return api::not_found().await.into_response();
+        return crate::pages::not_found(crate::pages::NotFound::Share);
     }
 
     // Unknown host: answer health probes (containers/LBs probe by IP or an
     // internal name, not the public domain); everything else is a 404.
-    if req.uri().path() == "/healthz" {
-        return api::healthz().await.into_response();
+    match req.uri().path() {
+        "/healthz" | "/livez" => api::livez().await.into_response(),
+        "/readyz" => api::readyz().await.into_response(),
+        _ => crate::pages::not_found(crate::pages::NotFound::Generic),
     }
-    api::not_found().await.into_response()
 }
 
 /// The host the viewer actually addressed. Behind a trusted edge
@@ -246,6 +248,100 @@ async fn shutdown_on_signal(handle: axum_server::Handle) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode, header};
+
+    fn test_state() -> AppState {
+        AppState {
+            config: Arc::new(GatewayConfig {
+                domain: "share.example".into(),
+                listen: "127.0.0.1:0".parse().unwrap(),
+                tls: None,
+                auth_token: veld_core::config::SecretSource::Literal("t".into()),
+                relays: None,
+                lease: std::time::Duration::from_secs(90),
+                state_dir: None,
+                max_registrations: 8,
+                trust_forwarded_headers: false,
+                trust_forwarded_host: false,
+            }),
+            registry: Registry::new(
+                "share.example".into(),
+                std::time::Duration::from_secs(90),
+                crate::registry::RelayAllowList::Unconfined,
+                iroh::SecretKey::generate(),
+                8,
+            ),
+            auth_token: "t".into(),
+            limiter: Arc::new(crate::auth::RateLimiter::default()),
+        }
+    }
+
+    async fn dispatch_to(host: &str, path: &str) -> Response {
+        let req = Request::builder()
+            .method("GET")
+            .uri(path)
+            .header(header::HOST, host)
+            .body(Body::empty())
+            .unwrap();
+        match router(test_state()).oneshot(req).await {
+            Ok(resp) => resp,
+            Err(never) => match never {},
+        }
+    }
+
+    async fn body_string(resp: Response) -> String {
+        let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+            .await
+            .unwrap();
+        String::from_utf8_lossy(&bytes).into_owned()
+    }
+
+    #[tokio::test]
+    async fn apex_root_serves_the_branded_index() {
+        let resp = dispatch_to("share.example", "/").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "text/html; charset=utf-8"
+        );
+        let body = body_string(resp).await;
+        assert!(body.contains("Veld gateway"), "{body}");
+        assert!(body.contains("class=\"wordmark\""), "{body}");
+    }
+
+    #[tokio::test]
+    async fn health_endpoints_answer_on_apex_and_unknown_hosts() {
+        for host in ["share.example", "10.0.0.7", "gateway.internal:8080"] {
+            for path in ["/healthz", "/livez", "/readyz"] {
+                let resp = dispatch_to(host, path).await;
+                assert_eq!(resp.status(), StatusCode::OK, "{host}{path}");
+                assert_eq!(body_string(resp).await, "ok", "{host}{path}");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_slug_gets_the_branded_share_not_found() {
+        let resp = dispatch_to("nosuchslug.share.example", "/").await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = body_string(resp).await;
+        assert!(body.contains("Share not found"), "{body}");
+    }
+
+    #[tokio::test]
+    async fn apex_unmatched_path_and_unknown_host_get_the_generic_404() {
+        for (host, path) in [
+            ("share.example", "/nope"),
+            ("evil.example", "/"),
+            ("10.0.0.7", "/index.html"),
+        ] {
+            let resp = dispatch_to(host, path).await;
+            assert_eq!(resp.status(), StatusCode::NOT_FOUND, "{host}{path}");
+            let body = body_string(resp).await;
+            assert!(body.contains("Nothing lives at this address"), "{body}");
+        }
+    }
 
     #[test]
     fn slug_extraction_is_exactly_one_label() {

--- a/crates/veld-gateway/src/server.rs
+++ b/crates/veld-gateway/src/server.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use axum::Router;
 use axum::extract::{Request, State};
-use axum::response::{IntoResponse, Response};
+use axum::response::Response;
 use tower::util::ServiceExt as _;
 use tracing::{info, warn};
 
@@ -117,6 +117,11 @@ async fn dispatch(State(state): State<AppState>, req: Request) -> Response {
 
     let domain = &state.config.domain;
     if host == *domain {
+        // Health probes answer before the API router — same single source of
+        // truth as the unknown-host branch below.
+        if let Some(resp) = api::health_response(req.uri().path()) {
+            return resp;
+        }
         return match api::router().with_state(state.clone()).oneshot(req).await {
             Ok(resp) => resp,
             Err(never) => match never {},
@@ -137,11 +142,12 @@ async fn dispatch(State(state): State<AppState>, req: Request) -> Response {
     }
 
     // Unknown host: answer health probes (containers/LBs probe by IP or an
-    // internal name, not the public domain); everything else is a 404.
-    match req.uri().path() {
-        "/healthz" | "/livez" => api::livez().await.into_response(),
-        "/readyz" => api::readyz().await.into_response(),
-        _ => crate::pages::not_found(crate::pages::NotFound::Generic),
+    // internal name, not the public domain); everything else is a 404. The
+    // probe paths live in `api::health_response` — the one place to add or
+    // retire them.
+    match api::health_response(req.uri().path()) {
+        Some(resp) => resp,
+        None => crate::pages::not_found(crate::pages::NotFound::Generic),
     }
 }
 

--- a/docs/branding.md
+++ b/docs/branding.md
@@ -11,6 +11,13 @@ assets (inline CSS, embedded SVG, data-URI favicon; no external requests, so
 pages render under any CSP). No page ships looking like a bare `<h1>` on
 white.
 
+**Scope:** the rule covers pages a human is meant to read in a browser —
+index, login, 404s, viewer-facing error pages (dead tunnel, upstream
+timeout). Machine-facing responses stay plain text by design: API errors
+(Bearer-gated registration), health probe bodies, abuse-path guards
+(405/413/oversized form), and WebSocket upgrade failures. Responses an
+origin app produces and the gateway merely proxies are the app's own.
+
 ## Brand assets
 
 | Asset | Canonical source | Notes |

--- a/docs/branding.md
+++ b/docs/branding.md
@@ -1,0 +1,72 @@
+# Veld branding — for every user-facing surface
+
+This is the canonical reference for how anything Veld shows to a human in a
+browser must look. It exists so that new HTML surfaces (a gateway page, a
+daemon UI, an error page, an overlay) come out branded by default instead of
+falling back to unstyled system-default pages.
+
+**The rule:** any HTML page a Veld binary serves to a browser carries the
+Veld brand — the wordmark, the dark token palette below, and self-contained
+assets (inline CSS, embedded SVG, data-URI favicon; no external requests, so
+pages render under any CSP). No page ships looking like a bare `<h1>` on
+white.
+
+## Brand assets
+
+| Asset | Canonical source | Notes |
+|-------|------------------|-------|
+| Icon logo (`V.`) | `logo.svg` (repo root) | White `V` + accent-green dot, 32×32 viewBox |
+| Wordmark (`veld.`) | `crates/veld-daemon/assets/management-ui.html` (header SVG) and `crates/veld-gateway/src/pages.rs` (`WORDMARK_SVG`) | Letters take `var(--text)`, the final dot path takes `var(--accent)` |
+| Favicon | data-URI SVG in `website/index.html` and `crates/veld-gateway/src/pages.rs` | Rounded dark square, white `V`, accent dot |
+
+The wordmark's trailing dot is always the accent green — that is the brand's
+signature detail. When embedding the wordmark, color it via CSS
+(`.wordmark path{fill:var(--text)} .wordmark path:last-child{fill:var(--accent)}`)
+rather than hard-coded fills, so it follows the palette.
+
+## Product UI palette (dark)
+
+Used by the daemon management UI, the gateway pages, and any future product
+surface. Tokens (from `crates/veld-daemon/assets/management-ui.html`):
+
+```css
+:root{
+  --bg:#0f1117;--surface:#181a24;--surface2:#1f2233;--border:#2a2d3e;
+  --text:#e0e0e6;--text2:#8b8fa3;
+  --accent:#C4F56A;--accent-bg:rgba(196,245,106,.12);
+  --blue:#6c8cff;
+  --green:#3dd68c;--green-bg:rgba(61,214,140,.1);
+  --yellow:#f0c040;--yellow-bg:rgba(240,192,64,.1);
+  --red:#f06060;--red-bg:rgba(240,96,96,.1);
+  --dim:#555870;
+}
+```
+
+Conventions: system-ui font stack, 8–12px border radii, `--surface` cards on
+the `--bg` page with 1px `--border`, links in `--blue`, primary buttons in
+`--accent` with dark text, errors in `--red`. Header pattern:
+`wordmark / <subtitle>` (see the management UI and gateway pages).
+
+## Marketing palette (website)
+
+The website (`website/`) uses its own darker, editorial variant — same accent:
+
+```css
+:root{
+  --bg:#0A0A0B;--text:#E8E4DF;--accent:#C4F56A;--blue:#5B8DEF;
+  --muted:#4A4A50;--red:#ef4444;--code-bg:#141416;
+}
+```
+
+with JetBrains Mono / Playfair Display / Space Grotesk. Marketing pages follow
+`website/AGENTS.md`; product surfaces do NOT adopt the marketing fonts.
+
+## Checklist for a new user-facing page
+
+- [ ] Wordmark embedded (SVG, CSS-colored), accent dot green
+- [ ] Product palette tokens above (dark), not ad-hoc colors
+- [ ] Self-contained: inline CSS, no external fonts/scripts/images
+- [ ] `<meta name="viewport">` and (for non-indexable surfaces) `<meta name="robots" content="noindex">`
+- [ ] Data-URI favicon
+- [ ] No sensitive/enumerable data on anonymous pages (share names, hostnames, counts)
+- [ ] Reuse an existing shell where one exists (`crates/veld-gateway/src/pages.rs::shell` for gateway pages) instead of a new bespoke page

--- a/docs/branding.md
+++ b/docs/branding.md
@@ -13,9 +13,12 @@ white.
 
 **Scope:** the rule covers pages a human is meant to read in a browser —
 index, login, 404s, viewer-facing error pages (dead tunnel, upstream
-timeout). Machine-facing responses stay plain text by design: API errors
-(Bearer-gated registration), health probe bodies, abuse-path guards
-(405/413/oversized form), and WebSocket upgrade failures. Responses an
+unresponsive or timed out — whether the request was a plain fetch or a
+WebSocket upgrade attempt). Machine-facing responses stay plain text by
+design: API errors (Bearer-gated registration), health probe bodies,
+abuse-path guards (405/413/oversized form), and belt-and-braces guards on
+practically-unreachable paths (e.g. a password-mode slug without a
+password, a non-upgradable client connection at splice time). Responses an
 origin app produces and the gateway merely proxies are the app's own.
 
 ## Brand assets

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -208,7 +208,11 @@ Two consequences to know before sharing a non-trivial app:
   distinct targets if that ever changes. Readiness also stays `ok` through
   the SIGTERM drain: traffic shedding during a rolling restart is handled by
   the listener refusing new connections and the orchestrator removing the
-  endpoint, not by the probe flipping. `GET /healthz` remains as a legacy
+  endpoint, not by the probe flipping. On Kubernetes, endpoint removal
+  propagates asynchronously, so pair the probe with a short `preStop` sleep
+  (a few seconds) to keep the listener accepting until the pod has left the
+  Service endpoints — otherwise a rollout can surface brief connection
+  resets. `GET /healthz` remains as a legacy
   alias for liveness. Logs go to stdout (`RUST_LOG` controls verbosity).
 - **Shutdown**: SIGTERM drains gracefully (10s budget) — rolling restarts are
   safe; in-flight requests finish and heartbeats re-register.

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -136,6 +136,13 @@ File form (all fields optional, `SecretSource` accepted for secrets):
   refreshes the lease. `DELETE /api/v1/shares/{id}` unregisters (also
   idempotent). Driven entirely by `veld share --web`; you never call it by
   hand.
+- **Browser-facing pages are branded**: the apex `/` serves a small index
+  page identifying the server as a Veld gateway; unknown slugs answer a
+  branded "Share not found" 404 (unknown hosts and unmatched apex paths get a
+  generic branded 404); password-protected slugs show a branded login. All
+  pages follow [docs/branding.md](branding.md), are fully self-contained
+  (inline CSS, no external assets), `noindex`, and deliberately static — no
+  share metadata, counts, or hostnames are exposed to anonymous viewers.
 - **Public URLs are deterministic**: `slug = hash(host machine ‖ hostname ‖
   share capability)` — 26 lowercase base32 chars, unguessable (the URL is the
   baseline access control), stable across gateway restarts, new per share.
@@ -191,8 +198,14 @@ Two consequences to know before sharing a non-trivial app:
   throughput (n0's public relays throttle) — the first thing to check when a
   share feels slow. The developer sees the same picture in `veld shares` and
   the overlay's Web sharing card.
-- **Health**: `GET /healthz` answers `ok` on any Host (container/LB probes
-  included). Logs go to stdout (`RUST_LOG` controls verbosity).
+- **Health**: `GET /livez` (liveness — the process is up) and `GET /readyz`
+  (readiness — safe to route traffic) both answer `ok` on any Host
+  (container/LB probes included), so Kubernetes `livenessProbe` /
+  `readinessProbe` and Docker `HEALTHCHECK` work without knowing the domain.
+  The gateway has no warm-up phase or external dependency, so today readiness
+  equals liveness — the endpoints are split so probe configs have stable,
+  distinct targets if that ever changes. `GET /healthz` remains as a legacy
+  alias for liveness. Logs go to stdout (`RUST_LOG` controls verbosity).
 - **Shutdown**: SIGTERM drains gracefully (10s budget) — rolling restarts are
   safe; in-flight requests finish and heartbeats re-register.
 

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -139,7 +139,8 @@ File form (all fields optional, `SecretSource` accepted for secrets):
 - **Browser-facing pages are branded**: the apex `/` serves a small index
   page identifying the server as a Veld gateway; unknown slugs answer a
   branded "Share not found" 404 (unknown hosts and unmatched apex paths get a
-  generic branded 404); password-protected slugs show a branded login. All
+  generic branded 404); password-protected slugs show a branded login; a dead
+  tunnel or unresponsive upstream gets a branded 502/504. All
   pages follow [docs/branding.md](branding.md), are fully self-contained
   (inline CSS, no external assets), `noindex`, and deliberately static — no
   share metadata, counts, or hostnames are exposed to anonymous viewers.
@@ -204,7 +205,10 @@ Two consequences to know before sharing a non-trivial app:
   `readinessProbe` and Docker `HEALTHCHECK` work without knowing the domain.
   The gateway has no warm-up phase or external dependency, so today readiness
   equals liveness — the endpoints are split so probe configs have stable,
-  distinct targets if that ever changes. `GET /healthz` remains as a legacy
+  distinct targets if that ever changes. Readiness also stays `ok` through
+  the SIGTERM drain: traffic shedding during a rolling restart is handled by
+  the listener refusing new connections and the orchestrator removing the
+  endpoint, not by the probe flipping. `GET /healthz` remains as a legacy
   alias for liveness. Logs go to stdout (`RUST_LOG` controls verbosity).
 - **Shutdown**: SIGTERM drains gracefully (10s budget) — rolling restarts are
   safe; in-flight requests finish and heartbeats re-register.


### PR DESCRIPTION
## What

### Health endpoints (Kubernetes-ready)
- `GET /livez` — liveness (process up), `GET /readyz` — readiness (safe to route traffic). Both answer on **any Host** (probes address the pod by IP), on the apex and unknown hosts; slug hosts keep proxying these paths to the app.
- `GET /healthz` stays as a legacy liveness alias.
- Readiness equals liveness today (no warm-up phase / external dependency) and deliberately stays `ok` through the SIGTERM drain — documented, incl. the k8s `preStop` companion advice.
- Single source of truth for the probe paths: `api::health_response`, consulted by dispatch for apex and unknown hosts alike.

### Branded pages (Veld brand everywhere a viewer looks)
- New `pages` module: self-contained branded shell — management-UI dark token palette, embedded `veld.` wordmark SVG (accent-green dot), data-URI favicon, inline CSS only (renders under any CSP), `noindex`.
- **Apex index page**: identifies the server as a Veld gateway, links to the project — static on purpose, no share metadata.
- **404s**: "Share not found" on slug hosts, generic branded 404 for unknown hosts / unmatched apex paths / reserved paths. Still deliberately vague — neither variant confirms whether a share ever existed.
- **Login page**: rebranded via the shared shell; flow, one-link `#veld-key` script, escaping (incl. brace-escaping) unchanged.
- **Viewer-facing proxy errors**: dead tunnel / unresponsive / timed-out upstream now render branded 502/504 pages. `pages::error` takes `&'static str` so "trusted constants only — never echo request data" is compile-time enforced. Machine-facing responses (registration API, 405/413 abuse guards, pre-101 splice guard) stay plain text by design.

### Harness hardening (branding awareness for future work)
- **docs/branding.md** (new): canonical brand reference — assets (logo, wordmark, favicon), product-UI palette tokens, marketing palette, and a checklist for any new user-facing page.
- **AGENTS.md**: new key convention — every user-facing HTML surface must follow docs/branding.md; reuse the existing page shell instead of bespoke HTML.
- docs/gateway.md + Dockerfile updated for the new endpoints and pages.

## Review
Three rounds of the multi-angle adversarial review (docs/agentic-review.md): round 1 five angles (1 major — duplicated health-path allowlist — plus mediums, all fixed), round 2 five angles (2 majors — doc/scope contradiction on upgrade-path errors, `pages::error` injection-guard typing — both fixed), round 3 three-angle verification pass.

## Tests
`cargo test -p veld-gateway`: 65 passed. Clippy clean, fmt applied. New coverage: dispatch host×path matrix for health endpoints (+ method-agnostic pin), branded index/404/error rendering, login page brand assertion.