### PR TITLE
feat(gateway): loading state on password login page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4302,7 +4302,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "veld"
-version = "9.6.0"
+version = "10.1.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4322,7 +4322,7 @@ dependencies = [
 
 [[package]]
 name = "veld-core"
-version = "9.6.0"
+version = "10.1.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "veld-daemon"
-version = "9.6.0"
+version = "10.1.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -4369,7 +4369,7 @@ dependencies = [
 
 [[package]]
 name = "veld-gateway"
-version = "9.6.0"
+version = "10.1.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -4400,7 +4400,7 @@ dependencies = [
 
 [[package]]
 name = "veld-helper"
-version = "9.6.0"
+version = "10.1.2"
 dependencies = [
  "anyhow",
  "nix",
@@ -4416,7 +4416,7 @@ dependencies = [
 
 [[package]]
 name = "veld-share"
-version = "9.6.0"
+version = "10.1.2"
 dependencies = [
  "anyhow",
  "dirs",

--- a/crates/veld-gateway/src/auth.rs
+++ b/crates/veld-gateway/src/auth.rs
@@ -514,26 +514,70 @@ fn login_page(status: StatusCode, next: &str, error: Option<&str>) -> Response {
 }
 
 /// The login form + one-link script, rendered inside the branded page shell
-/// (self-contained, CSP-friendly, no external assets). The inline script
-/// implements the one-link flow: a `#veld-key=…` fragment auto-fills and
-/// submits the form, then strips itself from the URL — the fragment never
-/// reaches the server or its logs.
+/// (self-contained, CSP-friendly, no external assets). Two behaviours:
+///
+/// * **One-link flow** — a `#veld-key=…` fragment auto-fills and submits the
+///   form, then strips itself from the URL, so the fragment never reaches the
+///   server or its logs.
+/// * **Loading state** — on submit (manual OR the auto-fill path) the form
+///   enters a `loading` state: the field goes read-only and dims, the button
+///   shows a spinner and "Unlocking…", so there is a visible cue that an
+///   attempt is in flight. It is progressive: with JS disabled the form still
+///   submits, just without the affordance. The field is made **read-only, not
+///   disabled** — a disabled field is omitted from the POST body, which would
+///   silently drop the password. No client-side reset is needed: a wrong
+///   password re-renders this page fresh (server-side), which clears the
+///   state; a correct one navigates away.
 const LOGIN_BODY: &str = r#"<form id="f" method="post" action="/__veld_gateway__/auth" autocomplete="off">
   <h1>Password required</h1>
   <p>This preview is protected. Enter the password you were given.</p>
   {error}
   <input type="hidden" name="next" value="{next}">
-  <input id="pw" type="password" name="password" autofocus aria-label="Password">
-  <button type="submit">Open</button>
+  <input id="pw" type="password" name="password" autofocus aria-label="Password" required>
+  <button id="unlock" type="submit">
+    <span class="btn-idle">Open</span>
+    <span class="btn-busy"><span class="spinner" aria-hidden="true"></span>Unlocking&hellip;</span>
+  </button>
   <p class="hint">Your browser must allow cookies for this site.</p>
 </form>
+<style>
+  .btn-busy{display:none;align-items:center;justify-content:center;gap:.5rem}
+  #f.loading .btn-idle{display:none}
+  #f.loading .btn-busy{display:inline-flex}
+  #f.loading input[type=password]{opacity:.55}
+  button:disabled{cursor:default;filter:none}
+  .spinner{width:.85rem;height:.85rem;border:2px solid rgba(15,17,23,.3);border-top-color:var(--bg);border-radius:50%;display:inline-block;animation:veld-spin .6s linear infinite}
+  @keyframes veld-spin{to{transform:rotate(360deg)}}
+  @media (prefers-reduced-motion:reduce){.spinner{animation:none}}
+</style>
 <script>
 (function () {
+  var form = document.getElementById('f');
+  var pw = document.getElementById('pw');
+  // NB: the button's id must not be `submit` (or any HTMLFormElement member) —
+  // a like-named child shadows `form.submit`, breaking the auto-submit below.
+  var btn = document.getElementById('unlock');
+  var loading = false;
+  function setLoading() {
+    if (loading) return;
+    loading = true;
+    form.classList.add('loading');
+    form.setAttribute('aria-busy', 'true');
+    // `readOnly` (not `disabled`) keeps the value in the POST body while
+    // still blocking edits while the attempt is in flight.
+    pw.readOnly = true;
+    btn.disabled = true;
+  }
+  // Manual submit: the native submit event fires, so hook it. (The auto-fill
+  // path below calls form.submit(), which does NOT fire this event, so it
+  // sets the state itself.)
+  form.addEventListener('submit', setLoading);
+
   var m = location.hash.match(/[#&]veld-key=([^&]+)/);
   if (!m) return;
   var key;
   try { key = decodeURIComponent(m[1]); } catch (e) { return; }
-  document.getElementById('pw').value = key;
+  pw.value = key;
   // Everything in the fragment except the key survives: it is stripped from
   // the visible URL and forwarded through `next` so the app's own hash (e.g.
   // a deep-link anchor) still arrives after the redirect.
@@ -545,7 +589,8 @@ const LOGIN_BODY: &str = r#"<form id="f" method="post" action="/__veld_gateway__
     next.value = location.pathname + location.search;
   if (rest) next.value += '#' + rest;
   history.replaceState(null, '', location.pathname + location.search + (rest ? '#' + rest : ''));
-  document.getElementById('f').submit();
+  setLoading();
+  form.submit();
 })();
 </script>"#;
 
@@ -1034,6 +1079,29 @@ mod tests {
             panic!("expected a response");
         };
         assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    #[tokio::test]
+    async fn login_page_ships_loading_state_that_preserves_the_password() {
+        let body = body_string(login_page(StatusCode::OK, "/", None)).await;
+        // The busy affordance and its trigger ship on the page…
+        assert!(body.contains("Unlocking"), "{body}");
+        assert!(body.contains("class=\"spinner\""), "{body}");
+        assert!(body.contains("classList.add('loading')"), "{body}");
+        assert!(body.contains("addEventListener('submit'"), "{body}");
+        // The one-link path calls form.submit() (which does NOT fire the submit
+        // event), so it must set the loading state itself right before it —
+        // this coupling is the only loading cue the auto-submit flow gets.
+        assert!(body.contains("setLoading();\n  form.submit();"), "{body}");
+        // The button's id must never be `submit`: a like-named child shadows
+        // HTMLFormElement.submit, turning form.submit() into a TypeError and
+        // freezing the one-link flow on a permanent spinner.
+        assert!(!body.contains("id=\"submit\""), "{body}");
+        // …and the field is made read-only, NOT disabled — a disabled field is
+        // omitted from the POST body, which would silently drop the password.
+        assert!(body.contains("readOnly = true"), "{body}");
+        assert!(body.contains("btn.disabled = true"), "{body}");
+        assert!(!body.contains("pw.disabled"), "{body}");
     }
 
     #[test]

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -303,7 +303,11 @@ How a viewer gets in:
 2. The form POSTs to `/__veld_gateway__/auth` on the slug host (a reserved
    path prefix — `/__veld_gateway__/` never reaches the origin service).
    A `#veld-key=…` URL fragment auto-fills and submits the form (the
-   "one-link" flow); fragments never reach the gateway or its logs.
+   "one-link" flow); fragments never reach the gateway or its logs. On submit
+   — manual or one-link — the form shows a loading state (field goes
+   read-only, button spins on "Unlocking…") so an in-flight attempt is
+   visible; it degrades gracefully when JS is off, and a wrong password simply
+   re-renders the page (clearing the state) with an error.
 3. Correct password → a session cookie scoped to that slug host
    (`HttpOnly; Secure; SameSite=Lax`), then a redirect to the originally
    requested path. The cookie is **stripped before proxying** — the origin


### PR DESCRIPTION
## What

Adds a loading state to the gateway password login page, for **both** ways a viewer submits:

- **Manual entry** — on submit the field goes read-only + dims, the button swaps to a spinner labelled "Unlocking…".
- **One-link (`#veld-key=…`)** — same cue fires immediately on the auto-submit, so a pre-filled URL no longer just sits there with no sign it's unlocking.

## Why / root cause

The login page (`crates/veld-gateway/src/auth.rs`, `LOGIN_BODY`) is a plain form POST with no in-flight feedback. Manual submit left the page static until navigation; the one-link flow pre-filled the password and called `form.submit()` with zero visual clue. The maintainer asked for a loading state with the input disabled and correct wrong-password behaviour.

## How

- JS `setLoading()` toggles a `loading` class: field → `readOnly` (**not** `disabled` — a disabled field is dropped from the POST body, silently losing the password), button → `disabled` (double-submit guard) with a CSS spinner.
- Manual path hooks the `submit` event; the one-link path calls `setLoading()` itself right before `form.submit()` (programmatic submit does **not** fire the event).
- **Wrong password**: no client reset needed — the server re-renders a fresh page (`no-store`) which ships the non-loading markup, clearing the state.
- Progressive enhancement: JS off → button reads "Open", form still POSTs.
- `required` on the field skips the busy flash on an empty manual submit (bypassed by programmatic submit, so the one-link path is unaffected); `prefers-reduced-motion` fallback stops the spin.

## Test evidence

- `cargo test -p veld-gateway` → 68 passed. New test `login_page_ships_loading_state_that_preserves_the_password` locks the markup, the read-only-not-disabled invariant, the auto-submit `setLoading(); form.submit()` coupling, and asserts the button id is never `submit`.
- `cargo clippy -p veld-gateway --all-targets` clean, `cargo fmt --all` clean.

## Review

Two rounds of multi-angle adversarial review (counterfactual / what-isn't-here / self-consistency, opus). Round 1 caught a 🔴 I introduced: a button `id="submit"` shadows `HTMLFormElement.submit`, turning the one-link `form.submit()` into a `TypeError` and freezing the flow on a permanent spinner (verified in real Chrome by two independent angles). Fixed by renaming the id to `unlock` and adding a regression assert. Round 2 clean on all angles.

## Reviewer scope notes

- `Cargo.lock`: benign workspace version sync (9.6.0 → 10.1.2) to match the already-released crate versions in the branch's `Cargo.toml`; regenerated by the build, not a dependency change.
- Purely a gateway login-page surface change — no new config fields / CLI flags / schema, so only `docs/gateway.md` needed updating per the AGENTS.md checklist.

## Known follow-ups

None.