### PR TITLE
fix(ci): restore GitHub release notes (pin conventionalcommits preset to v9)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,10 +43,18 @@ jobs:
         id: semantic
         with:
           dry_run: true
+          # conventional-changelog-conventionalcommits is pinned to v9:
+          # @semantic-release/release-notes-generator@14 bundles
+          # conventional-changelog-writer@8, and the conventionalcommits preset
+          # v10+ emits writerOpts incompatible with it — the release notes body
+          # comes out empty (header only). v9 matches the bundled writer. The
+          # empty-notes regression started with #128, which added this preset.
+          # NOTE: keep this list free of "#" comments — the action runs
+          # `npm install` on every non-empty line verbatim.
           extra_plugins: |
             @semantic-release/exec
             @semantic-release/git
-            conventional-changelog-conventionalcommits
+            conventional-changelog-conventionalcommits@^9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -181,10 +189,12 @@ jobs:
       - uses: cycjimmy/semantic-release-action@v4
         id: semantic
         with:
+          # Pin conventional-changelog-conventionalcommits to v9 — see the plan
+          # job above for why (preset v10+ breaks release notes with writer@8).
           extra_plugins: |
             @semantic-release/exec
             @semantic-release/git
-            conventional-changelog-conventionalcommits
+            conventional-changelog-conventionalcommits@^9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Problem

Every GitHub release since **v8.0.0** has an empty body — just the version header + compare link, no **Features / Bug Fixes / BREAKING CHANGES** sections. See v8.0.0, v10.0.0, v10.1.0 releases.

## Root cause

The Release workflow's `cycjimmy/semantic-release-action@v4` `extra_plugins` installed `conventional-changelog-conventionalcommits` **unpinned**, so it floated to **v10**. But `@semantic-release/release-notes-generator@14` bundles `conventional-changelog-writer@8`, and the conventionalcommits preset **v10+** emits `writerOpts` incompatible with writer@8 — the notes template renders the header but drops every commit group.

The action installs the plugin fresh each run (no lockfile), and semantic-release's dynamic `import('conventional-changelog-conventionalcommits')` resolves the hoisted top-level v10 over the nested v9.3.1.

Timeline: #128 added `preset: conventionalcommits` to `.releaserc.json`. Before that, no preset was set (default angular, using the bundled writer) → notes worked (v7.3.0). The first release after #128 was **v8.0.0** — exactly where notes went empty.

## Fix

Pin `conventional-changelog-conventionalcommits@^9` in the `extra_plugins` of both semantic-release jobs (`plan` dry-run + `release` real run). `^9` resolves to 9.3.1, matching the writer@8 the notes generator bundles.

## Verification

Reproduced by calling `generateNotes({preset:'conventionalcommits'})` directly against sample `feat`/`fix`/`feat!` commits:

- `conventional-changelog-conventionalcommits@10.2.1` → **header only** (reproduces the bug)
- `@^9` (→ 9.3.1) → full **⚠ BREAKING CHANGES / Features / Bug Fixes** sections

YAML comments are placed outside the `extra_plugins: |` block scalar so `npm install` never receives a `#` line.

## Docs checklist

N/A — internal CI fix, no new config/CLI surface.