### PR TITLE
fix(gateway): IPv4-only bind option to silence iroh NetworkUnreachable warns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4302,7 +4302,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "veld"
-version = "10.1.2"
+version = "10.4.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4322,7 +4322,7 @@ dependencies = [
 
 [[package]]
 name = "veld-core"
-version = "10.1.2"
+version = "10.4.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "veld-daemon"
-version = "10.1.2"
+version = "10.4.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4369,7 +4369,7 @@ dependencies = [
 
 [[package]]
 name = "veld-gateway"
-version = "10.1.2"
+version = "10.4.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4400,7 +4400,7 @@ dependencies = [
 
 [[package]]
 name = "veld-helper"
-version = "10.1.2"
+version = "10.4.0"
 dependencies = [
  "anyhow",
  "nix",
@@ -4416,7 +4416,7 @@ dependencies = [
 
 [[package]]
 name = "veld-share"
-version = "10.1.2"
+version = "10.4.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/crates/veld-daemon/src/share/manager.rs
+++ b/crates/veld-daemon/src/share/manager.rs
@@ -217,7 +217,17 @@ impl ShareManager {
         if let Some(ep) = endpoints.get(requested) {
             return Ok(ep.clone());
         }
-        let ep = bind_endpoint(self.key_for(requested), requested).await?;
+        // Daemon endpoints are short-lived, per-session client endpoints, not a
+        // long-running edge service, so the recurring IPv6 re-probe noise the
+        // gateway's knob addresses isn't worth a daemon-side config surface;
+        // keep iroh's native dual-stack bind. (A v4-only user network still just
+        // fails the v6 probe as iroh natively tolerates.)
+        let ep = bind_endpoint(
+            self.key_for(requested),
+            requested,
+            veld_share::endpoint::IpFamilies::default(),
+        )
+        .await?;
         info!(node_id = %ep.id(), relays = %requested, "iroh share endpoint bound");
         self.clone()
             .spawn_accept_loop(ep.clone(), requested.clone());

--- a/crates/veld-gateway/src/auth.rs
+++ b/crates/veld-gateway/src/auth.rs
@@ -776,6 +776,7 @@ mod tests {
                 max_registrations: 8,
                 trust_forwarded_headers: trust_forwarded,
                 trust_forwarded_host: trust_forwarded,
+                ip_families: veld_share::endpoint::IpFamilies::default(),
             }),
             registry: Registry::new(
                 "share.example".into(),
@@ -783,6 +784,7 @@ mod tests {
                 RelayAllowList::Unconfined,
                 iroh::SecretKey::generate(),
                 8,
+                veld_share::endpoint::IpFamilies::default(),
             ),
             auth_token: "t".into(),
             limiter: std::sync::Arc::new(RateLimiter::default()),

--- a/crates/veld-gateway/src/config.rs
+++ b/crates/veld-gateway/src/config.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 use anyhow::{Context, Result, bail};
 use serde::Deserialize;
 use veld_core::config::{RelayEntry, RelayPolicy, SecretSource};
+use veld_share::endpoint::IpFamilies;
 
 /// How long a registration lives without a heartbeat before the gateway drops
 /// it. Origins re-`POST` (heartbeat) well inside this window.
@@ -75,6 +76,12 @@ pub struct GatewayConfig {
     /// inbound `X-Forwarded-Host` — an edge that merely passes it through
     /// lets a viewer inject the value that origin apps then see.
     pub trust_forwarded_host: bool,
+    /// Which IP families the gateway's iroh (QUIC/UDP) endpoints bind. Both
+    /// default **on** (iroh's native dual-stack, IPv6 allowed to fail). Set
+    /// `VELD_GATEWAY_BIND_IPV6=false` on a host with no IPv6 egress route
+    /// (e.g. Qovery) to stop iroh re-probing unreachable IPv6 peer candidates
+    /// and logging a `NetworkUnreachable` WARN every ~60s.
+    pub ip_families: IpFamilies,
 }
 
 /// Paths to a TLS certificate chain and private key (PEM).
@@ -104,6 +111,10 @@ struct FileConfig {
     trust_forwarded_headers: Option<bool>,
     #[serde(rename = "trust_forwarded_host")]
     trust_forwarded_host: Option<bool>,
+    #[serde(rename = "bind_ipv4")]
+    bind_ipv4: Option<bool>,
+    #[serde(rename = "bind_ipv6")]
+    bind_ipv6: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -243,6 +254,25 @@ impl GatewayConfig {
             None => file.trust_forwarded_host.unwrap_or(false),
         };
 
+        let bind_v4 = match get("VELD_GATEWAY_BIND_IPV4") {
+            Some(raw) => parse_bool("VELD_GATEWAY_BIND_IPV4", raw)?,
+            None => file.bind_ipv4.unwrap_or(true),
+        };
+        let bind_v6 = match get("VELD_GATEWAY_BIND_IPV6") {
+            Some(raw) => parse_bool("VELD_GATEWAY_BIND_IPV6", raw)?,
+            None => file.bind_ipv6.unwrap_or(true),
+        };
+        if !bind_v4 && !bind_v6 {
+            bail!(
+                "VELD_GATEWAY_BIND_IPV4 and VELD_GATEWAY_BIND_IPV6 cannot both be false; \
+                 the gateway needs at least one IP family to reach peers over a direct path"
+            );
+        }
+        let ip_families = IpFamilies {
+            v4: bind_v4,
+            v6: bind_v6,
+        };
+
         Ok(Self {
             domain,
             listen,
@@ -254,6 +284,7 @@ impl GatewayConfig {
             max_registrations,
             trust_forwarded_headers,
             trust_forwarded_host,
+            ip_families,
         })
     }
 }
@@ -394,6 +425,49 @@ mod tests {
         let mut huge = base.to_vec();
         huge.push(("VELD_GATEWAY_MAX_REGISTRATIONS", "99999999999"));
         assert!(GatewayConfig::from_parts(FileConfig::default(), &env(&huge)).is_err());
+    }
+
+    #[test]
+    fn ip_families_default_env_and_both_disabled_guard() {
+        let base = [
+            ("VELD_GATEWAY_DOMAIN", "share.acme.internal"),
+            ("VELD_GATEWAY_TOKEN", "t"),
+        ];
+        // Default is dual-stack (unchanged behaviour).
+        let cfg = GatewayConfig::from_parts(FileConfig::default(), &env(&base)).unwrap();
+        assert_eq!(cfg.ip_families, IpFamilies::default());
+        assert!(cfg.ip_families.v4 && cfg.ip_families.v6);
+
+        // Disabling IPv6 (the Qovery no-v6-egress case) keeps IPv4 only.
+        let mut v4_only = base.to_vec();
+        v4_only.push(("VELD_GATEWAY_BIND_IPV6", "false"));
+        let cfg = GatewayConfig::from_parts(FileConfig::default(), &env(&v4_only)).unwrap();
+        assert_eq!(
+            cfg.ip_families,
+            IpFamilies {
+                v4: true,
+                v6: false
+            }
+        );
+
+        // Env wins over a file value.
+        let file = FileConfig {
+            bind_ipv6: Some(true),
+            ..FileConfig::default()
+        };
+        let cfg = GatewayConfig::from_parts(file, &env(&v4_only)).unwrap();
+        assert!(!cfg.ip_families.v6);
+
+        // Both families off is refused — the endpoint needs at least one.
+        let mut none = base.to_vec();
+        none.push(("VELD_GATEWAY_BIND_IPV4", "false"));
+        none.push(("VELD_GATEWAY_BIND_IPV6", "false"));
+        assert!(GatewayConfig::from_parts(FileConfig::default(), &env(&none)).is_err());
+
+        // A garbage boolean is rejected.
+        let mut bad = base.to_vec();
+        bad.push(("VELD_GATEWAY_BIND_IPV4", "maybe"));
+        assert!(GatewayConfig::from_parts(FileConfig::default(), &env(&bad)).is_err());
     }
 
     #[test]

--- a/crates/veld-gateway/src/registry.rs
+++ b/crates/veld-gateway/src/registry.rs
@@ -21,7 +21,7 @@ use tracing::{info, warn};
 use veld_core::config::{RelayPolicy, WebAccessMode};
 use veld_core::share::{Capability, GatewayAccessPolicy, ShareTicket};
 use veld_share::endpoint::{
-    RelayAuth, RelayChoice, bind_endpoint, relay_auth_status, resolve_secret,
+    IpFamilies, RelayAuth, RelayChoice, bind_endpoint, relay_auth_status, resolve_secret,
 };
 use veld_share::join;
 
@@ -177,6 +177,10 @@ pub struct Registry {
     lease: Duration,
     relays: RelayAllowList,
     secret_key: SecretKey,
+    /// Which IP families the gateway's iroh endpoints bind. Restricting to IPv4
+    /// on a host with no IPv6 egress route silences iroh's recurring
+    /// `NetworkUnreachable` re-probe warnings (see [`IpFamilies`]).
+    ip_families: IpFamilies,
     /// Hard bound on registrations, covering both settled and in-flight
     /// attempts: a permit is taken before dialing and held until the
     /// registration is removed. Closes the leaked-token exhaustion vector
@@ -211,12 +215,14 @@ impl Registry {
         relays: RelayAllowList,
         secret_key: SecretKey,
         max_registrations: usize,
+        ip_families: IpFamilies,
     ) -> Arc<Self> {
         Arc::new(Self {
             domain,
             lease,
             relays,
             secret_key,
+            ip_families,
             slots: Arc::new(tokio::sync::Semaphore::new(max_registrations)),
             max_registrations,
             endpoints: Mutex::new(HashMap::new()),
@@ -640,8 +646,13 @@ impl Registry {
             RelayChoice::Public => self.secret_key.clone(),
             RelayChoice::Custom(_) => SecretKey::generate(),
         };
-        let ep = bind_endpoint(key, requested).await?;
-        info!(node_id = %ep.id(), relays = %requested, "gateway iroh endpoint bound");
+        let ep = bind_endpoint(key, requested, self.ip_families).await?;
+        info!(
+            node_id = %ep.id(),
+            relays = %requested,
+            ip_families = ?self.ip_families,
+            "gateway iroh endpoint bound"
+        );
         endpoints.insert(requested.clone(), (ep.clone(), 1));
         Ok(ep)
     }
@@ -742,6 +753,7 @@ mod tests {
             relays,
             SecretKey::generate(),
             512,
+            IpFamilies::default(),
         );
 
         let listed: RelayUrl = "https://relay.acme.internal".parse().unwrap();
@@ -776,6 +788,7 @@ mod tests {
             RelayAllowList::Unconfined,
             SecretKey::generate(),
             1,
+            IpFamilies::default(),
         );
         // Hold the only slot, as a live registration would.
         let held = Arc::clone(&reg.slots).try_acquire_owned().unwrap();
@@ -839,6 +852,7 @@ mod tests {
             RelayAllowList::Unconfined,
             SecretKey::generate(),
             8,
+            IpFamilies::default(),
         );
         let ticket = ShareTicket {
             iroh_ticket: "does-not-matter".into(),

--- a/crates/veld-gateway/src/server.rs
+++ b/crates/veld-gateway/src/server.rs
@@ -46,6 +46,7 @@ pub async fn run(config: GatewayConfig) -> Result<()> {
         relays,
         secret_key,
         config.max_registrations,
+        config.ip_families,
     );
     tokio::spawn(Arc::clone(&registry).sweep_expired_leases());
 
@@ -270,6 +271,7 @@ mod tests {
                 max_registrations: 8,
                 trust_forwarded_headers: false,
                 trust_forwarded_host: false,
+                ip_families: veld_share::endpoint::IpFamilies::default(),
             }),
             registry: Registry::new(
                 "share.example".into(),
@@ -277,6 +279,7 @@ mod tests {
                 crate::registry::RelayAllowList::Unconfined,
                 iroh::SecretKey::generate(),
                 8,
+                veld_share::endpoint::IpFamilies::default(),
             ),
             auth_token: "t".into(),
             limiter: Arc::new(crate::auth::RateLimiter::default()),

--- a/crates/veld-gateway/tests/loopback.rs
+++ b/crates/veld-gateway/tests/loopback.rs
@@ -166,9 +166,13 @@ async fn gateway_proxies_through_daemon_host_half() {
         manifest,
     });
 
-    let host_ep = bind_endpoint(SecretKey::generate(), &RelayChoice::Public)
-        .await
-        .unwrap();
+    let host_ep = bind_endpoint(
+        SecretKey::generate(),
+        &RelayChoice::Public,
+        veld_share::endpoint::IpFamilies::default(),
+    )
+    .await
+    .unwrap();
     host_ep.online().await;
     let ticket = ShareTicket {
         iroh_ticket: iroh_tickets::endpoint::EndpointTicket::new(host_ep.addr()).to_string(),
@@ -203,6 +207,7 @@ async fn gateway_proxies_through_daemon_host_half() {
         veld_gateway::registry::RelayAllowList::Unconfined,
         SecretKey::generate(),
         512,
+        veld_share::endpoint::IpFamilies::default(),
     );
     // Register with a §6.1 access policy: the node is password-protected.
     let mut access_nodes = std::collections::BTreeMap::new();
@@ -301,9 +306,13 @@ async fn gateway_splices_websocket_upgrade_end_to_end() {
         manifest,
     });
 
-    let host_ep = bind_endpoint(SecretKey::generate(), &RelayChoice::Public)
-        .await
-        .unwrap();
+    let host_ep = bind_endpoint(
+        SecretKey::generate(),
+        &RelayChoice::Public,
+        veld_share::endpoint::IpFamilies::default(),
+    )
+    .await
+    .unwrap();
     host_ep.online().await;
     let ticket = ShareTicket {
         iroh_ticket: iroh_tickets::endpoint::EndpointTicket::new(host_ep.addr()).to_string(),
@@ -319,6 +328,7 @@ async fn gateway_splices_websocket_upgrade_end_to_end() {
         veld_gateway::registry::RelayAllowList::Unconfined,
         SecretKey::generate(),
         512,
+        veld_share::endpoint::IpFamilies::default(),
     );
     // Link access: the slug itself is the credential — no password gate in
     // the way of the upgrade request.
@@ -345,6 +355,7 @@ async fn gateway_splices_websocket_upgrade_end_to_end() {
         max_registrations: 512,
         trust_forwarded_headers: false,
         trust_forwarded_host: false,
+        ip_families: veld_share::endpoint::IpFamilies::default(),
     };
     let state = veld_gateway::state::AppState {
         config: Arc::new(config),

--- a/crates/veld-share/src/endpoint.rs
+++ b/crates/veld-share/src/endpoint.rs
@@ -10,13 +10,48 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
-use iroh::endpoint::presets;
+use iroh::endpoint::{BindOpts, presets};
 use iroh::{Endpoint, RelayConfig, RelayMap, RelayMode, RelayUrl, SecretKey};
 use tracing::warn;
 use veld_core::config::{RelayEntry, RelayPolicy, SecretSource};
 
 /// ALPN protocol identifier for veld's share tunnels.
 pub const ALPN: &[u8] = b"veld/share/1";
+
+/// Which IP address families the endpoint's **direct** (QUIC/UDP) sockets bind.
+///
+/// Relay transports are always kept; this only gates the direct IP sockets.
+/// The default binds both, matching iroh's native `.bind()` — where the IPv6
+/// socket is allowed to fail, so a host without IPv6 still comes up.
+///
+/// Restricting to a single family matters on a host that has no *egress route*
+/// for the other family. iroh still opens the socket there (the bind succeeds
+/// on the unspecified address) and then, whenever a peer advertises a candidate
+/// in that family, re-probes it on a timer — each attempt logging a `noq_udp:
+/// sendmsg error: ... NetworkUnreachable` WARN. A cloud gateway with no IPv6
+/// route is the canonical case: dropping the v6 socket removes the wasted
+/// probes and the recurring warning outright.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IpFamilies {
+    /// Bind an IPv4 (`0.0.0.0`) direct socket.
+    pub v4: bool,
+    /// Bind an IPv6 (`[::]`) direct socket.
+    pub v6: bool,
+}
+
+impl Default for IpFamilies {
+    fn default() -> Self {
+        Self { v4: true, v6: true }
+    }
+}
+
+impl IpFamilies {
+    /// Both families enabled — iroh's native default bind, which we leave
+    /// untouched so its "IPv6 bind may fail" leniency is preserved.
+    fn is_dual(self) -> bool {
+        self.v4 && self.v6
+    }
+}
 
 /// Env var to point the endpoint at a self-hosted relay instead of n0's public
 /// relays (e.g. `VELD_SHARE_RELAY=https://relay.example.com`). Only consulted
@@ -379,10 +414,46 @@ fn restrict_permissions(_path: &Path) {}
 /// `Debug` prints `auth_token` in the clear. Veld's own types redact it (see
 /// `SecretSource`'s `Debug`) and never log the built `RelayConfig`/`RelayMap` —
 /// keep it that way (no `debug!(?config)` on these).
-pub async fn bind_endpoint(secret_key: SecretKey, choice: &RelayChoice) -> Result<Endpoint> {
+pub async fn bind_endpoint(
+    secret_key: SecretKey,
+    choice: &RelayChoice,
+    families: IpFamilies,
+) -> Result<Endpoint> {
     let mut builder = Endpoint::builder(presets::N0)
         .secret_key(secret_key)
         .alpns(vec![ALPN.to_vec()]);
+
+    // Only touch the default IP transports when restricting to one family; the
+    // dual default keeps iroh's native `.bind()` (v6 allowed to fail). Both
+    // disabled would leave a relay-only endpoint with no direct path at all,
+    // which is never intended — refuse it with a clear message. This is a
+    // generic veld-share API (the daemon calls it too), so the message names
+    // the type, not the gateway's env vars.
+    if !families.is_dual() {
+        if !families.v4 && !families.v6 {
+            bail!(
+                "iroh endpoint needs at least one IP family; enable at least one of \
+                 IpFamilies::v4 / IpFamilies::v6"
+            );
+        }
+        builder = builder.clear_ip_transports();
+        if families.v4 {
+            // IPv4 is the primary family — required, matching iroh's native v4
+            // transport (a failed v4 bind is a real error worth surfacing).
+            builder = builder
+                .bind_addr("0.0.0.0:0")
+                .map_err(|e| anyhow::anyhow!("configuring IPv4 socket for iroh endpoint: {e}"))?;
+        }
+        if families.v6 {
+            // Mirror iroh's native leniency: its default v6 transport is
+            // `is_required=false` ("bind allowed to fail"). Keep that here so a
+            // v6-only request on a host with the v6 stack disabled degrades to
+            // relay rather than hard-aborting endpoint creation.
+            builder = builder
+                .bind_addr_with_opts("[::]:0", BindOpts::default().set_is_required(false))
+                .map_err(|e| anyhow::anyhow!("configuring IPv6 socket for iroh endpoint: {e}"))?;
+        }
+    }
 
     if let RelayChoice::Custom(entries) = choice {
         let mut configs: Vec<RelayConfig> = Vec::new();
@@ -414,7 +485,23 @@ pub async fn bind_endpoint(secret_key: SecretKey, choice: &RelayChoice) -> Resul
         builder = builder.relay_mode(RelayMode::Custom(RelayMap::from_iter(configs)));
     }
 
-    builder.bind().await.context("binding iroh endpoint")
+    let endpoint = builder.bind().await.context("binding iroh endpoint")?;
+
+    // A restricted single family whose bind was lenient (v6, is_required=false)
+    // can leave the endpoint with no direct socket on a host lacking that stack
+    // — a relay-only endpoint. That's a valid degrade, but it's almost always an
+    // operator misconfig (e.g. IPv6-only on a v4-only host), so surface it rather
+    // than let it be silent. The gateway's v4-only case never hits this: v4 is
+    // required, so `bind()` only returns once a v4 socket exists.
+    if !families.is_dual() && endpoint.bound_sockets().is_empty() {
+        warn!(
+            ?families,
+            "iroh endpoint bound with no direct IP socket (relay-only); the requested \
+             IP family failed to bind — check the host's network stack"
+        );
+    }
+
+    Ok(endpoint)
 }
 
 /// Resolve the relay auth tokens to embed in a share ticket — one per relay the
@@ -1085,7 +1172,7 @@ mod tests {
                 sentinel.display()
             ))),
         }]);
-        let err = bind_endpoint(SecretKey::generate(), &choice)
+        let err = bind_endpoint(SecretKey::generate(), &choice, IpFamilies::default())
             .await
             .unwrap_err();
         assert!(err.to_string().contains("no valid relay URLs"));
@@ -1093,6 +1180,71 @@ mod tests {
             !sentinel.exists(),
             "token command ran for an unparseable relay URL"
         );
+    }
+
+    #[tokio::test]
+    async fn bind_endpoint_v4_only_binds_no_ipv6_socket() {
+        // The load-bearing branch of this change: a v4-only endpoint must open a
+        // direct socket and it must be IPv4 (dropping the v6 socket is what
+        // stops the NetworkUnreachable re-probe). Binding to `0.0.0.0:0` is a
+        // local socket op — no relay/network needed for `.bind()` to return.
+        let ep = bind_endpoint(
+            SecretKey::generate(),
+            &RelayChoice::Public,
+            IpFamilies {
+                v4: true,
+                v6: false,
+            },
+        )
+        .await
+        .unwrap();
+        let socks = ep.bound_sockets();
+        assert!(!socks.is_empty(), "v4-only endpoint bound no direct socket");
+        assert!(
+            socks.iter().all(|s| s.is_ipv4()),
+            "v4-only endpoint bound a non-IPv4 socket: {socks:?}"
+        );
+        ep.close().await;
+    }
+
+    #[tokio::test]
+    async fn bind_endpoint_v6_only_binds_no_ipv4_socket() {
+        // Symmetric guard: v6-only must never open a v4 direct socket. The v6
+        // bind is lenient (`is_required=false`), so on a host with no IPv6 stack
+        // `bound_sockets` is empty — which still satisfies "no IPv4 socket".
+        let ep = bind_endpoint(
+            SecretKey::generate(),
+            &RelayChoice::Public,
+            IpFamilies {
+                v4: false,
+                v6: true,
+            },
+        )
+        .await
+        .unwrap();
+        assert!(
+            ep.bound_sockets().iter().all(|s| s.is_ipv6()),
+            "v6-only endpoint bound an IPv4 socket: {:?}",
+            ep.bound_sockets()
+        );
+        ep.close().await;
+    }
+
+    #[tokio::test]
+    async fn bind_endpoint_refuses_no_ip_families() {
+        // Both families disabled is rejected before any socket bind or network
+        // I/O — a relay-only endpoint with no direct path is never intended.
+        let err = bind_endpoint(
+            SecretKey::generate(),
+            &RelayChoice::Public,
+            IpFamilies {
+                v4: false,
+                v6: false,
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("at least one IP family"));
     }
 
     #[tokio::test]

--- a/crates/veld-share/src/lib.rs
+++ b/crates/veld-share/src/lib.rs
@@ -66,12 +66,20 @@ mod tests {
             }
         });
 
-        let host_ep = bind_endpoint(SecretKey::generate(), &RelayChoice::Public)
-            .await
-            .unwrap();
-        let client_ep = bind_endpoint(SecretKey::generate(), &RelayChoice::Public)
-            .await
-            .unwrap();
+        let host_ep = bind_endpoint(
+            SecretKey::generate(),
+            &RelayChoice::Public,
+            crate::endpoint::IpFamilies::default(),
+        )
+        .await
+        .unwrap();
+        let client_ep = bind_endpoint(
+            SecretKey::generate(),
+            &RelayChoice::Public,
+            crate::endpoint::IpFamilies::default(),
+        )
+        .await
+        .unwrap();
         host_ep.online().await;
         let host_addr = host_ep.addr();
 

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -112,6 +112,8 @@ Env-var-first; a config file is optional (`--config /path` or
 | `VELD_GATEWAY_MAX_REGISTRATIONS` | `max_registrations` | `512` | Hard cap on concurrently live + in-flight shares; bounds a leaked token's blast radius. Raise for a large fleet — share #N+1 is refused with a clear error |
 | `VELD_GATEWAY_TRUST_FORWARDED` | `trust_forwarded_headers` | `false` | Trust the immediate upstream LB's `X-Forwarded-For`: its last entry becomes the client IP (password rate-limit keying) and the chain is forwarded upstream. **Enable this when the gateway sits behind a TLS-terminating LB** — otherwise every viewer shares the LB's IP and a few wrong passwords rate-limit everyone. Leave off when the gateway is the direct internet edge (an inbound chain would be viewer-spoofable). Deliberately does not affect `X-Forwarded-Host` |
 | `VELD_GATEWAY_TRUST_FORWARDED_HOST` | `trust_forwarded_host` | `false` | Trust `X-Forwarded-Host` (first entry) as the host the viewer addressed: it overrides `Host` for slug routing, the upstream `X-Forwarded-Host`, and Referer rewriting. Required behind a CDN that rewrites `Host` to its origin (see [Behind a CDN](#behind-a-cdn-cloudfront)). Enable ONLY behind an edge that **overwrites or strips** inbound `X-Forwarded-Host` — an edge that passes it through lets viewers inject the host your apps see |
+| `VELD_GATEWAY_BIND_IPV4` | `bind_ipv4` | `true` | Bind an IPv4 direct (QUIC/UDP) socket for iroh. Leave on. |
+| `VELD_GATEWAY_BIND_IPV6` | `bind_ipv6` | `true` | Bind an IPv6 direct socket for iroh. **Set to `false` on a host with no IPv6 egress route** (e.g. Qovery). Otherwise iroh re-probes each peer's IPv6 candidate on a timer and logs a `noq_udp: sendmsg error … NetworkUnreachable` WARN every ~60s. Sharing already works over IPv4 + relay; this only removes the dead probes and the log noise. At least one family must stay enabled |
 
 File form (all fields optional, `SecretSource` accepted for secrets):
 
@@ -125,7 +127,9 @@ File form (all fields optional, `SecretSource` accepted for secrets):
   "lease_secs": 90,
   "max_registrations": 512,
   "trust_forwarded_headers": false,
-  "trust_forwarded_host": false
+  "trust_forwarded_host": false,
+  "bind_ipv4": true,
+  "bind_ipv6": false
 }
 ```
 


### PR DESCRIPTION
## What

Adds operator control over which IP address families the gateway's iroh
(QUIC/UDP) endpoints bind: `VELD_GATEWAY_BIND_IPV4` / `VELD_GATEWAY_BIND_IPV6`
(file keys `bind_ipv4` / `bind_ipv6`), **both default `true`** — unchanged
dual-stack behaviour. Setting `VELD_GATEWAY_BIND_IPV6=false` on a host with no
IPv6 egress route (e.g. Qovery) drops the v6 direct socket so iroh never
attempts the dead path.

## Why / root cause

The deployed gateway logged a recurring warning roughly every 60s:

```
WARN connect{... alpn=veld/share/1 ...}:poll_send{network_path=Ip { remote: [2a01:...]:52161, local: None }}: noq_udp: sendmsg error: Os { code: 101, kind: NetworkUnreachable }
```

iroh binds a **dual-stack** endpoint, learns a peer's **IPv6** direct
candidate, and re-probes that path on a timer. The Qovery container has **no
IPv6 egress route**, so every `sendmsg` to the v6 candidate fails with
`errno 101`. Sharing itself was unaffected (IPv4 + relay carry the tunnel) — it
was pure log noise plus wasted probes.

The ~60s cadence is **iroh's path re-probe timer**, *not* Qovery's
`network.gateway_api.tcp_keepalive_interval_seconds=60` (that governs the L4/L7
TCP proxy in front of the gateway, a separate transport from iroh's UDP). The
match was coincidental.

## How

- New `IpFamilies { v4, v6 }` in `veld-share` threaded through `bind_endpoint`.
  Default (both true) leaves iroh's native `.bind()` untouched. A restricted
  family calls `clear_ip_transports()` + `bind_addr` for the kept family only
  (the only correct way in iroh 1.0.1 — there's no API to drop one default
  socket selectively).
- v4 binds required (matches iroh's native v4); v6 binds with
  `is_required=false` (mirrors iroh's native v6 leniency, so a v6-only request
  on a v6-less host degrades to relay rather than hard-failing). A restricted
  bind that ends up relay-only logs a `warn!`.
- Gateway config parses the two env/file keys (both default true; both-false is
  refused). Daemon keeps native dual-stack (short-lived per-session endpoints,
  no operator knob).
- Gateway "endpoint bound" log now reports `ip_families` so an operator can
  confirm the setting took effect.

## To fix the live gateway

Set `VELD_GATEWAY_BIND_IPV6=false` in the Qovery service env and redeploy.

## Test evidence

- New unit tests: v4-only bind opens only IPv4 sockets; v6-only opens no IPv4
  socket; both-false is refused; config parse (default / v6-off / env-wins /
  both-off refusal / bad-bool). `bind()` returns offline, so these run in CI
  (not `#[ignore]`).
- `cargo test --workspace`: 338 passed, 3 ignored (pre-existing network
  loopback tests). `cargo clippy --workspace --all-targets`: clean.

## Review

Two full 5-angle adversarial rounds (`docs/agentic-review.md`), all findings
verified against the pinned iroh 1.0.1 source. Round 1: fixed 1 major (added
real bind-path test coverage) + the v6 `is_required` leniency (flagged by 3
angles) + log/message clarity. Round 2: all angles clean, zero critical/major;
folded in the relay-only `warn!`.

## Docs

`docs/gateway.md` env table + file-config example updated. Purely
gateway-operator config — not `veld.json`/CLI surface, so the general docs
checklist (README/configuration/skills/schema) and the marketing site don't
apply.
