### PR TITLE
feat(feedback): survive page reloads without losing in-progress overlay state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4302,7 +4302,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "veld"
-version = "10.1.2"
+version = "10.4.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4322,7 +4322,7 @@ dependencies = [
 
 [[package]]
 name = "veld-core"
-version = "10.1.2"
+version = "10.4.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "veld-daemon"
-version = "10.1.2"
+version = "10.4.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4369,7 +4369,7 @@ dependencies = [
 
 [[package]]
 name = "veld-gateway"
-version = "10.1.2"
+version = "10.4.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4400,7 +4400,7 @@ dependencies = [
 
 [[package]]
 name = "veld-helper"
-version = "10.1.2"
+version = "10.4.0"
 dependencies = [
  "anyhow",
  "nix",
@@ -4416,7 +4416,7 @@ dependencies = [
 
 [[package]]
 name = "veld-share"
-version = "10.1.2"
+version = "10.4.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/crates/veld-daemon/frontend/src/feedback-overlay.css
+++ b/crates/veld-daemon/frontend/src/feedback-overlay.css
@@ -644,7 +644,10 @@
 }
 
 /* --- Panel section (page group) --- */
-.veld-feedback-panel-section { margin-bottom: 12px; }
+/* flex-shrink:0 — panel-body is a flex column; without it a section shrinks
+   below its content when the list overflows instead of letting the body
+   scroll. */
+.veld-feedback-panel-section { margin-bottom: 12px; flex-shrink: 0; }
 .veld-feedback-panel-section-heading {
   display: flex; align-items: center; gap: 6px;
   font-size: 11px; font-weight: 600; color: var(--vf-text-muted);
@@ -668,6 +671,11 @@
   border: 1px solid var(--vf-border); cursor: pointer;
   transition: border-color .15s;
   overflow: hidden; min-width: 0;
+  /* flex-shrink:0 — resolved cards are direct children of the flex-column
+     panel-body, and `overflow:hidden` above zeroes their flex min-size, so
+     without this a long resolved list squishes every card below its text
+     height (collapsed, clipped rows) instead of scrolling. */
+  flex-shrink: 0;
 }
 .veld-feedback-thread-card:hover { border-color: var(--vf-accent); }
 .veld-feedback-thread-card-resolved { opacity: 0.45; cursor: pointer; }

--- a/crates/veld-daemon/frontend/src/feedback-overlay/dom.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/dom.ts
@@ -13,6 +13,7 @@ import { togglePanel, togglePanelSide, showThreadList, renderPanel, markAllRead,
 import { sendAllGood } from "./listening";
 import { captureFullScreenshot } from "./screenshot";
 import { buildSharingMenuItem } from "./sharing";
+import { savePanelState, schedulePanelSave } from "./persist";
 
 export function buildDOM(): void {
   initTooltip();
@@ -250,9 +251,9 @@ export function buildDOM(): void {
 
   const segControl = mkEl("div", "segmented");
   refs.segBtnActive = mkEl("button", "segmented-btn segmented-btn-active", "Active");
-  refs.segBtnActive.addEventListener("click", function () { dispatch({ type: "SET_PANEL_TAB", tab: "active" }); renderPanel(); });
+  refs.segBtnActive.addEventListener("click", function () { dispatch({ type: "SET_PANEL_TAB", tab: "active" }); renderPanel(); savePanelState(); });
   refs.segBtnResolved = mkEl("button", "segmented-btn", "Resolved");
-  refs.segBtnResolved.addEventListener("click", function () { dispatch({ type: "SET_PANEL_TAB", tab: "resolved" }); renderPanel(); });
+  refs.segBtnResolved.addEventListener("click", function () { dispatch({ type: "SET_PANEL_TAB", tab: "resolved" }); renderPanel(); savePanelState(); });
   segControl.appendChild(refs.segBtnActive);
   segControl.appendChild(refs.segBtnResolved);
   panelHead.appendChild(segControl);
@@ -283,6 +284,9 @@ export function buildDOM(): void {
   refs.panel.appendChild(panelHead);
 
   refs.panelBody = mkEl("div", "panel-body");
+  // Persist the panel scroll position (rAF-coalesced) so a reload restores the
+  // spot in a long thread list, not the top.
+  refs.panelBody.addEventListener("scroll", schedulePanelSave);
   refs.panel.appendChild(refs.panelBody);
 
   refs.panelResize = mkEl("div", "panel-resize");

--- a/crates/veld-daemon/frontend/src/feedback-overlay/init.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/init.ts
@@ -7,7 +7,7 @@ import { restoreFabPos, clampFabToViewport } from "./fab";
 import { onKeyDown } from "./keyboard";
 import { pollEvents, pollListenStatus, loadThreads, primeEventSeq } from "./polling";
 import { pollShareStatus } from "./sharing";
-import { togglePanel, renderPanel, openThreadInPanel, syncPanelSideClass, applyPanelLayout } from "./panel";
+import { togglePanel, renderPanel, openThreadInPanel, syncPanelSideClass, applyPanelLayout, restoreSession } from "./panel";
 import { setMode } from "./modes";
 import { toggleToolbar } from "./toolbar";
 import { togglePageComment, closeActivePopover, showCreatePopover } from "./popover";
@@ -35,6 +35,7 @@ function wireDeps(): void {
     openThreadInPanel,
     scrollToThread,
     checkPendingScroll,
+    restoreSession,
     updateBadge,
     captureScreenshot,
     showCreatePopover,

--- a/crates/veld-daemon/frontend/src/feedback-overlay/listening.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/listening.ts
@@ -4,6 +4,7 @@ import { PREFIX } from "./constants";
 import { api } from "./api";
 import { toast } from "./toast";
 import { positionRadialButtons } from "./toolbar";
+import { clearSession } from "./persist";
 
 export function updateListeningModule(): void {
   if (refs.fab) {
@@ -17,6 +18,13 @@ export function sendAllGood(): void {
   api("POST", "/session/end")
     .then(function () {
       toast("Done — feedback session ended.");
+      // The reviewer deliberately clicked Done — drop their unsent tab-local
+      // drafts/UI state so a later reload doesn't resurrect a composer from a
+      // session they finished. Deliberately NOT cleared on an agent-side
+      // session end (the session_ended / agent_stopped events in polling.ts):
+      // an agent stopping is not the reviewer abandoning their half-typed work,
+      // so that work is preserved across the agent's restart.
+      clearSession();
       dispatch({ type: "SET_LISTENING", listening: false });
       updateListeningModule();
     })

--- a/crates/veld-daemon/frontend/src/feedback-overlay/panel.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/panel.ts
@@ -8,6 +8,15 @@ import { updateBadge } from "./badge";
 import type { Thread, Message } from "./types";
 import { deps } from "../shared/registry";
 import { scheduleReposition } from "./pins";
+import { restoreComposer } from "./popover";
+import {
+  savePanelState,
+  saveReplyDraft,
+  clearReplyDraft,
+  getReplyDraft,
+  getComposerDraft,
+  getPanelState,
+} from "./persist";
 
 export function togglePanel(): void {
   dispatch({ type: "SET_PANEL_OPEN", open: !getState().panelOpen });
@@ -15,6 +24,7 @@ export function togglePanel(): void {
   refs.panel.classList.toggle(PREFIX + "panel-open", getState().panelOpen);
   applyPanelLayout();
   if (getState().panelOpen) renderPanel();
+  savePanelState();
 }
 
 export function togglePanelSide(): void {
@@ -111,11 +121,13 @@ export function initPanelResize(): void {
 export function showThreadDetail(threadId: string): void {
   dispatch({ type: "SET_EXPANDED_THREAD", threadId });
   renderPanel();
+  savePanelState();
 }
 
 export function showThreadList(): void {
   dispatch({ type: "SET_EXPANDED_THREAD", threadId: null });
   renderPanel();
+  savePanelState();
 }
 
 export function openThreadInPanel(threadId: string): void {
@@ -125,6 +137,7 @@ export function openThreadInPanel(threadId: string): void {
   refs.panel.classList.add(PREFIX + "panel-open");
   applyPanelLayout();
   renderPanel();
+  savePanelState();
 }
 
 function updateSegmentedControl(): void {
@@ -433,6 +446,12 @@ function renderThreadMessages(thread: Thread): HTMLElement {
   textarea.placeholder = "Reply...";
   textarea.rows = 2;
   textarea.dataset.threadId = thread.id;
+  // Restore any reply draft saved for this thread before a reload. (The
+  // in-memory captureDraft/restoreDraft in renderPanel handles the same box
+  // across re-renders and, running after this, keeps the cursor position.)
+  const savedReply = getReplyDraft(thread.id);
+  if (savedReply) textarea.value = savedReply;
+  textarea.addEventListener("input", function () { saveReplyDraft(thread.id, textarea.value); });
   input.appendChild(textarea);
 
   const inputActions = mkEl("div", "thread-input-actions");
@@ -443,6 +462,7 @@ function renderThreadMessages(thread: Thread): HTMLElement {
     const doResolve = function () {
       api("POST", "/threads/" + thread.id + "/resolve").then(function () {
         thread.status = "resolved";
+        clearReplyDraft(thread.id);
         dispatch({ type: "SET_THREADS", threads: [...getState().threads] });
         deps().closeActivePopover();
         showThreadList();
@@ -471,6 +491,7 @@ function renderThreadMessages(thread: Thread): HTMLElement {
       thread.messages.push(raw as Message);
       thread.updated_at = new Date().toISOString();
       textarea.value = "";
+      clearReplyDraft(thread.id);
       sendBtn.disabled = false;
       if (getState().panelOpen) renderPanel();
       deps().renderAllPins();
@@ -497,6 +518,49 @@ export function markThreadSeen(threadId: string): void {
   if (thread) deps().addPin(thread);
   updateBadge();
   updateMarkReadBtn();
+}
+
+let sessionRestored = false;
+
+/** One-shot restore of tab-local state after a reload — the open panel + tab +
+ *  scroll, the expanded thread, and the open new-comment composer. Reply drafts
+ *  restore lazily inside renderThreadMessages, so they're not handled here.
+ *
+ *  Called once when the boot loadThreads() settles (success OR failure, so a
+ *  failed first fetch can't defer restore onto a later event-driven load).
+ *  Threads, when present, let a saved expanded-thread id be validated; without
+ *  them it degrades to the list. Guarded to run at most once per overlay boot —
+ *  loadThreads is re-invoked on some events, and re-running this would re-open a
+ *  panel the user has since closed or re-summon a dismissed composer. A reload
+ *  re-executes the whole bundle, resetting the guard, which is the point.
+ *  Restore is boot-only by design: it does NOT retry to pick up a saved
+ *  expanded thread that arrives in a later, slower load. */
+export function restoreSession(): void {
+  if (sessionRestored) return;
+  sessionRestored = true;
+
+  const panel = getPanelState();
+  // NOTE: every panel field below is only meaningful while the panel is open,
+  // so all restore is gated on panel.open. A future field that matters while
+  // the panel is CLOSED (a default filter, a mute flag) must restore outside
+  // this guard.
+  if (panel.open) {
+    dispatch({ type: "SET_PANEL_OPEN", open: true });
+    dispatch({ type: "SET_PANEL_TAB", tab: panel.tab });
+    // Only re-expand a thread that still exists; else fall back to the list.
+    const canExpand = !!panel.expandedThreadId
+      && getState().threads.some(function (t: Thread) { return t.id === panel.expandedThreadId; });
+    dispatch({ type: "SET_EXPANDED_THREAD", threadId: canExpand ? panel.expandedThreadId : null });
+    refs.panel.classList.add(PREFIX + "panel-open");
+    applyPanelLayout();
+    renderPanel();
+    // Restore scroll after the body is populated. Only meaningful in list view
+    // (detail view sets overflow-y:hidden on the body).
+    if (refs.panelBody) refs.panelBody.scrollTop = panel.scrollTop;
+  }
+
+  const composer = getComposerDraft();
+  if (composer) restoreComposer(composer);
 }
 
 export function markAllRead(): void {

--- a/crates/veld-daemon/frontend/src/feedback-overlay/persist.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/persist.ts
@@ -1,0 +1,209 @@
+import { getState } from "./store";
+import { refs } from "./refs";
+
+/**
+ * Tab-scoped persistence of UNSENT overlay state across a page reload.
+ *
+ * The overlay is re-injected from scratch on every reload — dev-server HMR
+ * (browser-sync does a full reload), the agent's hot-reload after a fix, or a
+ * plain refresh — which otherwise throws away whatever the reviewer was in the
+ * middle of: a half-typed comment, which element it was attached to, the open
+ * panel + tab, the panel's scroll position, and half-typed thread replies.
+ * This module mirrors that state into sessionStorage so a reload is invisible.
+ *
+ * Scope, deliberately:
+ *  - sessionStorage, not localStorage — the state is tab-local and should die
+ *    with the tab (the same call the gateway makes for SHARE_SEEN_KEY, and the
+ *    overlay already makes for `veld-feedback-scroll-to-thread` in
+ *    navigation.ts). A run maps to its own hostname, so the browser scopes the
+ *    key per run automatically.
+ *  - keyed by the full path+query+hash — element selectors are page-relative
+ *    and a draft belongs to the exact URL it was written on. Including the
+ *    query and hash (not just the pathname) keeps hash-routed and
+ *    query-distinguished SPA "pages" (which share one pathname) from colliding
+ *    onto one key. A reload preserves path+query+hash, so this doesn't weaken
+ *    the reload case it's built for. (A live composer that survives a
+ *    client-side navigation to a different URL is prevented from writing under
+ *    the new URL's key at the save site — see popover.ts.)
+ *  - only UNSENT, in-browser state. Threads themselves are persisted
+ *    server-side (SQLite); nothing here duplicates or races that.
+ *  - the screenshot composer is deliberately NOT persisted: its draft is
+ *    anchored to a captured frame (a live MediaStream grab) that cannot be
+ *    reconstructed after the page is torn down, so restoring the text alone
+ *    would resurrect a composer with no image. Only the element/page comment
+ *    composer is restorable.
+ *
+ * Never throws: merely touching sessionStorage throws in sandboxed /
+ * cookie-blocked iframes, so every access is wrapped — a storage failure
+ * degrades to "no restore", never a broken overlay boot.
+ */
+
+const KEY_PREFIX = "veld-feedback-session:";
+
+/** The URL a draft belongs to: path + query + hash (see the module doc for
+ *  why all three). Exposed so the composer save site can detect a client-side
+ *  navigation away from the URL a draft was opened on. */
+export function pageKey(): string {
+  return window.location.pathname + window.location.search + window.location.hash;
+}
+
+function storageKey(): string {
+  return KEY_PREFIX + pageKey();
+}
+
+/** The open new-comment composer (popover), enough to rebuild + re-anchor it
+ *  after the DOM is torn down and re-created. */
+export interface ComposerDraft {
+  text: string;
+  /** true = page/global comment (no element); false = element-scoped. */
+  isPage: boolean;
+  selector: string | null;
+  tagInfo: string | null;
+  trace: string[] | null;
+  elementText: string | null;
+  sourceFile: string | null;
+  sourceLine: number | null;
+  /** Document-relative anchor rect captured at open time (see helpers.docRect).
+   *  Used as-is for page comments and as the fallback when the element can no
+   *  longer be found; re-derived from the live element when it still exists. */
+  rect: { x: number; y: number; width: number; height: number };
+}
+
+interface PersistedSession {
+  v: 1;
+  panelOpen?: boolean;
+  panelTab?: "active" | "resolved";
+  expandedThreadId?: string | null;
+  panelScrollTop?: number;
+  composer?: ComposerDraft | null;
+  /** threadId -> in-progress reply text. */
+  replies?: Record<string, string>;
+}
+
+function read(key: string = storageKey()): PersistedSession {
+  try {
+    const raw = sessionStorage.getItem(key);
+    if (raw) {
+      const parsed = JSON.parse(raw) as PersistedSession;
+      // Ignore anything not written by this schema version — a future bump can
+      // then change the shape without a stale blob crashing the restore.
+      if (parsed && parsed.v === 1) return parsed;
+    }
+  } catch (_) { /* ignore */ }
+  return { v: 1 };
+}
+
+function write(s: PersistedSession, key: string = storageKey()): void {
+  try {
+    sessionStorage.setItem(key, JSON.stringify(s));
+  } catch (_) { /* ignore */ }
+}
+
+/** Read-modify-write one field group without clobbering the rest. Defaults to
+ *  the current page's key; a specific key targets another page's blob. */
+function mutate(fn: (s: PersistedSession) => void, key: string = storageKey()): void {
+  const s = read(key);
+  fn(s);
+  write(s, key);
+}
+
+/** Snapshot the panel's open/tab/expanded/scroll — the "where was I" bits. */
+export function savePanelState(): void {
+  mutate((s) => {
+    const st = getState();
+    s.panelOpen = st.panelOpen;
+    s.panelTab = st.panelTab;
+    s.expandedThreadId = st.expandedThreadId;
+    // panelBody may not be built yet during very early boot; guard it.
+    s.panelScrollTop = refs.panelBody ? refs.panelBody.scrollTop : 0;
+  });
+}
+
+/** rAF-coalesced panel save for high-frequency events (scroll). */
+let saveScheduled = false;
+export function schedulePanelSave(): void {
+  if (saveScheduled) return;
+  saveScheduled = true;
+  requestAnimationFrame(() => {
+    saveScheduled = false;
+    savePanelState();
+  });
+}
+
+export function saveComposerDraft(draft: ComposerDraft): void {
+  mutate((s) => { s.composer = draft; });
+}
+
+/** Clear the composer draft. `originPageKey` (from `pageKey()` captured when the
+ *  composer opened) targets the page the composer belongs to — the overlay lets
+ *  a composer outlive a client-side navigation, so a dismiss must clear the
+ *  draft's origin page, not whatever page the app happens to be showing now. */
+export function clearComposerDraft(originPageKey?: string): void {
+  const key = originPageKey ? KEY_PREFIX + originPageKey : storageKey();
+  mutate((s) => { s.composer = null; }, key);
+}
+
+export function getComposerDraft(): ComposerDraft | null {
+  return read().composer ?? null;
+}
+
+export function saveReplyDraft(threadId: string, text: string): void {
+  mutate((s) => {
+    const replies = s.replies || (s.replies = {});
+    // Drop empties so cleared boxes don't linger and re-open on reload.
+    if (text) replies[threadId] = text;
+    else delete replies[threadId];
+  });
+}
+
+export function clearReplyDraft(threadId: string): void {
+  mutate((s) => { if (s.replies) delete s.replies[threadId]; });
+}
+
+/** Drop reply drafts whose thread is no longer restorable (resolved or deleted
+ *  out-of-band): those threads render no reply box, so their draft would never
+ *  otherwise be cleared until the session ends. Keeps the blob bounded. */
+export function pruneReplyDrafts(keepThreadIds: Iterable<string>): void {
+  const keep = new Set(keepThreadIds);
+  mutate((s) => {
+    if (!s.replies) return;
+    for (const id of Object.keys(s.replies)) {
+      if (!keep.has(id)) delete s.replies[id];
+    }
+  });
+}
+
+export function getReplyDraft(threadId: string): string {
+  return read().replies?.[threadId] ?? "";
+}
+
+export interface PanelSnapshot {
+  open: boolean;
+  tab: "active" | "resolved";
+  expandedThreadId: string | null;
+  scrollTop: number;
+}
+
+export function getPanelState(): PanelSnapshot {
+  const s = read();
+  return {
+    open: !!s.panelOpen,
+    tab: s.panelTab === "resolved" ? "resolved" : "active",
+    expandedThreadId: s.expandedThreadId ?? null,
+    scrollTop: typeof s.panelScrollTop === "number" ? s.panelScrollTop : 0,
+  };
+}
+
+/** Wipe the whole tab-local feedback session across every page — the reviewer
+ *  clicked Done, which ends the session globally, so no unsent state on any
+ *  page (this key or a draft left on another route) is worth restoring. */
+export function clearSession(): void {
+  try {
+    const keys: string[] = [];
+    for (let i = 0; i < sessionStorage.length; i++) {
+      const k = sessionStorage.key(i);
+      if (k && k.startsWith(KEY_PREFIX)) keys.push(k);
+    }
+    keys.forEach((k) => sessionStorage.removeItem(k));
+  } catch (_) { /* ignore */ }
+}

--- a/crates/veld-daemon/frontend/src/feedback-overlay/polling.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/polling.ts
@@ -7,6 +7,7 @@ import { api } from "./api";
 import { mkEl } from "./helpers";
 import { updateBadge } from "./badge";
 import { updateListeningModule } from "./listening";
+import { pruneReplyDrafts } from "./persist";
 import { deps } from "../shared/registry";
 
 export function pollEvents(): void {
@@ -288,10 +289,27 @@ export function sendBrowserNotification(title: string, body: string, threadId: s
 
 export function loadThreads(): void {
   api("GET", "/threads").then(function (raw) {
-    dispatch({ type: "SET_THREADS", threads: (raw as Thread[]) || [] });
+    const threads = (raw as Thread[]) || [];
+    dispatch({ type: "SET_THREADS", threads });
+    // Threads are authoritative here (fetch succeeded), so drop reply drafts
+    // orphaned by a thread resolved/deleted while the tab was away — they'd
+    // render no reply box and never otherwise clear. NOT done on fetch failure
+    // (the .catch below), where an empty list would wipe live drafts.
+    pruneReplyDrafts(threads.filter((t) => t.status === "open").map((t) => t.id));
     deps().renderAllPins();
     updateBadge();
     deps().checkPendingScroll();
     if (getState().panelOpen) deps().renderPanel();
-  }).catch(function () {});
+    // Restore tab-local state saved before a reload (open panel/tab/scroll,
+    // expanded thread, open composer). One-shot: no-ops on later loadThreads
+    // calls triggered by events.
+    deps().restoreSession();
+  }).catch(function () {
+    // Even if the initial thread fetch fails, restore once at boot so a later
+    // event-driven loadThreads can't fire the (one-shot) restore late — after
+    // the user has already started interacting with the freshly-booted overlay.
+    // Composer/panel restore don't need threads; a saved expanded thread just
+    // degrades to the list view when the thread set is empty.
+    deps().restoreSession();
+  });
 }

--- a/crates/veld-daemon/frontend/src/feedback-overlay/popover.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/popover.ts
@@ -1,11 +1,17 @@
 import { refs } from "./refs";
 import { getState, dispatch } from "./store";
-import type { Thread } from "./types";
-import { mkEl, submitOnModEnter, formatTrace } from "./helpers";
+import type { Thread, VeldPopoverElement } from "./types";
+import { mkEl, submitOnModEnter, formatTrace, docRect } from "./helpers";
 import { PREFIX, SUBMIT_HINT, ICONS } from "./constants";
 import { api } from "./api";
 import { toast } from "./toast";
 import { deps } from "../shared/registry";
+import {
+  saveComposerDraft,
+  clearComposerDraft,
+  pageKey,
+  type ComposerDraft,
+} from "./persist";
 
 export function positionPopover(
   pop: HTMLElement,
@@ -49,7 +55,13 @@ export function appendPopoverClose(pop: HTMLElement): void {
 }
 
 export function closeActivePopover(): void {
+  // The composer is going away (sent, cancelled, ×, Escape, a thread action
+  // that closes it, or replaced by a new selection) — its unsent draft must
+  // not survive into the next reload. Clear against the page the composer was
+  // opened on (`_veldPageKey`), which may differ from the current URL if the
+  // app client-navigated while the composer stayed open.
   const popover = getState().activePopover;
+  clearComposerDraft(popover?._veldPageKey);
   if (popover) {
     if (typeof popover._veldCleanup === "function") {
       popover._veldCleanup();
@@ -99,6 +111,37 @@ export function showCreatePopover(
   textarea.placeholder = "Leave feedback...";
   textarea.rows = 3;
   popoverBody.appendChild(textarea);
+
+  // Mirror the draft (text + the scope it's attached to) to tab-local storage
+  // on every keystroke so a reload can re-open this exact composer. Writes are
+  // synchronous and tiny; an empty box clears the draft rather than restoring
+  // an empty popover on the next reload.
+  //
+  // The composer survives a client-side (SPA) navigation — onNavigate doesn't
+  // close it — so pin the URL it opened on and stop persisting once the app
+  // routes elsewhere: the draft's selector/rect are relative to the open-time
+  // page and must not be written under a different URL's key (which a later
+  // reload of that URL would then mis-restore).
+  const openPageKey = pageKey();
+  (popover as VeldPopoverElement)._veldPageKey = openPageKey;
+  textarea.addEventListener("input", () => {
+    if (pageKey() !== openPageKey) return;
+    if (textarea.value.trim()) {
+      saveComposerDraft({
+        text: textarea.value,
+        isPage: !selector,
+        selector,
+        tagInfo,
+        trace,
+        elementText: extra?.elementText ?? null,
+        sourceFile: extra?.sourceFile ?? null,
+        sourceLine: extra?.sourceLine ?? null,
+        rect,
+      });
+    } else {
+      clearComposerDraft();
+    }
+  });
 
   const actions = mkEl("div", "popover-actions");
   const cancelBtn = mkEl("button", "btn btn-secondary btn-sm", "Cancel");
@@ -157,4 +200,74 @@ export function togglePageComment(): void {
     null, null, null, null,
   );
   refs.toolBtnPageComment.classList.add(PREFIX + "tool-active");
+}
+
+/** Fallback anchor: viewport-centred, current scroll — used when a restored
+ *  draft's element can't be re-found so the popover still lands somewhere
+ *  visible. */
+function fallbackRect(): { x: number; y: number; width: number; height: number } {
+  return {
+    x: window.scrollX + window.innerWidth / 2 - 180,
+    y: window.scrollY + 120,
+    width: 0,
+    height: 0,
+  };
+}
+
+/** Re-open the new-comment composer from a persisted draft after a reload.
+ *
+ *  Element-scoped drafts are re-anchored to the live element by selector (the
+ *  same lookup navigation.ts uses to scroll to a thread). If the element is
+ *  gone — removed or renamed by the edit that triggered the reload — the draft
+ *  and its original element scope are KEPT (so the thread still attaches to
+ *  that selector on send, degrading like an anchored pin whose element left),
+ *  and the popover is shown at a visible fallback position instead of the
+ *  vanished element's stale coordinates. */
+export function restoreComposer(draft: ComposerDraft): void {
+  const finiteRect = (r: { x: number; y: number; width: number; height: number }): boolean =>
+    !!r && [r.x, r.y, r.width, r.height].every((n) => typeof n === "number" && isFinite(n));
+
+  // Page/global comments aren't anchored to anything, so their saved rect is
+  // just an arbitrary point captured at open time — and its document-relative
+  // Y is stale after a reload that changed scroll or layout (exactly the HMR
+  // case), which would drop the composer off-screen. Re-centre it in the
+  // current viewport instead. Element comments re-anchor to the live element
+  // below; only when that element is gone do they fall back too.
+  let rect = draft.isPage || !finiteRect(draft.rect) ? fallbackRect() : draft.rect;
+  let targetEl: Element | null = null;
+  if (!draft.isPage && draft.selector) {
+    try { targetEl = document.querySelector(draft.selector); } catch (_) { targetEl = null; }
+    if (targetEl) {
+      rect = docRect(targetEl); // re-anchor to the element's fresh position
+    } else {
+      rect = fallbackRect();
+      toast("The element for your saved comment is gone — draft kept");
+    }
+  }
+
+  showCreatePopover(
+    rect,
+    draft.isPage ? null : draft.selector,
+    draft.tagInfo,
+    targetEl,
+    draft.trace,
+    draft.isPage
+      ? null
+      : { elementText: draft.elementText, sourceFile: draft.sourceFile, sourceLine: draft.sourceLine },
+  );
+
+  // showCreatePopover cleared the persisted draft (via closeActivePopover) and
+  // built an empty textarea; refill it and fire `input` so the listener above
+  // re-persists — keeping the text through a second reload before the user
+  // types again, and re-saving with the element's fresh anchor rect.
+  const pop = getState().activePopover;
+  const ta = pop
+    ? (pop.querySelector("textarea." + PREFIX + "textarea") as HTMLTextAreaElement | null)
+    : null;
+  if (ta) {
+    ta.value = draft.text;
+    ta.dispatchEvent(new Event("input", { bubbles: true }));
+    ta.focus();
+    try { ta.setSelectionRange(draft.text.length, draft.text.length); } catch (_) { /* ignore */ }
+  }
 }

--- a/crates/veld-daemon/frontend/src/feedback-overlay/types.ts
+++ b/crates/veld-daemon/frontend/src/feedback-overlay/types.ts
@@ -52,4 +52,8 @@ export interface FeedbackEvent {
 export interface VeldPopoverElement extends HTMLElement {
   _veldType?: string;
   _veldCleanup?: () => void;
+  /** For a new-comment composer: the pageKey() of the URL it was opened on, so
+   *  its persisted draft is cleared against the right page even after a
+   *  client-side navigation. */
+  _veldPageKey?: string;
 }

--- a/crates/veld-daemon/frontend/src/shared/registry.ts
+++ b/crates/veld-daemon/frontend/src/shared/registry.ts
@@ -16,6 +16,7 @@ export interface Deps {
   openThreadInPanel: (threadId: string) => void;
   scrollToThread: (threadId: string) => void;
   checkPendingScroll: () => void;
+  restoreSession: () => void;
   updateBadge: () => void;
   captureScreenshot: (x: number, y: number, w: number, h: number) => void;
   showCreatePopover: (rect: { x: number; y: number; width: number; height: number }, selector: string | null, tagInfo: string | null, targetEl: Element | null, trace: string[] | null, extra?: CreatePopoverExtra | null) => void;

--- a/crates/veld-daemon/frontend/tests/panel.test.ts
+++ b/crates/veld-daemon/frontend/tests/panel.test.ts
@@ -9,7 +9,9 @@ import {
   showThreadDetail,
   showThreadList,
   applyPanelLayout,
+  restoreSession,
 } from "../src/feedback-overlay/panel";
+import { savePanelState, saveComposerDraft } from "../src/feedback-overlay/persist";
 import { refs } from "../src/feedback-overlay/refs";
 import { getState, dispatch } from "../src/feedback-overlay/store";
 import { PREFIX } from "../src/feedback-overlay/constants";
@@ -235,5 +237,50 @@ describe("panel float/dock layout", () => {
     dispatch({ type: "SET_PANEL_OPEN", open: false });
     applyPanelLayout();
     expect(document.documentElement.style.marginRight).toBe("");
+  });
+});
+
+// restoreSession is guarded to run once per module load, so this file gets a
+// single effective restore test (the unguarded restoreComposer is covered in
+// popover.test.ts).
+describe("restoreSession", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    window.history.pushState({}, "", "/");
+    setupMockRefs();
+  });
+
+  it("re-opens the panel with the saved tab and the open composer after a reload", () => {
+    // Simulate pre-reload state: panel open on the Resolved tab, plus a
+    // half-typed page comment.
+    dispatch({ type: "SET_PANEL_OPEN", open: true });
+    dispatch({ type: "SET_PANEL_TAB", tab: "resolved" });
+    savePanelState();
+    saveComposerDraft({
+      text: "unsent page comment",
+      isPage: true,
+      selector: null,
+      tagInfo: null,
+      trace: null,
+      elementText: null,
+      sourceFile: null,
+      sourceLine: null,
+      rect: { x: 0, y: 0, width: 0, height: 0 },
+    });
+
+    // Reload: fresh store + refs, sessionStorage survives.
+    setupMockRefs();
+    expect(getState().panelOpen).toBe(false);
+
+    restoreSession();
+
+    expect(getState().panelOpen).toBe(true);
+    expect(getState().panelTab).toBe("resolved");
+    expect(refs.panel.classList.contains(PREFIX + "panel-open")).toBe(true);
+    // The composer was re-opened with its text.
+    const pop = getState().activePopover;
+    expect(pop).not.toBeNull();
+    const ta = pop!.querySelector("textarea." + PREFIX + "textarea") as HTMLTextAreaElement;
+    expect(ta.value).toBe("unsent page comment");
   });
 });

--- a/crates/veld-daemon/frontend/tests/persist.test.ts
+++ b/crates/veld-daemon/frontend/tests/persist.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  saveComposerDraft,
+  clearComposerDraft,
+  getComposerDraft,
+  saveReplyDraft,
+  clearReplyDraft,
+  getReplyDraft,
+  savePanelState,
+  getPanelState,
+  clearSession,
+  pruneReplyDrafts,
+  type ComposerDraft,
+} from "../src/feedback-overlay/persist";
+import { initState } from "../src/feedback-overlay/state";
+import { dispatch } from "../src/feedback-overlay/store";
+
+function makeComposer(overrides: Partial<ComposerDraft> = {}): ComposerDraft {
+  return {
+    text: "hello",
+    isPage: false,
+    selector: "div > button:nth-child(2)",
+    tagInfo: "button.btn",
+    trace: ["App", "Toolbar"],
+    elementText: "Click me",
+    sourceFile: "src/Toolbar.tsx",
+    sourceLine: 42,
+    rect: { x: 10, y: 20, width: 30, height: 40 },
+    ...overrides,
+  };
+}
+
+describe("persist", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    window.history.pushState({}, "", "/");
+    const host = document.createElement("veld-feedback");
+    const shadow = host.attachShadow({ mode: "open" });
+    initState(shadow, host);
+  });
+
+  describe("composer draft", () => {
+    it("round-trips a saved draft", () => {
+      const draft = makeComposer();
+      saveComposerDraft(draft);
+      expect(getComposerDraft()).toEqual(draft);
+    });
+
+    it("returns null when none saved", () => {
+      expect(getComposerDraft()).toBeNull();
+    });
+
+    it("clears a saved draft", () => {
+      saveComposerDraft(makeComposer());
+      clearComposerDraft();
+      expect(getComposerDraft()).toBeNull();
+    });
+  });
+
+  describe("reply drafts", () => {
+    it("round-trips per thread", () => {
+      saveReplyDraft("t-1", "reply one");
+      saveReplyDraft("t-2", "reply two");
+      expect(getReplyDraft("t-1")).toBe("reply one");
+      expect(getReplyDraft("t-2")).toBe("reply two");
+    });
+
+    it("empty text clears the entry rather than storing it", () => {
+      saveReplyDraft("t-1", "typed");
+      saveReplyDraft("t-1", "");
+      expect(getReplyDraft("t-1")).toBe("");
+    });
+
+    it("clearReplyDraft removes one without touching others", () => {
+      saveReplyDraft("t-1", "a");
+      saveReplyDraft("t-2", "b");
+      clearReplyDraft("t-1");
+      expect(getReplyDraft("t-1")).toBe("");
+      expect(getReplyDraft("t-2")).toBe("b");
+    });
+
+    it("pruneReplyDrafts keeps only the given thread ids", () => {
+      saveReplyDraft("t-live", "keep");
+      saveReplyDraft("t-gone", "drop");
+      pruneReplyDrafts(["t-live"]);
+      expect(getReplyDraft("t-live")).toBe("keep");
+      expect(getReplyDraft("t-gone")).toBe("");
+    });
+
+    it("returns empty string for an unknown thread", () => {
+      expect(getReplyDraft("nope")).toBe("");
+    });
+  });
+
+  describe("panel state", () => {
+    it("snapshots open/tab/expanded from the store", () => {
+      dispatch({ type: "SET_PANEL_OPEN", open: true });
+      dispatch({ type: "SET_PANEL_TAB", tab: "resolved" });
+      dispatch({ type: "SET_EXPANDED_THREAD", threadId: "t-9" });
+      savePanelState();
+      const p = getPanelState();
+      expect(p.open).toBe(true);
+      expect(p.tab).toBe("resolved");
+      expect(p.expandedThreadId).toBe("t-9");
+    });
+
+    it("defaults sensibly when nothing is stored", () => {
+      const p = getPanelState();
+      expect(p).toEqual({ open: false, tab: "active", expandedThreadId: null, scrollTop: 0 });
+    });
+  });
+
+  describe("scoping + lifecycle", () => {
+    it("keys drafts per pathname — a draft on one page does not leak to another", () => {
+      saveComposerDraft(makeComposer({ text: "page A draft" }));
+      window.history.pushState({}, "", "/other");
+      expect(getComposerDraft()).toBeNull();
+      window.history.pushState({}, "", "/");
+      expect(getComposerDraft()?.text).toBe("page A draft");
+    });
+
+    it("keys drafts per query string — hash/query-routed SPA pages don't collide", () => {
+      window.history.pushState({}, "", "/view?id=1");
+      saveComposerDraft(makeComposer({ text: "draft for id=1" }));
+      window.history.pushState({}, "", "/view?id=2");
+      expect(getComposerDraft()).toBeNull();
+      window.history.pushState({}, "", "/view?id=1");
+      expect(getComposerDraft()?.text).toBe("draft for id=1");
+    });
+
+    it("clearSession wipes composer + replies for the current page", () => {
+      saveComposerDraft(makeComposer());
+      saveReplyDraft("t-1", "reply");
+      clearSession();
+      expect(getComposerDraft()).toBeNull();
+      expect(getReplyDraft("t-1")).toBe("");
+    });
+
+    it("clearSession wipes drafts on OTHER pages too (Done ends the session globally)", () => {
+      saveComposerDraft(makeComposer({ text: "draft on /" }));
+      window.history.pushState({}, "", "/other");
+      saveComposerDraft(makeComposer({ text: "draft on /other" }));
+      clearSession();
+      expect(getComposerDraft()).toBeNull();
+      window.history.pushState({}, "", "/");
+      expect(getComposerDraft()).toBeNull();
+    });
+
+    it("ignores a stored blob written under a different schema version", () => {
+      sessionStorage.setItem(
+        "veld-feedback-session:/",
+        JSON.stringify({ v: 999, composer: makeComposer() }),
+      );
+      expect(getComposerDraft()).toBeNull();
+    });
+
+    it("survives a corrupt (non-JSON) blob", () => {
+      sessionStorage.setItem("veld-feedback-session:/", "{not json");
+      expect(getComposerDraft()).toBeNull();
+      expect(getPanelState().open).toBe(false);
+    });
+  });
+});

--- a/crates/veld-daemon/frontend/tests/polling.test.ts
+++ b/crates/veld-daemon/frontend/tests/polling.test.ts
@@ -5,6 +5,7 @@ import { refs } from "../src/feedback-overlay/refs";
 import { dispatch, getState } from "../src/feedback-overlay/store";
 import { PREFIX } from "../src/feedback-overlay/constants";
 import { setupMockRefs, makeThread, makeMessage } from "./test-helpers";
+import { saveReplyDraft, getReplyDraft } from "../src/feedback-overlay/persist";
 
 // Mock the api module
 vi.mock("../src/feedback-overlay/api", () => ({
@@ -65,6 +66,8 @@ describe("loadThreads", () => {
   let fakeDeps: ReturnType<typeof setupMockRefs>["deps"];
 
   beforeEach(() => {
+    sessionStorage.clear();
+    window.history.pushState({}, "", "/");
     const env = setupMockRefs();
     fakeDeps = env.deps;
     mockApi.mockReset();
@@ -99,5 +102,39 @@ describe("loadThreads", () => {
     await new Promise((r) => setTimeout(r, 10));
     // State unchanged
     expect(getState().threads).toEqual([]);
+  });
+
+  it("restores the session on success", async () => {
+    mockApi.mockResolvedValueOnce([]);
+    loadThreads();
+    await vi.waitFor(() => expect(fakeDeps.restoreSession).toHaveBeenCalled());
+  });
+
+  it("restores the session even when the fetch fails (boot restore isn't deferred)", async () => {
+    const env = setupMockRefs();
+    mockApi.mockRejectedValueOnce(new Error("down"));
+    loadThreads();
+    await vi.waitFor(() => expect(env.deps.restoreSession).toHaveBeenCalled());
+  });
+
+  it("prunes reply drafts for gone threads on a successful load, keeping live ones", async () => {
+    saveReplyDraft("t-live", "keep this");
+    saveReplyDraft("t-gone", "orphan");
+    mockApi.mockResolvedValueOnce([makeThread({ id: "t-live", status: "open" })]);
+
+    loadThreads();
+    await vi.waitFor(() => expect(getState().threads.length).toBe(1));
+    expect(getReplyDraft("t-live")).toBe("keep this");
+    expect(getReplyDraft("t-gone")).toBe("");
+  });
+
+  it("does NOT prune reply drafts when the fetch fails (no data loss)", async () => {
+    saveReplyDraft("t-1", "unsent reply");
+    mockApi.mockRejectedValueOnce(new Error("Network error"));
+
+    loadThreads();
+    await new Promise((r) => setTimeout(r, 10));
+    // The draft survives a failed boot fetch — the thread list wasn't authoritative.
+    expect(getReplyDraft("t-1")).toBe("unsent reply");
   });
 });

--- a/crates/veld-daemon/frontend/tests/popover.test.ts
+++ b/crates/veld-daemon/frontend/tests/popover.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach } from "vitest";
-import { positionPopover, closeActivePopover } from "../src/feedback-overlay/popover";
+import { positionPopover, closeActivePopover, restoreComposer } from "../src/feedback-overlay/popover";
+import { getComposerDraft, saveComposerDraft, type ComposerDraft } from "../src/feedback-overlay/persist";
+import { PREFIX } from "../src/feedback-overlay/constants";
 import { initState } from "../src/feedback-overlay/state";
 import { refs } from "../src/feedback-overlay/refs";
 import { getState, dispatch } from "../src/feedback-overlay/store";
@@ -27,6 +29,7 @@ function makeFakeDeps() {
     openThreadInPanel: vi.fn(),
     scrollToThread: vi.fn(),
     checkPendingScroll: vi.fn(),
+    restoreSession: vi.fn(),
     updateBadge: vi.fn(),
     captureScreenshot: vi.fn(),
     showCreatePopover: vi.fn(),
@@ -122,5 +125,151 @@ describe("closeActivePopover", () => {
     // Should not throw
     closeActivePopover();
     expect(getState().activePopover).toBeNull();
+  });
+
+  it("clears any persisted composer draft (dismiss must not resurrect on reload)", () => {
+    sessionStorage.clear();
+    saveComposerDraft({
+      text: "typed then cancelled",
+      isPage: true,
+      selector: null,
+      tagInfo: null,
+      trace: null,
+      elementText: null,
+      sourceFile: null,
+      sourceLine: null,
+      rect: { x: 0, y: 0, width: 0, height: 0 },
+    });
+    closeActivePopover();
+    expect(getComposerDraft()).toBeNull();
+  });
+});
+
+describe("restoreComposer", () => {
+  function draft(overrides: Partial<ComposerDraft> = {}): ComposerDraft {
+    return {
+      text: "half-typed comment",
+      isPage: false,
+      selector: "#target",
+      tagInfo: "button.btn",
+      trace: ["App", "Toolbar"],
+      elementText: "Click me",
+      sourceFile: "src/Toolbar.tsx",
+      sourceLine: 42,
+      rect: { x: 10, y: 20, width: 30, height: 40 },
+      ...overrides,
+    };
+  }
+
+  function textareaOf(): HTMLTextAreaElement | null {
+    const pop = getState().activePopover;
+    return pop ? pop.querySelector("textarea." + PREFIX + "textarea") : null;
+  }
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    window.history.pushState({}, "", "/");
+    document.body.innerHTML = "";
+    const host = document.createElement("veld-feedback");
+    const shadow = host.attachShadow({ mode: "open" });
+    initState(shadow, host);
+    refs.hoverOutline = document.createElement("div");
+    refs.componentTraceEl = document.createElement("div");
+    refs.toolBtnPageComment = document.createElement("div");
+    refs.toolBtnScreenshot = document.createElement("div");
+    registerDeps(makeFakeDeps());
+  });
+
+  it("re-anchors to the live element and refills the draft text", () => {
+    const el = document.createElement("button");
+    el.id = "target";
+    document.body.appendChild(el);
+
+    restoreComposer(draft());
+
+    const ta = textareaOf();
+    expect(ta).not.toBeNull();
+    expect(ta!.value).toBe("half-typed comment");
+    // Locked to the re-found element so the thread re-attaches to it on send.
+    expect(getState().lockedEl).toBe(el);
+    // Re-persisted (so a second reload before typing keeps the text).
+    expect(getComposerDraft()?.text).toBe("half-typed comment");
+  });
+
+  it("keeps the draft + element scope when the element is gone (graceful degrade)", () => {
+    // No #target in the DOM.
+    restoreComposer(draft());
+
+    const ta = textareaOf();
+    expect(ta).not.toBeNull();
+    expect(ta!.value).toBe("half-typed comment");
+    // No live element to lock onto, but the popover still opened with the text.
+    expect(getState().lockedEl).toBeNull();
+    // The element selector is preserved so the thread still attaches on send.
+    expect(getComposerDraft()?.selector).toBe("#target");
+  });
+
+  it("restores a page-scoped draft with no selector", () => {
+    restoreComposer(draft({ isPage: true, selector: null, tagInfo: null, trace: null, elementText: null, sourceFile: null, sourceLine: null }));
+
+    const ta = textareaOf();
+    expect(ta!.value).toBe("half-typed comment");
+    expect(getComposerDraft()?.isPage).toBe(true);
+    expect(getComposerDraft()?.selector).toBeNull();
+  });
+
+  it("re-centres a page draft in the viewport instead of using a stale off-screen rect", () => {
+    // A page comment saved while scrolled far down carries a huge document-Y.
+    restoreComposer(draft({
+      isPage: true, selector: null, tagInfo: null, trace: null,
+      elementText: null, sourceFile: null, sourceLine: null,
+      rect: { x: 0, y: 999999, width: 0, height: 0 },
+    }));
+    const pop = getState().activePopover!;
+    const top = parseFloat(pop.style.top);
+    // Must land within the current viewport, not at the stale y=999999.
+    expect(top).toBeLessThan(window.scrollY + window.innerHeight);
+  });
+
+  it("falls back safely when the saved rect is non-finite", () => {
+    restoreComposer(draft({
+      selector: null, isPage: false, // element scope but no selector → uses rect
+      rect: { x: NaN, y: NaN, width: 0, height: 0 },
+    }));
+    const pop = getState().activePopover!;
+    expect(pop.style.top).toMatch(/^-?\d+(\.\d+)?px$/); // a real pixel value, not "NaNpx"
+    expect(pop.style.top).not.toContain("NaN");
+  });
+
+  it("stops persisting once the app client-navigates away from the open-time URL", () => {
+    const el = document.createElement("button");
+    el.id = "target";
+    document.body.appendChild(el);
+    restoreComposer(draft());
+    expect(getComposerDraft()?.text).toBe("half-typed comment"); // saved under "/"
+
+    // SPA navigation to a different URL, composer still open.
+    window.history.pushState({}, "", "/other?x=1");
+    const ta = textareaOf()!;
+    ta.value = "typed on the new page";
+    ta.dispatchEvent(new Event("input", { bubbles: true }));
+
+    // Nothing written under the new URL's key — the draft belongs to "/".
+    expect(getComposerDraft()).toBeNull();
+    window.history.pushState({}, "", "/");
+    expect(getComposerDraft()?.text).toBe("half-typed comment");
+  });
+
+  it("dismissing after a client-navigation clears the draft's ORIGIN page, not the current one", () => {
+    restoreComposer(draft({ isPage: true, selector: null, tagInfo: null, trace: null, elementText: null, sourceFile: null, sourceLine: null }));
+    expect(getComposerDraft()?.text).toBe("half-typed comment"); // under "/"
+
+    // App client-navigates away, composer still open, then the user cancels.
+    window.history.pushState({}, "", "/elsewhere");
+    closeActivePopover();
+
+    // The cancelled composer's origin page ("/") must not resurrect on reload.
+    window.history.pushState({}, "", "/");
+    expect(getComposerDraft()).toBeNull();
   });
 });

--- a/crates/veld-daemon/frontend/tests/test-helpers.ts
+++ b/crates/veld-daemon/frontend/tests/test-helpers.ts
@@ -42,6 +42,7 @@ export function makeFakeDeps() {
     openThreadInPanel: vi.fn(),
     scrollToThread: vi.fn(),
     checkPendingScroll: vi.fn(),
+    restoreSession: vi.fn(),
     updateBadge: vi.fn(),
     captureScreenshot: vi.fn(),
     showCreatePopover: vi.fn(),

--- a/skills/veld/reference/feedback.md
+++ b/skills/veld/reference/feedback.md
@@ -4,6 +4,8 @@ Veld injects a feedback overlay into every page it serves. A human leaves commen
 
 The queue is **stateless from your side**: there is no cursor to track. You call `veld feedback next`, work the item it returns, then `reply` or `resolve` it. That item drops off the queue and the next call returns the following one.
 
+The overlay is robust to reloads: when your fix hot-reloads the page (or the reviewer just refreshes), the overlay restores the reviewer's in-progress state — a half-typed element or page comment and the element it's attached to, the open panel/tab and scroll position, and any unsent thread replies — from tab-local `sessionStorage`. So you can push a fix mid-review without wiping the comment the reviewer was typing. (A half-drawn *screenshot* comment is the exception: its captured frame can't survive a reload, so that composer isn't restored.) It's cleared when they submit or click Done.
+
 ## When to Run the Loop
 
 - After visual/UI changes that need human eyes

--- a/website/llms-full.txt
+++ b/website/llms-full.txt
@@ -186,6 +186,8 @@ The feedback server runs per-run and exposes:
 
 The feedback overlay automatically captures React and Vue component stack traces when available, providing agents with component-level context (not just CSS selectors) for precise modifications.
 
+The overlay survives full page reloads: when the agent's fix hot-reloads the page or the reviewer refreshes, it restores in-progress state (a half-typed element or page comment and the element it targets, the open panel/tab and scroll position, and unsent replies) from tab-local session storage — so an agent can push a fix mid-review without discarding the comment the reviewer was writing. (A screenshot comment in progress is not restored — its captured frame can't be reconstructed after a reload.)
+
 This makes veld uniquely suited for agentic workflows where AI agents build UI and humans provide iterative feedback without context-switching.
 
 ---


### PR DESCRIPTION
## What & why

The feedback overlay was re-injected from scratch on every page reload — dev-server HMR (browser-sync full reload), the agent's hot-reload after a fix, or a plain refresh — and threw away whatever the reviewer was mid-flow on: a half-typed comment and the element it was attached to, the open panel/tab, scroll position, and unsent thread replies. That broke the human-in-the-loop review exactly when it was most active (comment → agent fixes → page reloads → your half-typed next comment is gone).

This makes a reload transparent to the reviewer by mirroring their **unsent, in-browser** state into tab-local `sessionStorage` and restoring it on boot.

## Root cause

The overlay is a compiled TS bundle re-executed on every load. Draft text lives only in DOM `<textarea>`s, the element scope only in the composer's closure, and panel open/tab/scroll only in the in-memory store — nothing was persisted, so a reload started from zero. (Not a dev-server choice: reproduces with any dev server and a plain refresh. Out of scope: keeping browser-sync as the website dev server.)

## What's persisted (and cleared)

New module `persist.ts` — tab-local `sessionStorage`, keyed by **path + query + hash** (a run maps to its own hostname, so the browser scopes it per run; including query+hash keeps hash-/query-routed SPA "pages" from colliding). Never throws (every access wrapped — sandboxed iframes throw on mere access).

- **Open new-comment composer** — text + the element scope (selector / element text / component trace / source location). Restored by re-anchoring to the live element via `document.querySelector`; if the element is gone after the edit, the draft **and its scope are kept** and the composer opens at a visible fallback with a toast (graceful degrade). Page/global comments re-centre in the viewport (their saved doc-rect goes stale across an HMR layout shift).
- **Panel** open/closed + active tab + scroll position + expanded thread (one-shot restore at boot).
- **Unsent thread replies** (per thread).
- **Cleared** on submit / cancel / Done. Reply drafts are pruned against the live open-thread set on each authoritative thread load. Deliberately **not** cleared on an agent-side session end (`session_ended`/`agent_stopped`) — an agent restarting isn't the reviewer abandoning their work.
- **Screenshot composer is intentionally not persisted** — its draft is anchored to a captured frame (a live `MediaStream` grab) that can't be reconstructed after a reload.

Follows the existing tab-scoped `sessionStorage` precedents: the gateway's `SHARE_SEEN_KEY` and the overlay's own `veld-feedback-scroll-to-thread`.

## Also in this PR — Resolved-threads list collapse

The Resolved tab rendered its cards squished/clipped on top of each other instead of scrolling. Root cause: `.thread-card` carries `overflow:hidden` (for text ellipsis), which zeroes a flex item's automatic min-size, so in the `flex-direction:column` `panel-body` a long list shrank every card below its text height. Fix: `flex-shrink:0` on `.thread-card` and `.panel-section`.

## Test evidence

- Frontend: `npm run typecheck` clean; `npx vitest run` → **260 pass / 0 fail** (16 new across `persist.test.ts`, `popover.test.ts`, `panel.test.ts`, `polling.test.ts`, covering round-trip, per-page/-query scoping, corrupt/version-mismatch blobs, element re-anchor + element-gone degrade, page-rect re-centre, non-finite rect, SPA-nav write guard + dismiss-clears-origin, one-shot restore, prune-on-success + no-prune-on-failure, global clear).
- `cargo build -p veld-daemon` (exercises the esbuild build.rs), `cargo clippy -p veld-daemon --all-targets` clean, `cargo fmt --all` no-op.

## Review

Ran the multi-angle adversarial review (`docs/agentic-review.md`): round 1 = 5 angles, round 2 = 3 angles on the post-fix diff, round 3 = 2 focused verifiers. Fixed everything real, most notably two majors caught in round 2:
- **Reply-draft data loss on a failed boot fetch** — `pruneReplyDrafts` moved out of `restoreSession` (which also runs on the fetch-failure path with an empty thread list) into the success path only.
- **Dismiss-after-navigation resurrection** — a composer that outlives a client-side navigation now clears its *origin* page key, matching the page-pinned write guard.

Also: `clearSession` now wipes drafts on all pages (Done ends the session globally); restore runs once at boot even if the first fetch fails.

## Docs

User-visible overlay behaviour, no new config/CLI/schema surface (those checklist rows are N/A). Updated the agent-facing feedback reference (`skills/veld/reference/feedback.md`) and `website/llms-full.txt` with the reload-survival note (scoped to element/page comments; screenshot exception called out).

## Notes for reviewer

- `Cargo.lock` shows the workspace crates going `10.1.2 → 10.4.0` — a stale lockfile on `main` catching up to the released tag when I built; not related to this change but harmless to carry.

### Known follow-up (non-blocking)

Reply drafts are keyed under the current page, but threads are cross-page (a thread can be opened from any page). The reload-same-page case — the target — restores correctly. The narrow gap: type a reply, SPA-navigate to a different page (no reload), then reload *that* page — the reply draft (stored under the first page's key) won't restore. In-memory it's preserved across the SPA nav; only a reload of the other page misses it. Could be closed later by keying reply drafts tab-globally rather than per-page; left out here to avoid a second storage scheme.
