### PR TITLE
feat(gateway): tab-aware "Sharing has stopped" message on the share 404

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4250,7 +4250,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "veld"
-version = "9.5.2"
+version = "9.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "veld-core"
-version = "9.5.2"
+version = "9.6.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -4292,7 +4292,7 @@ dependencies = [
 
 [[package]]
 name = "veld-daemon"
-version = "9.5.2"
+version = "9.6.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4316,7 +4316,7 @@ dependencies = [
 
 [[package]]
 name = "veld-gateway"
-version = "9.5.2"
+version = "9.6.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4347,7 +4347,7 @@ dependencies = [
 
 [[package]]
 name = "veld-helper"
-version = "9.5.2"
+version = "9.6.0"
 dependencies = [
  "anyhow",
  "nix",
@@ -4363,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "veld-share"
-version = "9.5.2"
+version = "9.6.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/crates/veld-gateway/src/auth.rs
+++ b/crates/veld-gateway/src/auth.rs
@@ -493,9 +493,12 @@ fn login_page(status: StatusCode, next: &str, error: Option<&str>) -> Response {
     let error_html = error
         .map(|e| format!("<p class=\"err\">{}</p>", html_escape(e)))
         .unwrap_or_default();
+    // The login page only renders while the share is registered, so it stamps
+    // the tab-local "seen alive" marker the share 404 reads (pages.rs).
+    let body = format!("{LOGIN_BODY}{}", crate::pages::mark_share_seen_script());
     // Shell placeholders expand first; the viewer-influenced values go in
     // last and are brace-escaped, so they can never re-trigger a placeholder.
-    let page = crate::pages::shell("Password required", LOGIN_BODY)
+    let page = crate::pages::shell("Password required", &body)
         .replace("{next}", &next_attr)
         .replace("{error}", &error_html);
     (
@@ -1012,6 +1015,15 @@ mod tests {
         assert!(body.contains("<form"), "{body}");
         // The login page must carry the brand (rendered via pages::shell).
         assert!(body.contains("class=\"wordmark\""), "{body}");
+        // It renders only while the share is registered, so it stamps the
+        // tab-local marker the share 404 reads to show "Sharing has stopped".
+        assert!(
+            body.contains(&format!(
+                "sessionStorage.setItem('{}'",
+                crate::pages::SHARE_SEEN_KEY
+            )),
+            "{body}"
+        );
 
         let del = Request::builder()
             .method("DELETE")

--- a/crates/veld-gateway/src/pages.rs
+++ b/crates/veld-gateway/src/pages.rs
@@ -6,8 +6,10 @@
 //! palette and embedded wordmark of the daemon's management UI
 //! (`crates/veld-daemon/assets/management-ui.html`), fully self-contained
 //! (inline CSS, data-URI favicon, no external assets) so they render under
-//! any CSP and leak no requests. Deliberately static: no share metadata, no
-//! counts, nothing an anonymous viewer can enumerate.
+//! any CSP and leak no requests. The served bytes carry no share metadata,
+//! no counts — nothing an anonymous viewer can enumerate; the only dynamic
+//! behavior is client-side, from tab-local state the viewer's own tab minted
+//! earlier (see [`SHARE_SEEN_KEY`]).
 
 use axum::http::{StatusCode, header};
 use axum::response::{IntoResponse, Response};
@@ -210,11 +212,11 @@ try {{
 ///
 /// These pages are only reachable while a share is registered on the slug —
 /// proxy.rs is the sole caller, and `share_` in the name is the contract:
-/// they stamp [`SHARE_SEEN_KEY`], so calling this for a failure that is NOT
-/// scoped to a live share (an apex/unknown-host error, say) would mint a
-/// false "Sharing has stopped" — add a separate unstamped helper instead.
-/// The stamp means a viewer who only ever saw "share disconnected" still
-/// gets the honest "sharing has stopped" copy once the registration is gone.
+/// they stamp [`SHARE_SEEN_KEY`]. The hazard to respect: any error served on
+/// a SLUG origin whose registration is missing or already gone would stamp
+/// the very origin the share 404 later reads, minting a false "Sharing has
+/// stopped" — so only call this after a successful registry lookup (a live
+/// `SlugTarget` in hand); for anything else add a separate unstamped helper.
 pub fn share_error(status: StatusCode, title: &'static str, message: &'static str) -> Response {
     let body = format!(
         "<h1>{title}</h1><p>{message}</p>{}",

--- a/crates/veld-gateway/src/pages.rs
+++ b/crates/veld-gateway/src/pages.rs
@@ -84,10 +84,19 @@ pub fn shell(title: &str, body: &str) -> String {
         .replace("{body}", body)
 }
 
-/// sessionStorage key marking "this tab saw this share alive". Set by every
-/// page the gateway serves *while a share is registered* on its slug host
-/// (login page, viewer-facing error pages) and read by the share 404, which
-/// then swaps its copy from "Share not found" to "Sharing has stopped".
+/// sessionStorage key marking "this tab saw this share's gateway pages while
+/// it was registered". Set by the gateway-GENERATED pages that only render
+/// with a live registration (the login page, the viewer-facing error pages)
+/// and read by the share 404, which then swaps its copy from "Share not
+/// found" to "Sharing has stopped".
+///
+/// Scope, honestly: proxied upstream responses are never touched (bodies are
+/// never rewritten — docs/gateway.md), so a tab that only ever saw the app
+/// itself (a link-access share, or a password share entered via an existing
+/// session cookie) carries no marker and gets the plain 404. The marker also
+/// lives on the same origin as the proxied app, whose own JS may legally
+/// clear it (`sessionStorage.clear()`); every such miss degrades to the
+/// anonymous copy — never to a false "stopped" claim.
 ///
 /// Why sessionStorage: each slug is its own subdomain, hence its own web
 /// origin — the browser scopes the key to that share automatically — and
@@ -175,7 +184,7 @@ fn share_not_found_body() -> String {
 </div>
 <div id="stopped" hidden>
 <h1>Sharing has stopped</h1>
-<p>This preview was live in this tab earlier, but its owner has since stopped sharing it (or the share expired).</p>
+<p>The owner of this preview has stopped sharing it (or the share expired), so it is no longer available.</p>
 <p>If you still need access, ask whoever sent you the link to share again.</p>
 </div>
 <script>
@@ -199,11 +208,14 @@ try {{
 /// like 405/413, the pre-101 splice guard) stay plain text by design; see
 /// docs/branding.md.
 ///
-/// These pages are only reachable while a share is registered on the slug
-/// (proxy.rs is the sole caller), so they also stamp [`SHARE_SEEN_KEY`] —
-/// a viewer who only ever saw "share disconnected" still gets the honest
-/// "sharing has stopped" copy once the registration is gone.
-pub fn error(status: StatusCode, title: &'static str, message: &'static str) -> Response {
+/// These pages are only reachable while a share is registered on the slug —
+/// proxy.rs is the sole caller, and `share_` in the name is the contract:
+/// they stamp [`SHARE_SEEN_KEY`], so calling this for a failure that is NOT
+/// scoped to a live share (an apex/unknown-host error, say) would mint a
+/// false "Sharing has stopped" — add a separate unstamped helper instead.
+/// The stamp means a viewer who only ever saw "share disconnected" still
+/// gets the honest "sharing has stopped" copy once the registration is gone.
+pub fn share_error(status: StatusCode, title: &'static str, message: &'static str) -> Response {
     let body = format!(
         "<h1>{title}</h1><p>{message}</p>{}",
         mark_share_seen_script()
@@ -270,11 +282,15 @@ mod tests {
         assert!(body.contains("<div id=\"nf\">"), "{body}");
         assert!(body.contains("<div id=\"stopped\" hidden>"), "{body}");
         assert!(body.contains("Sharing has stopped"), "{body}");
-        // The swap reads the tab-local marker…
+        // The swap reads the tab-local marker and targets exactly the two
+        // shipped ids — a drift between the divs and the script would leave
+        // the page stuck on the default copy with every other assert green.
         assert!(
             body.contains(&format!("sessionStorage.getItem('{SHARE_SEEN_KEY}')")),
             "{body}"
         );
+        assert!(body.contains("getElementById('nf')"), "{body}");
+        assert!(body.contains("getElementById('stopped')"), "{body}");
         // …and the 404 itself must never SET it: a viewer bouncing off dead
         // slugs twice would otherwise mint the "stopped" copy from nothing.
         assert!(!body.contains("setItem"), "{body}");
@@ -287,7 +303,7 @@ mod tests {
 
     #[tokio::test]
     async fn error_pages_stamp_the_share_seen_marker() {
-        let resp = error(
+        let resp = share_error(
             StatusCode::BAD_GATEWAY,
             "Share disconnected",
             "This share is no longer connected.",
@@ -301,7 +317,7 @@ mod tests {
 
     #[tokio::test]
     async fn error_pages_are_branded_with_matching_status() {
-        let resp = error(
+        let resp = share_error(
             StatusCode::BAD_GATEWAY,
             "Share disconnected",
             "This share is no longer connected.",

--- a/crates/veld-gateway/src/pages.rs
+++ b/crates/veld-gateway/src/pages.rs
@@ -84,6 +84,30 @@ pub fn shell(title: &str, body: &str) -> String {
         .replace("{body}", body)
 }
 
+/// sessionStorage key marking "this tab saw this share alive". Set by every
+/// page the gateway serves *while a share is registered* on its slug host
+/// (login page, viewer-facing error pages) and read by the share 404, which
+/// then swaps its copy from "Share not found" to "Sharing has stopped".
+///
+/// Why sessionStorage: each slug is its own subdomain, hence its own web
+/// origin — the browser scopes the key to that share automatically — and
+/// sessionStorage lives exactly as long as the tab, which is the requested
+/// semantics (a fresh tab on a dead slug sees the plain 404). Slugs are
+/// capability-derived (slug.rs), so a different share can never inherit the
+/// origin and a re-registered share maps back to it.
+///
+/// Privacy: this does NOT weaken the "404s never confirm a share existed"
+/// stance — the server response is byte-identical for every viewer; the swap
+/// happens client-side from state only a tab that itself witnessed the live
+/// share can hold.
+pub(crate) const SHARE_SEEN_KEY: &str = "veld-gw-share-seen";
+
+/// Inline snippet that stamps [`SHARE_SEEN_KEY`]. Appended to gateway pages
+/// that are only ever served while the slug's share is registered.
+pub(crate) fn mark_share_seen_script() -> String {
+    format!("<script>try{{sessionStorage.setItem('{SHARE_SEEN_KEY}','1')}}catch(e){{}}</script>")
+}
+
 /// Escape for HTML text/attribute contexts. `{`/`}` are escaped too: pages
 /// are assembled by ordered string replacement (see [`shell`] and the login
 /// page's `{next}`/`{error}` passes in `auth.rs`), so braces surviving into
@@ -121,24 +145,49 @@ pub fn index() -> Response {
     html_response(StatusCode::OK, shell("Veld Gateway", body))
 }
 
-/// A branded 404. Still deliberately vague: neither variant confirms whether
-/// a share ever existed at the address.
+/// A branded 404. Still deliberately vague **as served**: neither variant's
+/// HTTP response confirms whether a share ever existed at the address. The
+/// share variant additionally carries a hidden "Sharing has stopped" block
+/// that an inline script reveals only when the tab itself saw the share
+/// alive earlier ([`SHARE_SEEN_KEY`]) — no server state, no new information
+/// for anyone else.
 pub fn not_found(kind: NotFound) -> Response {
     let (title, body) = match kind {
-        NotFound::Share => (
-            "Share not found",
-            "<h1>Share not found</h1>\
-             <p>There is no active share at this address. The preview may have expired \
-             or been stopped by its owner.</p>\
-             <p>Ask whoever sent you the link for a fresh one.</p>",
-        ),
+        NotFound::Share => ("Share not found", share_not_found_body()),
         NotFound::Generic => (
             "Not found",
             "<h1>Not found</h1>\
-             <p>Nothing lives at this address.</p>",
+             <p>Nothing lives at this address.</p>"
+                .to_owned(),
         ),
     };
-    html_response(StatusCode::NOT_FOUND, shell(title, body))
+    html_response(StatusCode::NOT_FOUND, shell(title, &body))
+}
+
+/// The share-404 body: the default "not found" copy, plus the tab-local
+/// "sharing stopped" alternative revealed by the [`SHARE_SEEN_KEY`] check.
+fn share_not_found_body() -> String {
+    format!(
+        r#"<div id="nf">
+<h1>Share not found</h1>
+<p>There is no active share at this address. The preview may have expired or been stopped by its owner.</p>
+<p>Ask whoever sent you the link for a fresh one.</p>
+</div>
+<div id="stopped" hidden>
+<h1>Sharing has stopped</h1>
+<p>This preview was live in this tab earlier, but its owner has since stopped sharing it (or the share expired).</p>
+<p>If you still need access, ask whoever sent you the link to share again.</p>
+</div>
+<script>
+try {{
+  if (sessionStorage.getItem('{SHARE_SEEN_KEY}')) {{
+    document.getElementById('nf').hidden = true;
+    document.getElementById('stopped').hidden = false;
+    document.title = 'Sharing has stopped';
+  }}
+}} catch (e) {{}}
+</script>"#
+    )
 }
 
 /// A branded error page for viewer-facing failures (dead tunnel,
@@ -149,8 +198,16 @@ pub fn not_found(kind: NotFound) -> Response {
 /// compile). Machine-facing responses (the registration API, abuse guards
 /// like 405/413, the pre-101 splice guard) stay plain text by design; see
 /// docs/branding.md.
+///
+/// These pages are only reachable while a share is registered on the slug
+/// (proxy.rs is the sole caller), so they also stamp [`SHARE_SEEN_KEY`] —
+/// a viewer who only ever saw "share disconnected" still gets the honest
+/// "sharing has stopped" copy once the registration is gone.
 pub fn error(status: StatusCode, title: &'static str, message: &'static str) -> Response {
-    let body = format!("<h1>{title}</h1><p>{message}</p>");
+    let body = format!(
+        "<h1>{title}</h1><p>{message}</p>{}",
+        mark_share_seen_script()
+    );
     html_response(status, shell(title, &body))
 }
 
@@ -203,6 +260,43 @@ mod tests {
             assert!(body.contains(marker), "{body}");
             assert!(body.contains("class=\"wordmark\""), "{body}");
         }
+    }
+
+    #[tokio::test]
+    async fn share_not_found_swaps_to_stopped_copy_only_client_side() {
+        let resp = not_found(NotFound::Share);
+        let body = body_string(resp).await;
+        // Both copies ship, the stopped one hidden by default.
+        assert!(body.contains("<div id=\"nf\">"), "{body}");
+        assert!(body.contains("<div id=\"stopped\" hidden>"), "{body}");
+        assert!(body.contains("Sharing has stopped"), "{body}");
+        // The swap reads the tab-local marker…
+        assert!(
+            body.contains(&format!("sessionStorage.getItem('{SHARE_SEEN_KEY}')")),
+            "{body}"
+        );
+        // …and the 404 itself must never SET it: a viewer bouncing off dead
+        // slugs twice would otherwise mint the "stopped" copy from nothing.
+        assert!(!body.contains("setItem"), "{body}");
+
+        // The generic 404 has neither copy-swap nor marker.
+        let generic = body_string(not_found(NotFound::Generic)).await;
+        assert!(!generic.contains("sessionStorage"), "{generic}");
+        assert!(!generic.contains("Sharing has stopped"), "{generic}");
+    }
+
+    #[tokio::test]
+    async fn error_pages_stamp_the_share_seen_marker() {
+        let resp = error(
+            StatusCode::BAD_GATEWAY,
+            "Share disconnected",
+            "This share is no longer connected.",
+        );
+        let body = body_string(resp).await;
+        assert!(
+            body.contains(&format!("sessionStorage.setItem('{SHARE_SEEN_KEY}'")),
+            "{body}"
+        );
     }
 
     #[tokio::test]

--- a/crates/veld-gateway/src/proxy.rs
+++ b/crates/veld-gateway/src/proxy.rs
@@ -58,7 +58,7 @@ pub async fn handle(state: AppState, target: SlugTarget, req: Request) -> Respon
     let reg = &target.registration;
     if reg.conn.close_reason().is_some() {
         // The watcher will unpublish this slug momentarily; answer honestly.
-        return crate::pages::error(
+        return crate::pages::share_error(
             StatusCode::BAD_GATEWAY,
             "Share disconnected",
             "This share is no longer connected. The developer may have stopped \
@@ -110,7 +110,7 @@ pub async fn handle(state: AppState, target: SlugTarget, req: Request) -> Respon
         Ok(s) => s,
         Err(e) => {
             warn!(error = %format!("{e:#}"), hostname = %target.hostname, "tunnel stream failed");
-            return crate::pages::error(
+            return crate::pages::share_error(
                 StatusCode::BAD_GATEWAY,
                 "Could not reach the shared service",
                 "The tunnel to the shared service failed. Try again in a moment.",
@@ -139,7 +139,7 @@ pub async fn handle(state: AppState, target: SlugTarget, req: Request) -> Respon
                 } else {
                     debug!(error = %e, hostname = %target.hostname, "upstream request failed");
                 }
-                return crate::pages::error(
+                return crate::pages::share_error(
                     StatusCode::BAD_GATEWAY,
                     "The shared service did not respond",
                     "The service behind this share closed the connection without \
@@ -148,7 +148,7 @@ pub async fn handle(state: AppState, target: SlugTarget, req: Request) -> Respon
             }
             Err(_) => {
                 debug!(hostname = %target.hostname, is_upgrade, "upstream response timed out");
-                return crate::pages::error(
+                return crate::pages::share_error(
                     StatusCode::GATEWAY_TIMEOUT,
                     "The shared service timed out",
                     "The service behind this share did not respond in time. \

--- a/docs/branding.md
+++ b/docs/branding.md
@@ -78,5 +78,9 @@ with JetBrains Mono / Playfair Display / Space Grotesk. Marketing pages follow
 - [ ] Self-contained: inline CSS, no external fonts/scripts/images
 - [ ] `<meta name="viewport">` and (for non-indexable surfaces) `<meta name="robots" content="noindex">`
 - [ ] Data-URI favicon
-- [ ] No sensitive/enumerable data on anonymous pages (share names, hostnames, counts)
+- [ ] No sensitive/enumerable data on anonymous pages (share names, hostnames, counts).
+      Client-side, tab-scoped reveals are the one vetted exception: a page may
+      swap its copy from browser-local state the viewer's own tab minted
+      earlier (see `SHARE_SEEN_KEY` in `crates/veld-gateway/src/pages.rs`),
+      as long as the served bytes stay identical for every viewer
 - [ ] Reuse an existing shell where one exists (`crates/veld-gateway/src/pages.rs::shell` for gateway pages) instead of a new bespoke page

--- a/docs/branding.md
+++ b/docs/branding.md
@@ -82,5 +82,5 @@ with JetBrains Mono / Playfair Display / Space Grotesk. Marketing pages follow
       Client-side, tab-scoped reveals are the one vetted exception: a page may
       swap its copy from browser-local state the viewer's own tab minted
       earlier (see `SHARE_SEEN_KEY` in `crates/veld-gateway/src/pages.rs`),
-      as long as the served bytes stay identical for every viewer
+      as long as the served bytes stay identical for every viewer.
 - [ ] Reuse an existing shell where one exists (`crates/veld-gateway/src/pages.rs::shell` for gateway pages) instead of a new bespoke page

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -144,12 +144,16 @@ File form (all fields optional, `SecretSource` accepted for secrets):
   pages follow [docs/branding.md](branding.md), are fully self-contained
   (inline CSS, no external assets), `noindex`, and deliberately static — no
   share metadata, counts, or hostnames are exposed to anonymous viewers.
-- **A tab that saw a share alive gets an honest goodbye**: gateway pages that
-  only render while a share is registered (the login page, the 502/504 error
-  pages) stamp a per-tab `sessionStorage` marker on the slug's origin. When
-  the share is later stopped, a reload in that same tab shows "Sharing has
-  stopped" instead of the anonymous "Share not found"; a fresh tab (or anyone
-  who never saw the share) still gets the plain 404. The swap is purely
+- **A tab that saw a gateway page for a live share gets an honest goodbye**:
+  the pages the gateway itself renders only while a share is registered (the
+  password login page, the 502/504 error pages) stamp a per-tab
+  `sessionStorage` marker on the slug's origin. When the share is later
+  stopped, a reload in that same tab shows "Sharing has stopped" instead of
+  the anonymous "Share not found"; a fresh tab (or anyone who never saw the
+  share) still gets the plain 404. Scope caveat: proxied app responses are
+  never touched, so a tab that only ever saw the app itself — a link-access
+  share, or a password share entered through an existing session cookie —
+  carries no marker and gets the plain 404 too. The swap is purely
   client-side — the HTTP response is identical for every viewer, so 404s
   still confirm nothing about whether a share ever existed.
 - **Public URLs are deterministic**: `slug = hash(host machine ‖ hostname ‖

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -144,6 +144,14 @@ File form (all fields optional, `SecretSource` accepted for secrets):
   pages follow [docs/branding.md](branding.md), are fully self-contained
   (inline CSS, no external assets), `noindex`, and deliberately static — no
   share metadata, counts, or hostnames are exposed to anonymous viewers.
+- **A tab that saw a share alive gets an honest goodbye**: gateway pages that
+  only render while a share is registered (the login page, the 502/504 error
+  pages) stamp a per-tab `sessionStorage` marker on the slug's origin. When
+  the share is later stopped, a reload in that same tab shows "Sharing has
+  stopped" instead of the anonymous "Share not found"; a fresh tab (or anyone
+  who never saw the share) still gets the plain 404. The swap is purely
+  client-side — the HTTP response is identical for every viewer, so 404s
+  still confirm nothing about whether a share ever existed.
 - **Public URLs are deterministic**: `slug = hash(host machine ‖ hostname ‖
   share capability)` — 26 lowercase base32 chars, unguessable (the URL is the
   baseline access control), stable across gateway restarts, new per share.


### PR DESCRIPTION
## What

When a viewer's tab saw a password-protected share's gateway pages while the share was live, and the host later stops sharing, a reload in that same tab now shows **"Sharing has stopped"** instead of the anonymous **"Share not found"**. A fresh tab (or anyone who never saw the share) still gets the plain 404, and closing the tab resets to the plain 404 — exactly sessionStorage semantics.

## How

- Gateway pages that only render while a share is registered — the password login page and the viewer-facing 502/504 error pages — stamp a per-tab `sessionStorage` marker (`veld-gw-share-seen`) on the slug's origin. Each slug is its own subdomain, hence its own web origin, so the browser scopes the marker to that share automatically; slugs are capability-derived, so no other share can ever inherit it.
- The share 404 ships both copies (default "Share not found" + hidden "Sharing has stopped") and an inline script reveals the stopped copy only when the marker is present. No-JS viewers see the safe anonymous copy.
- **Privacy stance preserved**: the HTTP response stays byte-identical for every viewer — 404s still confirm nothing about whether a share ever existed. The swap is purely client-side from state only a tab that itself witnessed the live share can hold.
- `pages::error` renamed to `pages::share_error`: it now stamps the marker, and the name carries the share-scoped contract so a future non-share error page can't mint a false "Sharing has stopped".

## Scope caveat (documented)

Proxied app responses are never touched (bodies are never rewritten), so a tab that only ever saw the app itself — a link-access share, or a password share entered via an existing session cookie — carries no marker and gets the plain 404.

## Review

Two rounds of the five-angle adversarial review (docs/agentic-review.md). Round 1: 1 major (docs overclaimed scope) + 3 medium (unguarded stamp helper, test id-drift gap, copy asserting prior liveness) — all fixed. Round 2: zero critical/major; remaining doc-wording notes folded in.

## Docs

- `docs/gateway.md`: new behavior bullet with honest scoping.
- `docs/branding.md`: client-side, tab-scoped reveals documented as the one vetted exception to the no-enumerable-data rule.