### PR TITLE
feat(update): keep environments running through updates; deterministic privileged helper restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4302,7 +4302,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "veld"
-version = "9.6.0"
+version = "10.1.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4322,7 +4322,7 @@ dependencies = [
 
 [[package]]
 name = "veld-core"
-version = "9.6.0"
+version = "10.1.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "veld-daemon"
-version = "9.6.0"
+version = "10.1.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -4369,7 +4369,7 @@ dependencies = [
 
 [[package]]
 name = "veld-gateway"
-version = "9.6.0"
+version = "10.1.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -4400,7 +4400,7 @@ dependencies = [
 
 [[package]]
 name = "veld-helper"
-version = "9.6.0"
+version = "10.1.2"
 dependencies = [
  "anyhow",
  "nix",
@@ -4416,7 +4416,7 @@ dependencies = [
 
 [[package]]
 name = "veld-share"
-version = "9.6.0"
+version = "10.1.2"
 dependencies = [
  "anyhow",
  "dirs",

--- a/crates/veld-core/src/setup.rs
+++ b/crates/veld-core/src/setup.rs
@@ -1163,6 +1163,79 @@ pub fn helper_plist_filename() -> String {
 /// wedged service manager must degrade to "unknown", never hang the caller.
 pub const SERVICE_QUERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
+/// Deterministically restart the privileged (root) helper so it runs a
+/// freshly installed binary, without waiting on the helper's own binary
+/// watcher.
+///
+/// The helper's system-domain LaunchDaemon / systemd unit runs as root, so
+/// bouncing it needs privilege. `veld update` runs unprivileged, hence sudo:
+/// try passwordless first (`sudo -n`, silent and instant when a cached/NOPASSWD
+/// credential exists), and only if that fails and `interactive` is set (the
+/// caller has a TTY) prompt once for the password. This is the reliable path —
+/// it removes the dependence on the ~12s watcher poll + launchd `WatchPaths`
+/// that could otherwise leave `veld update` waiting out its timeout and telling
+/// the user to re-run `veld setup privileged`.
+///
+/// Returns `true` if a restart command was successfully issued (the caller
+/// should then verify the version flipped), `false` if sudo was unavailable or
+/// the attempt failed — in which case the caller falls back to the helper's
+/// self-restart watcher.
+///
+/// The restart is intentionally **graceful**, not a SIGKILL. On macOS it sends
+/// SIGTERM (`launchctl kill TERM`), which the helper handles by exiting while
+/// leaving Caddy running (see veld-helper `signal_stream`), and launchd's
+/// `KeepAlive` then relaunches the new binary. On Linux `systemctl restart`
+/// relies on the unit's `KillMode=process` for the same effect. Both keep the
+/// Caddy proxy — and therefore every live URL — up across the bounce; a hard
+/// `kickstart -k` / default-KillMode restart could take Caddy's process group
+/// down with the helper, which would break the "environments keep serving"
+/// guarantee this whole change exists to provide.
+pub async fn restart_privileged_helper(interactive: bool) -> bool {
+    // Build owned args so the label constant is the single source of truth.
+    #[cfg(target_os = "macos")]
+    let restart_args: Vec<String> = vec![
+        "launchctl".to_string(),
+        "kill".to_string(),
+        "TERM".to_string(),
+        format!("system/{HELPER_LABEL_MACOS}"),
+    ];
+    #[cfg(not(target_os = "macos"))]
+    let restart_args: Vec<String> = vec![
+        "systemctl".to_string(),
+        "restart".to_string(),
+        HELPER_SERVICE_LINUX.to_string(),
+    ];
+
+    let args: Vec<&str> = restart_args.iter().map(String::as_str).collect();
+
+    // Passwordless first: never prompts, so it's safe to always try.
+    if run_sudo(true, &args).await {
+        return true;
+    }
+    // Fall back to an interactive prompt only when the caller says a human is
+    // present (a TTY, and not VELD_NON_INTERACTIVE) — a headless/scripted
+    // `veld update` must never block on sudo's password prompt.
+    if interactive && run_sudo(false, &args).await {
+        return true;
+    }
+    false
+}
+
+/// Run `sudo` with `args`. When `noninteractive`, pass `-n` (fail instead of
+/// prompting) and swallow output so a probe stays silent; otherwise inherit the
+/// terminal so sudo can prompt for the password. Returns whether it exited 0.
+async fn run_sudo(noninteractive: bool, args: &[&str]) -> bool {
+    let mut cmd = Command::new("sudo");
+    if noninteractive {
+        cmd.arg("-n");
+        cmd.stdin(std::process::Stdio::null());
+        cmd.stdout(std::process::Stdio::null());
+        cmd.stderr(std::process::Stdio::null());
+    }
+    cmd.args(args);
+    matches!(cmd.status().await, Ok(s) if s.success())
+}
+
 /// The MainPID systemd reports for a service, if it exists and is running.
 /// `MainPID=0` means not running. `user_unit` selects `systemctl --user`.
 pub async fn systemd_main_pid(service: &str) -> Option<u32> {

--- a/crates/veld-helper/src/caddy.rs
+++ b/crates/veld-helper/src/caddy.rs
@@ -141,6 +141,14 @@ impl CaddyManager {
             // browsers get 404 on WebSocket connections (kills HMR, live reload).
             // See: golang/go#71128, caddyserver/caddy#7309
             .env("GODEBUG", "http2xconnect=1")
+            // Put Caddy in its own process group (pgid = its own pid) so a signal
+            // delivered to the helper's launchd job — e.g. `veld update`'s
+            // `launchctl kill TERM system/dev.veld.helper`, or a bootout — cannot
+            // reach Caddy through the shared group. The helper only ever controls
+            // Caddy deliberately (admin-API `/stop` or an explicit kill-by-pid),
+            // so detaching the group keeps every live URL up across a helper
+            // restart. Mirrors the Linux unit's `KillMode=process`.
+            .process_group(0)
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .spawn()

--- a/crates/veld/src/commands/update.rs
+++ b/crates/veld/src/commands/update.rs
@@ -1,7 +1,5 @@
-use std::io::Write;
+use std::io::IsTerminal;
 
-use veld_core::config;
-use veld_core::orchestrator::Orchestrator;
 use veld_core::state::RunStatus;
 
 use crate::output;
@@ -14,12 +12,20 @@ pub async fn run() -> i32 {
 
     match veld_core::setup::check_update().await {
         Ok(Some(new_version)) => {
-            // Check for running environments and stop them before updating.
+            // Running environments are NOT stopped for an update. State lives in
+            // a single SQLite DB with a forward-only migration system, so a
+            // binary swap no longer risks the stale/incompatible state files
+            // that the old JSON-per-run storage did. Service processes are
+            // independent of the CLI/daemon/helper: the helper leaves Caddy
+            // running across its own restart (URLs stay up) and the daemon GC
+            // self-heals, so nothing needs tearing down. Environments keep
+            // serving and pick up the new orchestrator on their next
+            // `veld start`/`veld restart`.
             let running = find_running_environments();
             if !running.is_empty() {
                 println!();
                 output::print_info(&format!(
-                    "Found {} running environment(s) that must be stopped before updating:",
+                    "{} environment(s) are running and will keep serving during the update:",
                     running.len()
                 ));
                 for (project, run_name) in &running {
@@ -30,39 +36,22 @@ pub async fn run() -> i32 {
                     );
                 }
                 println!();
-                print!(
-                    "{}",
-                    output::yellow("Stop all environments and proceed with update? [y/N] ")
-                );
-                let _ = std::io::stdout().flush();
-
-                let mut answer = String::new();
-                if std::io::stdin().read_line(&mut answer).is_err()
-                    || !answer.trim().eq_ignore_ascii_case("y")
-                {
-                    output::print_info("Update cancelled.");
-                    return 0;
-                }
-
-                // Stop all running environments.
-                let stopped = stop_all_environments(&running).await;
-                output::print_success(&format!("Stopped {stopped} environment(s)."));
-                println!();
             }
 
             output::print_info(&format!("New version available: {current} → {new_version}"));
 
-            // Privileged mode relies on the helper's own binary-change watcher
-            // plus launchd/systemd (KeepAlive + WatchPaths) to bring up the new
-            // version — restarting the root service from here would need sudo.
-            // Both mechanisms require the service to still be REGISTERED. A
-            // merely-unresponsive process behind an intact registration gets
-            // relaunched onto the new binary, so only the job being gone means
-            // the update truly can't self-apply. Check BEFORE installing so
-            // that's reported as the pre-existing problem it is, instead of a
-            // 45-second wait ending in a misleading "did not pick up the new
-            // binary". In unprivileged mode the installer bootstraps the
-            // LaunchAgent itself, so no pre-flight skip there.
+            // After install, privileged mode restarts the root helper via sudo
+            // (see restart_services), with the helper's own binary-change
+            // watcher + launchd/systemd KeepAlive as the no-sudo fallback. Both
+            // recovery paths require the service to still be REGISTERED: a sudo
+            // restart of a nonexistent job fails, and the watcher only helps a
+            // job launchd already knows about. So a job that is entirely GONE is
+            // the one case the update genuinely can't self-apply — it needs
+            // `veld setup privileged` to re-register the LaunchDaemon. Check for
+            // that BEFORE installing so it's reported as the pre-existing
+            // problem it is, instead of a 45-second wait ending in a misleading
+            // "did not pick up the new binary". In unprivileged mode the
+            // installer bootstraps the LaunchAgent itself, so no pre-flight skip.
             let helper_dead_privileged = super::read_setup_mode().as_deref() == Some("privileged")
                 && !privileged_helper_serviceable().await;
             if helper_dead_privileged {
@@ -102,8 +91,8 @@ pub async fn run() -> i32 {
     }
 }
 
-/// Find all running environments across all projects.
-/// Returns (project_root, run_name) pairs.
+/// Find all running environments across all projects, for the informational
+/// "these keep serving" notice. Returns (project_root, run_name) pairs.
 fn find_running_environments() -> Vec<(std::path::PathBuf, String)> {
     let registry = match veld_core::db::Db::open().and_then(|db| db.registry()) {
         Ok(r) => r,
@@ -119,52 +108,6 @@ fn find_running_environments() -> Vec<(std::path::PathBuf, String)> {
         }
     }
     running
-}
-
-/// Stop all running environments. Returns number successfully stopped.
-async fn stop_all_environments(envs: &[(std::path::PathBuf, String)]) -> usize {
-    let mut stopped = 0;
-    for (project_root, run_name) in envs {
-        let config_path = project_root.join("veld.json");
-        let cfg = match config::load_config(&config_path) {
-            Ok(c) => c,
-            Err(e) => {
-                output::print_error(
-                    &format!("Failed to load config for {}: {e}", project_root.display()),
-                    false,
-                );
-                // Even if config can't load, try to clean up state.
-                cleanup_state(project_root, run_name);
-                continue;
-            }
-        };
-
-        let mut orchestrator = match Orchestrator::new(config_path, cfg) {
-            Ok(o) => o,
-            Err(e) => {
-                output::print_error(&format!("Failed to initialize: {e}"), false);
-                cleanup_state(project_root, run_name);
-                continue;
-            }
-        };
-        match orchestrator.stop(run_name).await {
-            Ok(_) => {
-                output::print_info(&format!("  Stopped '{run_name}'"));
-                stopped += 1;
-            }
-            Err(e) => {
-                output::print_error(&format!("  Failed to stop '{run_name}': {e}"), false);
-            }
-        }
-    }
-    stopped
-}
-
-/// Best-effort cleanup of state for a run when config can't be loaded.
-fn cleanup_state(project_root: &std::path::Path, run_name: &str) {
-    if let Ok(db) = veld_core::db::Db::open() {
-        let _ = db.remove_run(project_root, run_name);
-    }
 }
 
 /// Re-install the Hammerspoon Spoon if it was previously set up.
@@ -280,6 +223,43 @@ async fn restart_services(target_version: &str, helper_dead_privileged: bool) {
             false,
         );
     } else {
+        // In privileged mode the helper is a root service, so `veld update`
+        // (unprivileged) cannot bounce it directly. Rather than passively wait
+        // out the ~12s binary-watcher poll (which, if it slips past the 45s
+        // budget, ends in a misleading "re-run veld setup privileged"),
+        // deterministically restart it via sudo (a graceful SIGTERM that leaves
+        // Caddy running — see restart_privileged_helper) — passwordless if a
+        // credential is cached, otherwise a single interactive prompt. This is
+        // the reliable path; the self-restart watcher stays as the no-sudo
+        // fallback. Unprivileged mode's helper is a user LaunchAgent the
+        // installer already bounced, so no sudo is needed there.
+        if mode.as_deref() == Some("privileged") {
+            output::print_info("Restarting veld-helper (privileged) with the new binary...");
+            // A human is present only if we have a TTY AND weren't asked to run
+            // non-interactively — otherwise sudo's password prompt would hang a
+            // scripted/pty-driven update. Treat VELD_NON_INTERACTIVE as set only
+            // when it's non-empty, matching install.sh's `[ -n ... ]` convention:
+            // unset or empty (`=`) stays interactive; any non-empty value
+            // (including `0`) means non-interactive, exactly as the shell reads
+            // it. When interactive, warn before the prompt appears so an
+            // unexpected sudo prompt from a dev tool isn't mistaken for malware.
+            let non_interactive_env = std::env::var("VELD_NON_INTERACTIVE")
+                .map(|v| !v.is_empty())
+                .unwrap_or(false);
+            let interactive = std::io::stdin().is_terminal() && !non_interactive_env;
+            if interactive {
+                output::print_info(
+                    "veld may prompt for your sudo password to restart the privileged helper.",
+                );
+            }
+            if !veld_core::setup::restart_privileged_helper(interactive).await {
+                output::print_info(
+                    "Could not restart the privileged helper via sudo — waiting for it to \
+                     restart itself instead.",
+                );
+            }
+        }
+
         // Verify against the specific socket for this mode — not `connect()` (which
         // falls through to the user socket and could latch onto a stale auto-helper
         // while the privileged one is mid-restart).

--- a/install.sh
+++ b/install.sh
@@ -215,71 +215,14 @@ else
 fi
 
 # --- Install ---
-
-# --- Stop running environments (prevents stale state files after upgrade) ---
 #
-# When upgrading across major versions, state file format may change.
-# Stop all running environments using the OLD binary so state is cleanly
-# removed before the new binary is installed.
-
-EXISTING_VELD_BIN="$(command -v veld 2>/dev/null || true)"
-if [ -n "$EXISTING_VELD_BIN" ]; then
-  # Use `veld list --json` to find running environments across ALL projects.
-  # Parse with basic grep — no jq dependency required.
-  LIST_JSON="$("$EXISTING_VELD_BIN" list --json 2>/dev/null || true)"
-
-  # Extract project_root + run_name pairs for running environments.
-  # The JSON structure is: { "projects": { "<path>": { "runs": { "<name>": { "status": "running" } } } } }
-  RUNNING_INFO=""
-  if [ -n "$LIST_JSON" ]; then
-    # Use python3 (available on macOS and most Linux) for reliable JSON parsing.
-    RUNNING_INFO="$(echo "$LIST_JSON" | python3 -c '
-import json, sys
-try:
-    data = json.load(sys.stdin)
-    for path, proj in data.get("projects", {}).items():
-        for name, run in proj.get("runs", {}).items():
-            if run.get("status") == "running":
-                print(f"{path}\t{name}")
-except: pass
-' 2>/dev/null || true)"
-  fi
-
-  if [ -n "$RUNNING_INFO" ]; then
-    echo ""
-    echo "============================================================"
-    echo "  RUNNING ENVIRONMENTS DETECTED"
-    echo "============================================================"
-    echo ""
-    echo "  The following environments will be stopped before updating"
-    echo "  (prevents stale state files after upgrade):"
-    echo ""
-    echo "$RUNNING_INFO" | while IFS=$'\t' read -r proj_root run_name; do
-      echo "    - ${run_name}  (${proj_root})"
-    done
-    echo ""
-
-    if [ -z "${VELD_NON_INTERACTIVE:-}" ] && [ -t 0 ]; then
-      printf "  Stop all and continue? [Y/n] "
-      read -r answer < /dev/tty 2>/dev/null || answer="y"
-      answer="${answer:-y}"
-      if [ "$answer" != "y" ] && [ "$answer" != "Y" ]; then
-        echo "Update cancelled."
-        exit 0
-      fi
-    fi
-
-    echo "  Stopping environments..."
-    echo "$RUNNING_INFO" | while IFS=$'\t' read -r proj_root run_name; do
-      if (cd "$proj_root" 2>/dev/null && "$EXISTING_VELD_BIN" stop --name "$run_name" 2>/dev/null); then
-        echo "    Stopped '${run_name}'"
-      else
-        echo "    Warning: could not stop '${run_name}' (may need manual cleanup)"
-      fi
-    done
-    echo ""
-  fi
-fi
+# Running environments are intentionally NOT stopped for an update. State lives
+# in a single SQLite DB with a forward-only migration system, so swapping the
+# binaries no longer risks the stale/incompatible state files that the old
+# JSON-per-run storage did. Service processes are independent of the CLI,
+# daemon, and helper (the helper leaves Caddy running across its own restart, so
+# URLs stay up), and they pick up the new orchestrator on the next
+# `veld start`/`veld restart`.
 
 echo "Installing binaries..."
 $NEED_SUDO mkdir -p "$INSTALL_DIR"
@@ -390,14 +333,23 @@ if [ "$OS" = "macos" ]; then
     # (root). Restarting it in the system domain requires root — the old code
     # ran `$NEED_SUDO launchctl ... system/...` with NEED_SUDO empty for the
     # default user-path install, so it silently failed and left a stale helper.
-    # If passwordless sudo is available, kickstart it now for an immediate swap;
+    # If passwordless sudo is available, restart it now for an immediate swap;
     # otherwise the helper restarts itself when it detects its binary changed
     # (in-process watcher + the plist's WatchPaths) — no password prompt.
+    #
+    # Use a graceful SIGTERM (`launchctl kill TERM`), NOT `kickstart -k`: the
+    # helper handles SIGTERM by exiting while leaving Caddy running, and the
+    # plist's unconditional KeepAlive relaunches it onto the new binary — so
+    # every live URL stays up across the swap. A hard `kickstart -k` (SIGKILL,
+    # possibly escalating to launchd job teardown) is riskier for the child
+    # Caddy; the helper also spawns Caddy in its own process group as a second
+    # safeguard (see veld-helper caddy.rs). `veld update`'s own post-install
+    # restart uses this same graceful path.
     HELPER_PLIST="/Library/LaunchDaemons/dev.veld.helper.plist"
     if [ -f "$HELPER_PLIST" ]; then
       if sudo -n true 2>/dev/null; then
         echo "Restarting veld-helper service (privileged)..."
-        sudo launchctl kickstart -k system/dev.veld.helper 2>/dev/null || true
+        sudo launchctl kill TERM system/dev.veld.helper 2>/dev/null || true
       else
         echo "Privileged veld-helper will restart itself to pick up the new binary (no sudo needed)."
       fi

--- a/skills/veld/reference/install.md
+++ b/skills/veld/reference/install.md
@@ -32,7 +32,12 @@ veld doctor
 veld update
 ```
 
-This downloads the latest release and restarts background services automatically.
+This downloads the latest release and restarts the background services
+(helper + daemon) onto the new binaries automatically. **Running environments
+are left running** — state lives in a migrated SQLite DB, so a binary swap no
+longer risks stale state, and services keep serving throughout. In privileged
+mode the root helper is restarted via sudo (you may be prompted once for your
+password); if sudo isn't available, the helper restarts itself shortly after.
 
 ## Uninstalling
 


### PR DESCRIPTION
## What & why

Two long-standing update pains, fixed together so `veld update` is finally pleasant and non-intrusive.

### 1. Updates no longer stop running environments

The forced stop was added once, in **#111**, purely to avoid stale **JSON-per-run** state files across a v1→v2 schema change. With the central **SQLite DB + forward-only migrations** (#146) that hazard is gone, so a binary swap is safe:

- Service processes are independent of the CLI/daemon/helper — they're spawned by the (already-exited) `veld start` invocation and run in their own process groups.
- The helper leaves Caddy running across its own restart (`"leaving caddy running"` → `"re-adopted orphaned caddy"`), so URLs stay up.
- The daemon GC self-heals; it reopens the DB each pass and treats a newer schema as warn-and-retry.
- Confirmed the schema-forward-compat window is safe: the helper's route store is a JSON file (never touches the migrated DB), and the CLI doesn't reopen the DB after migration.

Removed the stop from **both** places it lived: `veld update` (the y/N prompt + `stop_all_environments`) and `install.sh`. Running envs are now just listed as "will keep serving" and pick up the new orchestrator on the next `start`/`restart`. (README.md and llms-full.txt already asserted this guarantee — the code now matches the docs.)

### 2. Privileged helper reliably restarts onto the new binary (no more `veld setup privileged`)

Root cause: in privileged mode `veld update` runs unprivileged, so `install.sh` only tried **passwordless** sudo to bounce the root helper; without it, it just *waited* on the ~12s binary-change watcher, which could slip past the 45s budget and end in a misleading *"run `veld setup privileged`"*. (This area had been patched 6× — #15/#16/#29/#70/#129/#130 — without landing solid.)

Now `veld update` **deterministically** restarts the root helper via sudo — passwordless if a credential is cached, otherwise **one interactive prompt** (the maintainer OK'd a password prompt in exchange for reliability). The self-restart watcher stays as the no-sudo fallback.

**Caddy stays up by two independent safeguards:**
- The restart is a **graceful SIGTERM** (`launchctl kill TERM`), not `kickstart -k` (SIGKILL) — the helper's signal handler exits leaving Caddy running and launchd's `KeepAlive` relaunches the new binary. `install.sh` now uses the same graceful mechanism (was `kickstart -k`), so the whole flow is one mechanism. Linux keeps `systemctl restart` (unit has `KillMode=process`).
- The helper now spawns Caddy in its **own process group** (`process_group(0)`), so no signal to the helper's launchd job can reach Caddy through a shared group — mirrors Linux's `KillMode=process`.

Non-interactive safety: the interactive sudo prompt is gated on `stdin().is_terminal() && !VELD_NON_INTERACTIVE` (emptiness semantics match install.sh's `[ -n ]`), so scripted/pty-driven updates never hang on a password prompt.

## Files
- `crates/veld/src/commands/update.rs` — remove forced stop; deterministic privileged restart with TTY/NON_INTERACTIVE gating + heads-up message.
- `crates/veld-core/src/setup.rs` — new `restart_privileged_helper` (graceful, sudo passwordless→interactive) + `run_sudo`.
- `crates/veld-helper/src/caddy.rs` — spawn Caddy detached (`process_group(0)`).
- `install.sh` — remove stop block; graceful `kill TERM` for privileged restart.
- `skills/veld/reference/install.md` — document the new behavior.

## Test evidence
- `cargo build --workspace`, `clippy --workspace --all-targets` (clean), `cargo fmt --all`, `cargo test --workspace` → **333 passed, 3 ignored**.
- `bash -n install.sh` clean.
- Machine logs confirm the graceful-exit path preserves Caddy (pid survives ~10 helper restarts, "re-adopted orphaned caddy").

## Review
Full 5-angle adversarial review (docs/agentic-review.md), **3 rounds**. R1: 2 majors (Caddy SIGKILL-teardown risk; interactive-sudo hang under pty automation) → fixed. R2: 2 majors (install.sh still `kickstart -k`; Caddy shared the helper's process group) → fixed. R3: clean, both angles `ship it`.

## Known follow-up
The launchd Caddy-survival guarantee is proven by reasoning + process-group detachment + machine logs, but isn't covered by an automated test (launchd is impractical to exercise in CI). Recommended manual check on a privileged macOS box: `sudo launchctl kill TERM system/dev.veld.helper` and confirm the Caddy pid + live URLs survive.
