### PR TITLE
feat(start): --oneshot terminal node for one-off runs (e2e/CI)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,11 @@ If the change is purely internal (refactor, bugfix with no new surface area), th
   metadata on anonymous pages. Never ship an unbranded, system-default-styled
   page; when adding one to an existing binary, reuse its page shell (e.g.
   `veld-gateway`'s `pages::shell`) instead of writing bespoke HTML.
+- **Diagnostics go to stderr; machine-readable output goes to stdout.** Tracing
+  logs, progress, and human status/receipt lines are stderr; `--json` payloads
+  and the terminal node's own output under `veld start --oneshot` are the only
+  things on stdout. A stray `println!`/`tracing::*!`-to-stdout in a command
+  silently corrupts an agent's or CI's stdout capture — keep chrome on stderr.
 - Domain: `veld.oss.life.li` (not `veld.dev`)
 - Install URL: `https://veld.oss.life.li/get`
 - URL templates use `{variable}` (single braces); commands/env use `${variable}`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4302,7 +4302,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "veld"
-version = "10.4.0"
+version = "10.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4322,7 +4322,7 @@ dependencies = [
 
 [[package]]
 name = "veld-core"
-version = "10.4.0"
+version = "10.6.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "veld-daemon"
-version = "10.4.0"
+version = "10.6.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4369,7 +4369,7 @@ dependencies = [
 
 [[package]]
 name = "veld-gateway"
-version = "10.4.0"
+version = "10.6.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4400,7 +4400,7 @@ dependencies = [
 
 [[package]]
 name = "veld-helper"
-version = "10.4.0"
+version = "10.6.0"
 dependencies = [
  "anyhow",
  "nix",
@@ -4416,7 +4416,7 @@ dependencies = [
 
 [[package]]
 name = "veld-share"
-version = "10.4.0"
+version = "10.6.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ veld stop --name dev
 | Command | Description |
 |---------|-------------|
 | `veld start [NODE:VARIANT...] --name <n>` | Start an environment |
+| `veld start <NODE:VARIANT> --oneshot [--all-logs]` | Run a command node as a one-off: start its dependencies, run it to completion (streaming its output), tear everything down in reverse order, and exit with its exit code. Ideal for end-to-end test runs. |
 | `veld stop [--name <n>] [--all]` | Stop a running environment |
 | `veld restart [--name <n>]` | Restart an environment |
 | `veld status [--name <n>] [--json]` | Show run status |

--- a/crates/veld-core/src/orchestrator.rs
+++ b/crates/veld-core/src/orchestrator.rs
@@ -197,6 +197,15 @@ pub struct Orchestrator {
     progress_tx: Option<mpsc::UnboundedSender<ProgressEvent>>,
     /// Internal log writer for the current run (liveness/recovery/lifecycle events).
     internal_log: Option<LogWriter>,
+    /// When set, this `command` node is the run's terminal one-off: it is NOT
+    /// executed during the normal startup stages (its dependencies are), and is
+    /// instead run afterwards via [`Orchestrator::run_terminal`]. Its exit ends
+    /// the run (see `veld start --oneshot`).
+    terminal_node: Option<NodeSelection>,
+    /// Dependency outputs captured at the end of `start` when a terminal node
+    /// is set, so `run_terminal` can interpolate `${nodes.X.url}` etc. with the
+    /// exact values the stages produced (no reconstruction drift).
+    terminal_outputs: Option<HashMap<String, HashMap<String, String>>>,
 }
 
 impl Orchestrator {
@@ -220,7 +229,16 @@ impl Orchestrator {
             foreground: false,
             progress_tx: None,
             internal_log: None,
+            terminal_node: None,
+            terminal_outputs: None,
         })
+    }
+
+    /// Designate a `command` node as the run's terminal one-off (`--oneshot`).
+    /// The node is skipped during startup stages and run afterwards; its exit
+    /// terminates the run. Only its dependencies are brought up by `start`.
+    pub fn set_terminal_node(&mut self, sel: Option<NodeSelection>) {
+        self.terminal_node = sel;
     }
 
     /// Enable foreground mode (timestamped pipe for server output).
@@ -314,6 +332,16 @@ impl Orchestrator {
 
         let resolved = graph::resolve_selections(selections, &self.config)?;
         let plan = graph::build_execution_plan(&resolved, &self.config)?;
+
+        // The terminal one-off node (`--oneshot`) is part of the graph — its
+        // dependencies are brought up here — but the node itself is executed
+        // afterwards by `run_terminal`, so it is skipped in the stage loop and
+        // excluded from the healthy-node count. It stays seeded as `Pending`
+        // below so the reverse-order teardown path can still find it.
+        let terminal_key: Option<String> = self
+            .terminal_node
+            .as_ref()
+            .map(|s| RunState::node_key(&s.node, &s.variant));
 
         // Set up debug log writer if debug mode is enabled.
         if self.debug {
@@ -442,18 +470,29 @@ impl Orchestrator {
             }
         }
 
-        // Count total nodes for progress reporting.
-        let total_nodes: usize = plan.iter().map(|s| s.len()).sum();
+        // Count total nodes for progress reporting (the terminal node runs
+        // separately, so it does not contribute to the startup count). Because
+        // `--oneshot` allows exactly one endpoint selection, the terminal node
+        // is always the sole node in the final stage, so that stage empties out
+        // once it is filtered — drop it from the reported stage count too.
+        let total_nodes: usize = plan
+            .iter()
+            .flatten()
+            .filter(|sel| !is_terminal(terminal_key.as_deref(), sel))
+            .count();
+        let total_stages = if terminal_key.is_some() {
+            plan.len().saturating_sub(1)
+        } else {
+            plan.len()
+        };
         self.internal_log(&format!(
             "[start] starting environment '{}' — {} node(s) in {} stage(s)",
-            run_name,
-            total_nodes,
-            plan.len()
+            run_name, total_nodes, total_stages
         ))
         .await;
         self.emit(ProgressEvent::PlanResolved {
             total_nodes,
-            stages: plan.len(),
+            stages: total_stages,
         });
 
         // Persist the run *before* the first stage kicks off so it is
@@ -498,9 +537,16 @@ impl Orchestrator {
         let mut node_index: usize = 0;
         let execute_result: Result<(), OrchestratorError> = async {
             for stage in &plan {
+                // Drop the terminal node from its stage; only its dependencies
+                // run during startup.
+                let stage_nodes: Vec<NodeSelection> = stage
+                    .iter()
+                    .filter(|sel| !is_terminal(terminal_key.as_deref(), sel))
+                    .cloned()
+                    .collect();
                 let results = self
                     .execute_stage(
-                        stage,
+                        &stage_nodes,
                         &run,
                         &branch,
                         &worktree,
@@ -561,6 +607,11 @@ impl Orchestrator {
         // All reservations have been consumed — clear the map.
         self.precomputed_servers.clear();
 
+        // Capture the dependency outputs for a pending terminal-node run.
+        if terminal_key.is_some() {
+            self.terminal_outputs = Some(all_outputs.clone());
+        }
+
         run.status = RunStatus::Running;
 
         // Final state save with Running status.
@@ -573,6 +624,215 @@ impl Orchestrator {
         .await;
 
         Ok(run)
+    }
+
+    /// Run the terminal one-off node (`--oneshot`) after its dependencies are
+    /// healthy. Streams the node's output live (and into the run log), captures
+    /// its exit code, and persists its final state.
+    ///
+    /// A non-zero exit is the node's *result* (e.g. failing tests), not a
+    /// startup error, so — unlike a `command` node inside a startup stage — it
+    /// is captured and returned rather than raised as `NodeFailed`. The caller
+    /// is expected to tear the run down afterwards and propagate the code.
+    ///
+    /// A command node's `readiness_probe` (which `execute_command_isolated`
+    /// runs after a zero exit) is intentionally NOT run here — a post-run probe
+    /// on the run's final node is meaningless.
+    ///
+    /// **Must be called after [`Orchestrator::start`] on the same instance**:
+    /// `start` stashes the dependency outputs this method interpolates into the
+    /// command. Calling it standalone leaves `${nodes.X.*}` references
+    /// unresolved.
+    pub async fn run_terminal(
+        &mut self,
+        run_name: &str,
+        sel: &NodeSelection,
+    ) -> Result<i32, OrchestratorError> {
+        let node_cfg = self.config.nodes.get(&sel.node).cloned().ok_or_else(|| {
+            OrchestratorError::NodeFailed {
+                node: sel.node.clone(),
+                variant: sel.variant.clone(),
+                reason: "terminal node not found in config".to_owned(),
+            }
+        })?;
+        let variant_cfg = node_cfg
+            .variants
+            .get(&sel.variant)
+            .cloned()
+            .ok_or_else(|| OrchestratorError::NodeFailed {
+                node: sel.node.clone(),
+                variant: sel.variant.clone(),
+                reason: "terminal variant not found in config".to_owned(),
+            })?;
+
+        // A terminal node must run to completion — a start_server never exits,
+        // so it can never be the thing whose exit ends the run.
+        if variant_cfg.step_type != config::StepType::Command {
+            return Err(OrchestratorError::NodeFailed {
+                node: sel.node.clone(),
+                variant: sel.variant.clone(),
+                reason: "--oneshot requires a command-type node (start_server never exits)"
+                    .to_owned(),
+            });
+        }
+
+        // Load the run so we can persist the terminal node's result back into
+        // its state and execution order (for reverse-order teardown).
+        let mut run = match self.db.get_run(&self.project_root, run_name)? {
+            Some(r) => r,
+            None => {
+                return Err(OrchestratorError::NodeFailed {
+                    node: sel.node.clone(),
+                    variant: sel.variant.clone(),
+                    reason: format!("run '{run_name}' not found"),
+                });
+            }
+        };
+
+        // Build the variable context: same builtins as a stage node, plus the
+        // dependency outputs captured by `start`.
+        let branch = url::detect_git_branch(&self.project_root);
+        let worktree = self
+            .project_root
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("default")
+            .to_owned();
+        let username = whoami_username();
+
+        let mut var_ctx = VariableContext::new();
+        var_ctx.set_builtin("run", run_name.to_owned());
+        var_ctx.set_builtin("run_id", run.run_id.to_string());
+        var_ctx.set_builtin("root", self.project_root.to_string_lossy().into_owned());
+        var_ctx.set_builtin("project", self.config.name.clone());
+        var_ctx.set_builtin("name", self.config.name.clone());
+        var_ctx.set_builtin("worktree", url::slugify(&worktree));
+        var_ctx.set_builtin("branch", url::slugify(&branch));
+        var_ctx.set_builtin("username", username);
+
+        // Clone (not take) the stashed dependency outputs so a defensive
+        // re-invocation still resolves `${nodes.X.*}` rather than silently
+        // getting an empty map.
+        let outputs_map = self.terminal_outputs.clone().unwrap_or_default();
+        for (node_key, outputs) in &outputs_map {
+            for (field, value) in outputs {
+                var_ctx.set_node_output(&format!("nodes.{node_key}.{field}"), value.clone());
+            }
+        }
+
+        // Resolve working directory, command/script, and environment.
+        let working_dir = resolve_working_dir(
+            variant_cfg.cwd.as_deref(),
+            node_cfg.cwd.as_deref(),
+            &self.project_root,
+            &var_ctx,
+        )?;
+        let raw_cmd = if let Some(ref script) = variant_cfg.script {
+            format!("sh {}", self.project_root.join(script).display())
+        } else {
+            variant_cfg.command.clone().unwrap_or_default()
+        };
+        let resolved_cmd = crate::variables::interpolate(&raw_cmd, &var_ctx)?;
+        let merged_env = config::resolve_env(
+            self.config.env.as_ref(),
+            node_cfg.env.as_ref(),
+            variant_cfg.env.as_ref(),
+        );
+        let env = build_env(merged_env.as_ref(), &var_ctx)?;
+
+        let key = RunState::node_key(&sel.node, &sel.variant);
+
+        // Idempotency: if skip_if passes, skip the run entirely (exit 0).
+        if let Some(ref skip_if_cmd) = variant_cfg.skip_if {
+            let skip_if_resolved = crate::variables::interpolate(skip_if_cmd, &var_ctx)?;
+            if let Ok(out) = process::run_command(&skip_if_resolved, &working_dir, &env, None).await
+            {
+                if out.exit_code == 0 {
+                    tracing::info!(
+                        node = sel.node,
+                        variant = sel.variant,
+                        "skip_if passed — skipping terminal node"
+                    );
+                    if let Some(ns) = run.nodes.get_mut(&key) {
+                        ns.status = NodeStatus::Skipped;
+                        ns.outputs.insert("exit_code".to_owned(), "0".to_owned());
+                    }
+                    if !run.execution_order.contains(&key) {
+                        run.execution_order.push(key.clone());
+                    }
+                    // Best-effort persist — a bookkeeping failure must not turn
+                    // a skipped (exit 0) result into an error.
+                    if let Err(e) = self.save_state(&run) {
+                        tracing::warn!(error = %e, "failed to persist skipped terminal node");
+                    }
+                    return Ok(0);
+                }
+            }
+        }
+
+        // Run the command, streaming its output live and into the run log.
+        let output_file =
+            logging::output_file(&self.project_root, run_name, &sel.node, &sel.variant);
+        let log_target = process::LogTarget {
+            db: self.db.clone(),
+            project_root: self.project_root.clone(),
+            run_name: run_name.to_owned(),
+            node: sel.node.clone(),
+            variant: sel.variant.clone(),
+        };
+        let result = process::run_command_streaming(
+            &resolved_cmd,
+            &working_dir,
+            &env,
+            Some(&output_file),
+            Some(log_target),
+        )
+        .await?;
+
+        // Persist the terminal node's final state. Undeclared outputs are
+        // ignored (not fatal): the node has already produced its result and its
+        // exit code is what matters — failing the run over strict_outputs here
+        // would only mask it.
+        let declared_keys = variant_cfg
+            .outputs
+            .as_ref()
+            .map(|o| o.declared_keys())
+            .unwrap_or_default();
+        let mut node_state = run
+            .nodes
+            .get(&key)
+            .cloned()
+            .unwrap_or_else(|| NodeState::new(&sel.node, &sel.variant));
+        node_state
+            .outputs
+            .insert("exit_code".to_owned(), result.exit_code.to_string());
+        for (k, v) in &result.outputs {
+            if declared_keys.contains(k.as_str()) {
+                node_state.outputs.insert(k.clone(), v.clone());
+            }
+        }
+        node_state.status = if result.exit_code == 0 {
+            NodeStatus::Healthy
+        } else {
+            NodeStatus::Failed
+        };
+        if let Some(sensitive) = variant_cfg.sensitive_outputs.clone() {
+            node_state.sensitive_keys = sensitive;
+        }
+        run.nodes.insert(key.clone(), node_state);
+        // Append last so reverse-order teardown runs its on_stop hook first.
+        if !run.execution_order.contains(&key) {
+            run.execution_order.push(key.clone());
+        }
+        // Best-effort persist: the command has already run and its exit code is
+        // the whole `--oneshot` contract, so a post-completion bookkeeping
+        // failure must not override it (a passing run reporting 127 to CI would
+        // be a false failure). Log and return the real code regardless.
+        if let Err(e) = self.save_state(&run) {
+            tracing::warn!(error = %e, "failed to persist terminal node result");
+        }
+
+        Ok(result.exit_code)
     }
 
     /// Execute a single stage: all nodes run in parallel via `JoinSet`.
@@ -1244,6 +1504,18 @@ fn resolve_working_dir(
         }
         None => Ok(project_root.to_path_buf()),
     }
+}
+
+/// Whether `sel` is the run's terminal one-off node (`--oneshot`), given the
+/// precomputed terminal node key. Such a node is present in the execution plan
+/// (so its dependencies resolve) but must be dropped from startup execution and
+/// the healthy-node count — it runs later via [`Orchestrator::run_terminal`].
+/// Every pass over the plan that executes or counts nodes routes through this
+/// so the invariant "deps run at startup, terminal node runs after" holds in
+/// one place. The pre-stage `Pending` seeding is the deliberate exception: the
+/// terminal node IS seeded so reverse-order teardown can find it.
+fn is_terminal(terminal_key: Option<&str>, sel: &NodeSelection) -> bool {
+    terminal_key == Some(RunState::node_key(&sel.node, &sel.variant).as_str())
 }
 
 /// Execute a single node in isolation (no `&self`). Designed to be spawned
@@ -2099,5 +2371,77 @@ mod tests {
             assert!(!is_reapable_orphan(&status, false, false));
             assert!(!is_reapable_orphan(&status, false, true));
         }
+    }
+
+    /// Build a minimal orchestrator backed by a throwaway database, with no
+    /// helper interaction — enough to exercise `run_terminal` in isolation.
+    fn test_orchestrator(project_root: &std::path::Path, config: VeldConfig) -> Orchestrator {
+        let db = Db::open_at(&project_root.join("veld.db")).unwrap();
+        Orchestrator {
+            config,
+            config_path: project_root.join("veld.json"),
+            project_root: project_root.to_path_buf(),
+            db,
+            port_allocator: PortAllocator::new(),
+            helper_client: HelperClient::default_client(),
+            https_port: 443,
+            children: HashMap::new(),
+            precomputed_servers: HashMap::new(),
+            debug: false,
+            debug_writer: None,
+            foreground: false,
+            progress_tx: None,
+            internal_log: None,
+            terminal_node: None,
+            terminal_outputs: Some(HashMap::new()),
+        }
+    }
+
+    /// The core `--oneshot` contract: a non-zero terminal exit is returned (not
+    /// raised as an error) and the node's result is persisted, appended to the
+    /// execution order so reverse-order teardown can find it.
+    #[tokio::test]
+    async fn run_terminal_propagates_exit_code_and_persists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_root = tmp.path();
+
+        let config: VeldConfig = serde_json::from_str(
+            r#"{
+                "schemaVersion": "2",
+                "name": "testcfg",
+                "url_template": "{service}.{run}.{project}.localhost",
+                "nodes": {
+                    "task": { "default_variant": "local", "variants": {
+                        "local": { "type": "command", "command": "echo running; exit 7" }
+                    }}
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let mut orch = test_orchestrator(project_root, config.clone());
+        let sel = NodeSelection {
+            node: "task".to_owned(),
+            variant: "local".to_owned(),
+        };
+        let key = RunState::node_key(&sel.node, &sel.variant);
+
+        let mut run = RunState::new("testrun", &config.name);
+        run.status = RunStatus::Running;
+        run.nodes
+            .insert(key.clone(), NodeState::new(&sel.node, &sel.variant));
+        orch.save_state(&run).unwrap();
+
+        let code = orch.run_terminal("testrun", &sel).await.unwrap();
+        assert_eq!(code, 7, "non-zero exit must be returned, not an error");
+
+        let reloaded = orch.db.get_run(project_root, "testrun").unwrap().unwrap();
+        let ns = reloaded.nodes.get(&key).unwrap();
+        assert_eq!(ns.status, NodeStatus::Failed);
+        assert_eq!(ns.outputs.get("exit_code").map(String::as_str), Some("7"));
+        assert!(
+            reloaded.execution_order.contains(&key),
+            "terminal node must be appended to execution_order for teardown"
+        );
     }
 }

--- a/crates/veld-core/src/process.rs
+++ b/crates/veld-core/src/process.rs
@@ -382,6 +382,230 @@ pub async fn run_command(
 }
 
 // ---------------------------------------------------------------------------
+// Run a command to completion while streaming its output live
+// ---------------------------------------------------------------------------
+
+/// Run a command/script to completion, streaming its output live.
+///
+/// Unlike [`run_command`], every stdout line is echoed to the process's own
+/// stdout and every stderr line to its stderr, so a human (or CI, or a coding
+/// agent) sees the output as it happens — this is what makes a `--oneshot`
+/// terminal node (e.g. an end-to-end test runner) print its results inline.
+/// When `log_target` is `Some`, each line is also timestamped into the
+/// database `server` stream so `veld logs --node <n>` works after the run.
+///
+/// `VELD_OUTPUT key=value` control lines on stdout are still parsed (for
+/// declared outputs) but are never echoed or logged — they are machinery, not
+/// program output.
+///
+/// The child runs in its own process group so a Ctrl+C delivered to the CLI's
+/// controlling terminal is not auto-forwarded to it; instead we catch the
+/// signal, kill the whole group, and report exit code `130` (SIGINT). This
+/// keeps interruption deterministic regardless of how the child handles
+/// signals itself.
+pub async fn run_command_streaming(
+    command: &str,
+    working_dir: &Path,
+    env: &HashMap<String, String>,
+    output_file: Option<&Path>,
+    log_target: Option<LogTarget>,
+) -> Result<CommandOutput, ProcessError> {
+    use tokio::io::AsyncWriteExt;
+
+    // Prepare the output file and augmented env (mirrors `run_command`).
+    let mut env = env.clone();
+    if let Some(path) = output_file {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| ProcessError::OutputFileError {
+                path: path.to_path_buf(),
+                source: e,
+            })?;
+        }
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o600)
+                .open(path)
+                .map_err(|e| ProcessError::OutputFileError {
+                    path: path.to_path_buf(),
+                    source: e,
+                })?;
+        }
+        env.insert(
+            "VELD_OUTPUT_FILE".to_owned(),
+            path.to_string_lossy().into_owned(),
+        );
+    }
+
+    let spawn_result = Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .current_dir(working_dir)
+        .envs(&env)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .process_group(0) // own group — we forward Ctrl+C by killing the group
+        .spawn();
+
+    let mut child = match spawn_result {
+        Ok(child) => child,
+        Err(e) => {
+            if let Some(path) = output_file {
+                let _ = std::fs::remove_file(path);
+            }
+            return Err(ProcessError::SpawnFailed(e));
+        }
+    };
+
+    let pid = child.id().unwrap_or(0);
+    let stdout = child.stdout.take().expect("stdout should be piped");
+    let stderr = child.stderr.take().expect("stderr should be piped");
+
+    // Each stream is drained to completion by its own task, so a Ctrl+C
+    // (handled in the select below) can never cancel a partial read — the
+    // tasks own their readers and stop only at EOF (or an unrecoverable read
+    // error). Lines are decoded
+    // lossily: a test runner may emit non-UTF-8 bytes, and a bad byte must
+    // replace one character, not truncate the rest of the stream (which
+    // `Lines`/`str`-based reads would do on the first `InvalidData`).
+    //
+    // stdout carries the program's real output; `VELD_OUTPUT key=value`
+    // control lines are peeled off it and sent back over `out_tx` instead of
+    // being echoed or logged. stderr is forwarded verbatim.
+    let (out_tx, mut out_rx) = tokio::sync::mpsc::unbounded_channel::<(String, String)>();
+    let out_log = log_target.clone();
+    let out_task = tokio::spawn(async move {
+        let mut reader = BufReader::new(stdout);
+        let mut w = tokio::io::stdout();
+        let mut buf = Vec::new();
+        loop {
+            buf.clear();
+            match reader.read_until(b'\n', &mut buf).await {
+                Ok(0) | Err(_) => break,
+                Ok(_) => {
+                    while matches!(buf.last(), Some(b'\n' | b'\r')) {
+                        buf.pop();
+                    }
+                    let line = String::from_utf8_lossy(&buf);
+                    if let Some(kv) = line.strip_prefix("VELD_OUTPUT ") {
+                        if let Some((key, value)) = kv.split_once('=') {
+                            let _ = out_tx.send((key.trim().to_owned(), value.trim().to_owned()));
+                        }
+                        // Control line — never echoed or logged.
+                    } else {
+                        let _ = w.write_all(line.as_bytes()).await;
+                        let _ = w.write_all(b"\n").await;
+                        let _ = w.flush().await;
+                        if let Some(ref t) = out_log {
+                            t.append(&line);
+                        }
+                    }
+                }
+            }
+        }
+    });
+    let err_log = log_target.clone();
+    let err_task = tokio::spawn(async move {
+        let mut reader = BufReader::new(stderr);
+        let mut w = tokio::io::stderr();
+        let mut buf = Vec::new();
+        loop {
+            buf.clear();
+            match reader.read_until(b'\n', &mut buf).await {
+                Ok(0) | Err(_) => break,
+                Ok(_) => {
+                    while matches!(buf.last(), Some(b'\n' | b'\r')) {
+                        buf.pop();
+                    }
+                    let line = String::from_utf8_lossy(&buf);
+                    let _ = w.write_all(line.as_bytes()).await;
+                    let _ = w.write_all(b"\n").await;
+                    let _ = w.flush().await;
+                    if let Some(ref t) = err_log {
+                        t.append(&line);
+                    }
+                }
+            }
+        }
+    });
+
+    // Wait for both drain tasks to finish; a Ctrl+C kills the child's process
+    // group (the tasks then hit EOF) and reports the conventional 130 code.
+    let mut interrupted = false;
+    let drain = async {
+        let _ = tokio::join!(out_task, err_task);
+    };
+    tokio::pin!(drain);
+    tokio::select! {
+        _ = &mut drain => {}
+        _ = tokio::signal::ctrl_c() => {
+            interrupted = true;
+            if pid > 1 {
+                let _ = kill_process(pid).await;
+            }
+            // Bounded wait for the drain tasks to finish after the kill: they
+            // normally hit EOF immediately once the pipes close, but don't hang
+            // the interrupt forever if our own stdout consumer has stalled.
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(10), &mut drain).await;
+        }
+    }
+
+    let mut outputs = HashMap::new();
+    while let Ok((key, value)) = out_rx.try_recv() {
+        outputs.insert(key, value);
+    }
+
+    let status = child.wait().await.map_err(ProcessError::SpawnFailed)?;
+
+    // Read file-based outputs (overrides stdout for duplicate keys).
+    if let Some(path) = output_file {
+        match std::fs::read_to_string(path) {
+            Ok(contents) => {
+                for line in contents.lines() {
+                    let line = line.trim();
+                    if line.is_empty() {
+                        continue;
+                    }
+                    if let Some((key, value)) = line.split_once('=') {
+                        outputs.insert(key.trim().to_owned(), value.trim().to_owned());
+                    } else {
+                        tracing::warn!(
+                            line,
+                            "ignoring malformed line in output file (expected key=value)"
+                        );
+                    }
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                tracing::warn!(path = %path.display(), "output file was deleted by the script");
+            }
+            Err(e) => {
+                let _ = std::fs::remove_file(path);
+                return Err(ProcessError::OutputFileError {
+                    path: path.to_path_buf(),
+                    source: e,
+                });
+            }
+        }
+        let _ = std::fs::remove_file(path);
+    }
+
+    // On Ctrl+C, report the conventional SIGINT exit code regardless of how
+    // the child actually terminated.
+    let exit_code = if interrupted {
+        130
+    } else {
+        status.code().unwrap_or(-1)
+    };
+
+    Ok(CommandOutput { exit_code, outputs })
+}
+
+// ---------------------------------------------------------------------------
 // Process monitoring
 // ---------------------------------------------------------------------------
 
@@ -474,4 +698,59 @@ pub async fn kill_process(pid: u32) -> Result<(), ProcessError> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod streaming_tests {
+    use super::*;
+
+    /// A non-zero exit is the terminal node's *result*: `run_command_streaming`
+    /// must surface it as `exit_code` (never an error) so `--oneshot` can
+    /// propagate it, and must still parse `VELD_OUTPUT` control lines.
+    #[tokio::test]
+    async fn captures_nonzero_exit_and_outputs() {
+        let env = HashMap::new();
+        let dir = std::env::temp_dir();
+        let out = run_command_streaming(
+            "echo hello; echo 'VELD_OUTPUT foo=bar'; echo oops 1>&2; exit 3",
+            &dir,
+            &env,
+            None,
+            None,
+        )
+        .await
+        .expect("streaming run should not error on non-zero exit");
+        assert_eq!(out.exit_code, 3);
+        assert_eq!(out.outputs.get("foo").map(String::as_str), Some("bar"));
+    }
+
+    #[tokio::test]
+    async fn zero_exit_no_outputs() {
+        let env = HashMap::new();
+        let dir = std::env::temp_dir();
+        let out = run_command_streaming("true", &dir, &env, None, None)
+            .await
+            .expect("streaming run should succeed");
+        assert_eq!(out.exit_code, 0);
+        assert!(out.outputs.is_empty());
+    }
+
+    /// A raw non-UTF-8 byte on stdout must not truncate the stream: the later
+    /// `VELD_OUTPUT` line is still parsed (lossy decode replaces the bad byte).
+    #[tokio::test]
+    async fn lossy_decode_survives_non_utf8() {
+        let env = HashMap::new();
+        let dir = std::env::temp_dir();
+        let out = run_command_streaming(
+            "printf '\\377\\n'; echo 'VELD_OUTPUT foo=bar'",
+            &dir,
+            &env,
+            None,
+            None,
+        )
+        .await
+        .expect("streaming run should tolerate non-UTF-8 output");
+        assert_eq!(out.exit_code, 0);
+        assert_eq!(out.outputs.get("foo").map(String::as_str), Some("bar"));
+    }
 }

--- a/crates/veld/src/commands/start.rs
+++ b/crates/veld/src/commands/start.rs
@@ -8,12 +8,14 @@ use tokio::sync::mpsc;
 
 use crate::output::{self, is_tty};
 
-/// `veld start [node:variant...] [--preset <n>] [--name <n>] [-a] [--debug]`
+/// `veld start [node:variant...] [--preset <n>] [--name <n>] [-a] [--oneshot] [--debug]`
 pub async fn run(
     selections: Vec<String>,
     preset: Option<String>,
     name: Option<String>,
     attach: bool,
+    oneshot: bool,
+    all_logs: bool,
     _debug: bool,
 ) -> i32 {
     let Some((config_path, config)) = super::load_config(false) else {
@@ -83,6 +85,47 @@ pub async fn run(
         }
     }
 
+    // --oneshot: validate and pick the terminal command node.
+    let terminal_sel = if oneshot {
+        if attach {
+            output::print_error("--attach and --oneshot cannot be combined.", false);
+            return 1;
+        }
+        if parsed_selections.len() != 1 {
+            output::print_error(
+                "--oneshot requires exactly one command-type selection (the terminal node whose \
+                 exit ends the run). Its dependencies are started automatically.",
+                false,
+            );
+            return 1;
+        }
+        let sel = parsed_selections[0].clone();
+        let is_command = config
+            .nodes
+            .get(&sel.node)
+            .and_then(|n| n.variants.get(&sel.variant))
+            .map(|v| v.step_type == veld_core::config::StepType::Command)
+            .unwrap_or(false);
+        if !is_command {
+            output::print_error(
+                &format!(
+                    "--oneshot requires a command-type node; '{}:{}' is a start_server (it never \
+                     exits, so it cannot be the terminal node).",
+                    sel.node, sel.variant
+                ),
+                false,
+            );
+            return 1;
+        }
+        Some(sel)
+    } else {
+        if all_logs {
+            output::print_error("--all-logs only applies with --oneshot.", false);
+            return 1;
+        }
+        None
+    };
+
     let project_root = veld_core::config::project_root(&config_path);
     let run_name = match name {
         Some(ref n) => n.clone(),
@@ -101,12 +144,15 @@ pub async fn run(
     };
     orchestrator.set_debug(_debug);
     orchestrator.set_foreground(foreground);
+    orchestrator.set_terminal_node(terminal_sel.clone());
 
     // Set up live progress channel.
     let (progress_tx, progress_rx) = mpsc::unbounded_channel::<ProgressEvent>();
     orchestrator.set_progress_sender(progress_tx);
     let tty = is_tty();
-    let progress_handle = tokio::spawn(render_progress(progress_rx, tty));
+    // In --oneshot mode, stdout must carry ONLY the terminal node's output, so
+    // the startup progress stream goes to stderr.
+    let progress_handle = tokio::spawn(render_progress(progress_rx, tty, terminal_sel.is_some()));
 
     eprintln!(
         "{} Starting environment {}...",
@@ -122,9 +168,17 @@ pub async fn run(
             orchestrator.close_progress_sender();
             let _ = progress_handle.await;
             eprintln!();
-            output::print_info("Interrupted — stopping partially started environment...");
+            // Interrupt/cleanup messages are diagnostics → stderr (keeps stdout
+            // clean, notably for --oneshot where stdout is the node's output).
+            eprintln!(
+                "  {} Interrupted — stopping partially started environment...",
+                output::dim("»")
+            );
             match orchestrator.stop(run_name_str).await {
-                Ok(_) => output::print_success(&format!("Environment '{}' cleaned up.", run_name_str)),
+                Ok(_) => eprintln!(
+                    "  {} Environment '{run_name_str}' cleaned up.",
+                    output::checkmark()
+                ),
                 Err(e) => output::print_error(&format!("Cleanup failed: {e}"), false),
             }
             return 130; // Standard exit code for SIGINT
@@ -136,6 +190,20 @@ pub async fn run(
             // Drop the progress sender so the renderer can finish.
             orchestrator.close_progress_sender();
             let _ = progress_handle.await;
+
+            // --oneshot: dependencies are up; now run the terminal node to
+            // completion, tear everything down, and exit with its code.
+            if let Some(ref sel) = terminal_sel {
+                return run_oneshot_terminal(
+                    &mut orchestrator,
+                    &run_state,
+                    sel,
+                    run_name_str,
+                    &project_root,
+                    all_logs,
+                )
+                .await;
+            }
 
             // Final receipt: summary table.
             println!();
@@ -312,16 +380,26 @@ fn print_start_receipt(run_state: &veld_core::state::RunState) {
 ///
 /// TTY mode: Uses `indicatif::MultiProgress` for concurrent node spinners.
 /// Non-TTY/JSON mode: Emits NDJSON for agent consumption.
-async fn render_progress(mut rx: mpsc::UnboundedReceiver<ProgressEvent>, tty: bool) {
+async fn render_progress(
+    mut rx: mpsc::UnboundedReceiver<ProgressEvent>,
+    tty: bool,
+    json_stderr: bool,
+) {
     let mut ctx = TtyProgressCtx::new();
 
     while let Some(event) = rx.recv().await {
         if tty {
             render_progress_tty(&event, &mut ctx);
         } else {
-            // NDJSON for non-TTY / agent mode.
+            // NDJSON for non-TTY / agent mode. In --oneshot mode this startup
+            // progress is chrome, not program output, so route it to stderr to
+            // keep stdout carrying only the terminal node's output.
             if let Ok(json) = serde_json::to_string(&event) {
-                println!("{json}");
+                if json_stderr {
+                    eprintln!("{json}");
+                } else {
+                    println!("{json}");
+                }
             }
         }
     }
@@ -634,6 +712,155 @@ async fn follow_logs_until_interrupt(
             _ = tokio::signal::ctrl_c() => {
                 return;
             }
+        }
+    }
+}
+
+/// Run the terminal one-off node (`--oneshot`) after its dependencies are
+/// healthy: stream its output, tear everything down in reverse order, and
+/// return its exit code so CI/callers see pass/fail directly.
+async fn run_oneshot_terminal(
+    orchestrator: &mut Orchestrator,
+    run_state: &veld_core::state::RunState,
+    sel: &NodeSelection,
+    run_name: &str,
+    project_root: &std::path::Path,
+    all_logs: bool,
+) -> i32 {
+    let label = format!("{}:{}", sel.node, sel.variant);
+
+    // Everything veld prints here is chrome and goes to STDERR: stdout must
+    // carry only the terminal node's own output (streamed by run_terminal), so
+    // an agent or CI job that captures stdout gets just the test results.
+    eprintln!();
+    print_deps_summary_stderr(run_state, sel);
+    eprintln!();
+    eprintln!(
+        "  {} Running {} (Ctrl+C to abort)...",
+        output::dim("»"),
+        output::bold(&label)
+    );
+    eprintln!();
+
+    // Optionally interleave dependency logs — also on stderr, keeping stdout
+    // the terminal node's output only.
+    let tailer = if all_logs {
+        let db = orchestrator.db.clone();
+        let pr = project_root.to_path_buf();
+        let rn = run_name.to_owned();
+        let dep_targets: Vec<(String, String)> = run_state
+            .nodes
+            .values()
+            .filter(|ns| !(ns.node_name == sel.node && ns.variant == sel.variant))
+            .map(|ns| (ns.node_name.clone(), ns.variant.clone()))
+            .collect();
+        Some(tokio::spawn(async move {
+            follow_dep_logs(&db, &dep_targets, &pr, &rn).await;
+        }))
+    } else {
+        None
+    };
+
+    let result = orchestrator.run_terminal(run_name, sel).await;
+
+    if let Some(handle) = tailer {
+        handle.abort();
+    }
+
+    let exit_code = match result {
+        Ok(code) => code,
+        Err(e) => {
+            output::print_error(&format!("Failed to run {label}: {e}"), false);
+            127
+        }
+    };
+
+    // Tear down all dependencies in reverse order, regardless of outcome.
+    eprintln!();
+    eprintln!("  {} Tearing down environment...", output::dim("»"));
+    match orchestrator.stop(run_name).await {
+        Ok(_) => eprintln!(
+            "  {} Environment '{run_name}' torn down.",
+            output::checkmark()
+        ),
+        Err(e) => output::print_error(&format!("Teardown failed: {e}"), false),
+    }
+
+    eprintln!();
+    if exit_code == 0 {
+        eprintln!(
+            "  {} {} completed successfully (exit 0).",
+            output::checkmark(),
+            label
+        );
+    } else {
+        output::print_error(&format!("{label} exited with code {exit_code}."), false);
+    }
+
+    exit_code
+}
+
+/// Print a compact summary of the started dependencies to **stderr** (stdout is
+/// reserved for the terminal node's own output in `--oneshot` mode).
+fn print_deps_summary_stderr(run_state: &veld_core::state::RunState, terminal: &NodeSelection) {
+    use veld_core::state::{NodeStatus, RunState};
+
+    let term_key = RunState::node_key(&terminal.node, &terminal.variant);
+    for key in &run_state.execution_order {
+        if key == &term_key {
+            continue;
+        }
+        let Some(ns) = run_state.nodes.get(key) else {
+            continue;
+        };
+        let status = match ns.status {
+            NodeStatus::Healthy => output::green("healthy"),
+            NodeStatus::Skipped => output::dim("skipped"),
+            _ => output::dim(&format!("{:?}", ns.status).to_lowercase()),
+        };
+        eprintln!(
+            "  {} {} {}",
+            output::dim(&format!("{}:{}", ns.node_name, ns.variant)),
+            status,
+            output::dim(ns.url.as_deref().unwrap_or("-")),
+        );
+    }
+}
+
+/// Tail dependency server logs until the task is aborted. Used by
+/// `--oneshot --all-logs` to interleave dependency output with the terminal
+/// node's own (already-streamed) output.
+async fn follow_dep_logs(
+    db: &veld_core::db::Db,
+    targets: &[(String, String)],
+    project_root: &std::path::Path,
+    run_name: &str,
+) {
+    let mut last_id = db.max_log_id().unwrap_or(0);
+    let target_set: std::collections::HashSet<(String, String)> = targets.iter().cloned().collect();
+    let filter = veld_core::db::LogFilter {
+        node: None,
+        variant: None,
+        streams: Some(vec![veld_core::db::LogStream::Server.as_str()]),
+    };
+
+    let mut interval = tokio::time::interval(std::time::Duration::from_millis(200));
+    loop {
+        interval.tick().await;
+        let rows = match db.logs_after_id(project_root, run_name, &filter, last_id) {
+            Ok(rows) => rows,
+            Err(_) => continue,
+        };
+        for row in rows {
+            last_id = row.id;
+            let (Some(node), Some(variant)) = (row.node.as_deref(), row.variant.as_deref()) else {
+                continue;
+            };
+            if !target_set.contains(&(node.to_owned(), variant.to_owned())) {
+                continue;
+            }
+            let plabel = output::dim(&format!("{node}:{variant}"));
+            eprintln!("{plabel} {}", output::dim(&row.line));
         }
     }
 }

--- a/crates/veld/src/main.rs
+++ b/crates/veld/src/main.rs
@@ -65,6 +65,18 @@ enum Command {
         #[arg(long, short = 'a')]
         attach: bool,
 
+        /// Run the selected command node as a one-off: bring up its
+        /// dependencies, run it to completion streaming its output, then tear
+        /// everything down and exit with the node's exit code. Ideal for
+        /// end-to-end test runs. Requires exactly one command-type selection.
+        #[arg(long)]
+        oneshot: bool,
+
+        /// With --oneshot, also stream the dependencies' logs (not just the
+        /// terminal node's output).
+        #[arg(long)]
+        all_logs: bool,
+
         /// Enable debug logging for the started environment.
         #[arg(long)]
         debug: bool,
@@ -415,7 +427,13 @@ fn init_tracing(debug: bool) {
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"))
     };
 
-    tracing_subscriber::fmt().with_env_filter(filter).init();
+    // Diagnostic logs go to stderr (the conventional target), keeping stdout
+    // clean for machine-readable output — notably the terminal node's own
+    // output under `veld start --oneshot`.
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(filter)
+        .init();
 }
 
 #[tokio::main]
@@ -468,8 +486,10 @@ async fn main() {
             preset,
             name,
             attach,
+            oneshot,
+            all_logs,
             debug,
-        } => commands::start::run(selections, preset, name, attach, debug).await,
+        } => commands::start::run(selections, preset, name, attach, oneshot, all_logs, debug).await,
 
         Command::Stop { name, all } => commands::stop::run(name, all).await,
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1235,6 +1235,75 @@ veld logs -f
 
 When not running in a terminal (e.g. piped or in a script), `veld start` always detaches automatically.
 
+### One-off runs (`--oneshot`)
+
+`veld start <node> --oneshot` turns a `command` node into the run's **terminal
+node**: Veld starts the node's dependencies, waits for them to become healthy,
+then runs the node to completion — streaming its output live — and, the moment
+it exits, tears the whole environment down in reverse dependency order and exits
+with the node's exit code. It's the local-dev and CI analog of
+`docker compose run --rm` (with `--abort-on-container-exit --exit-code-from`).
+
+This makes end-to-end test setups trivial: one command brings up every backend
+and web app the tests need, runs the test runner, prints its results, and cleans
+everything up afterwards — with the test runner's pass/fail becoming the process
+exit code.
+
+```sh
+# Start db + api + web (e2e's dependencies), run the e2e suite, tear down,
+# and exit with the suite's exit code.
+veld start e2e --oneshot
+```
+
+```json
+{
+  "nodes": {
+    "e2e": {
+      "variants": {
+        "local": {
+          "type": "command",
+          "command": "playwright test --reporter=line",
+          "env": { "BASE_URL": "${nodes.web.url}" },
+          "depends_on": { "web": "local", "api": "local" }
+        }
+      }
+    }
+  }
+}
+```
+
+Ports are allocated dynamically, so the test runner can't hardcode a URL — hand
+it the started services' URLs by interpolating `${nodes.<node>.url}` (or
+`.url.host`, `.port`, …) into the command or its `env`, as the `BASE_URL` above
+does. See [Variables](#variables) for the full set of `${nodes.*}` references.
+
+Details:
+
+- **stdout carries only the terminal node's stdout.** Veld's own chrome (the
+  startup summary, "Running…", teardown lines, and the non-TTY NDJSON progress
+  stream) all go to **stderr**, so a CI job or coding agent can capture stdout
+  and get just the program's output. Dependency logs are recorded (read them
+  with `veld logs --node <dep>`), not streamed; pass `--all-logs` to interleave
+  them (on stderr) during the run.
+- **The terminal node must be a `command` type** (a `start_server` never exits,
+  so it can't be the thing whose exit ends the run). Veld errors otherwise —
+  and the command itself **must terminate**: a node mistyped as `command` that
+  actually runs a long-lived server will hang the run until you Ctrl+C.
+- **Exactly one selection** is required — the terminal node (a `--preset` that
+  expands to several nodes is rejected). Its dependencies are resolved through
+  the graph and started automatically.
+- **The exit code is the node's own.** A non-zero exit (failing tests) is the
+  node's *result*, not a startup error — Veld propagates it as its own exit
+  code so `veld start e2e --oneshot && deploy` works.
+- **Teardown always runs** — on normal completion and on Ctrl+C (which aborts
+  the run and exits `130`) — and runs to completion once started; a further
+  Ctrl+C during teardown is ignored. Per-node `on_stop` hooks and project
+  `teardown` steps run in reverse order, exactly as `veld stop` does.
+- **Dependencies are not health-monitored while the terminal node runs.** If a
+  dependency crashes mid-run it surfaces only as the node's own failure (e.g. a
+  connection error), not a distinct diagnostic.
+- `--oneshot` cannot be combined with `--attach`.
+
 ### Log Timestamps
 
 All log output (both `start_server` stdout/stderr and internal Veld events) is timestamped with ISO 8601 timestamps:

--- a/skills/veld/SKILL.md
+++ b/skills/veld/SKILL.md
@@ -261,6 +261,35 @@ loop:
 re-run and resumes cleanly after a restart. Reply parks a thread on the human
 and drops it off the queue; a new human comment brings it back automatically.
 
+## One-off runs (`--oneshot`) — e2e tests, CI
+
+`veld start <node> --oneshot` runs a `command` node as the run's **terminal
+node**: it starts the node's dependencies, runs the node to completion
+(streaming its output), then tears the whole environment down in reverse order
+and exits with the node's exit code. The local/CI analog of
+`docker compose run --rm --abort-on-container-exit`.
+
+```sh
+# Bring up e2e's deps (web, api, db), run the suite, tear down, exit w/ its code.
+veld start e2e --oneshot
+veld start e2e --oneshot --all-logs   # also interleave dependency logs (stderr)
+```
+
+- **stdout = only the terminal node's stdout.** Veld's chrome (summary,
+  progress NDJSON, teardown lines) and dependency logs all go to **stderr**, so
+  an agent/CI capturing stdout gets just the program output. Dep logs are
+  recorded (`veld logs --node <dep>`); `--all-logs` interleaves them live.
+- Ports are dynamic, so pass dep URLs into the runner via `${nodes.<node>.url}`
+  in the command or its `env` (e.g. `"env": { "BASE_URL": "${nodes.web.url}" }`).
+- The node **must be `command` type** (a `start_server` never exits) **and must
+  terminate** — a server mistyped as `command` hangs the run. Exactly **one**
+  selection is required (no multi-node preset); its deps start automatically.
+- A non-zero exit (failing tests) becomes veld's own exit code — chain it:
+  `veld start e2e --oneshot && deploy`. Ctrl+C aborts and exits `130`.
+- Teardown (`on_stop` hooks, project `teardown`) always runs — on completion
+  and on Ctrl+C — and runs to completion once started. Deps aren't
+  health-monitored while the node runs.
+
 ## Reading Outputs
 
 After starting an environment, read node outputs (database URLs, ports, credentials, etc.):
@@ -287,6 +316,7 @@ veld logs --source internal -f --name my-feature  # follow mode
 - **`${...}` vs `{...}`** — `${veld.port}` in commands/env, `{service}` in URL templates. Mixing them up silently produces wrong values.
 - **`outputs` shape differs by type** — object (`{"KEY": "template"}`) for `start_server`, array (`["KEY"]`) for `command`
 - **`${veld.port}` is only for `start_server`** — `command` variants don't get an allocated port
+- **`--oneshot` needs a `command` node** — the terminal node must run to completion; a `start_server` is rejected. Its exit code becomes veld's exit code; only its logs stream to stdout unless `--all-logs`
 - **`setup`/`teardown` are not nodes** — they have no variants, no health checks, no outputs. Only project-level variables (`${veld.name}`, `${veld.root}`, `${veld.run}`) are available, not `${veld.port}` or `${nodes.*}`
 - **Ports are dynamic** (19000–29999) — never hardcode a port in veld.json or dependent config
 - **Commands run from veld.json directory**, not your CWD — use `cwd` field if a node needs a different working directory

--- a/skills/veld/reference/config.md
+++ b/skills/veld/reference/config.md
@@ -62,6 +62,12 @@ Must bind to `${veld.port}`. Requires a readiness probe (`probes.readiness` or l
 
 Emits outputs by writing `key=value` lines to `$VELD_OUTPUT_FILE`.
 
+A `command` node can also be a run's **terminal node** via
+`veld start <node> --oneshot`: veld starts its dependencies, runs it to
+completion (streaming its output), then tears everything down and exits with the
+node's exit code — the e2e/CI pattern. See the CLI reference / configuration
+guide for details.
+
 ```json
 {
   "type": "command",

--- a/testproject/veld.json
+++ b/testproject/veld.json
@@ -32,6 +32,25 @@
           "depends_on": { "backend": "local" }
         }
       }
+    },
+    "e2e": {
+      "default_variant": "local",
+      "variants": {
+        "local": {
+          "type": "command",
+          "command": "echo \"running e2e against ${nodes.frontend.url}\"; curl -fsS ${nodes.backend.url}/health >/dev/null && echo '  ✓ backend healthy'; echo '  ✓ homepage loads'; echo; echo '2 passed, 0 failed'",
+          "depends_on": { "frontend": "local" }
+        }
+      }
+    },
+    "failtest": {
+      "default_variant": "local",
+      "variants": {
+        "local": {
+          "type": "command",
+          "command": "echo boom; exit 3"
+        }
+      }
     }
   }
 }

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -389,6 +389,66 @@ fi
 "$VELD_BIN" stop --name "$RUN_NAME" >/dev/null 2>&1 || true
 
 # ---------------------------------------------------------------------------
+# Test 12: veld start --oneshot (terminal node: e2e/CI pattern)
+# ---------------------------------------------------------------------------
+
+header "One-off run (--oneshot)"
+
+cd "$PROJECT_DIR"
+OS_RUN="oneshot-$$"
+OS_OUT="$(mktemp)"
+OS_ERR="$(mktemp)"
+
+# The `e2e` command node runs to completion after its deps are healthy, then
+# the whole environment is torn down; the node's exit code becomes veld's.
+if run_with_timeout 120 "$VELD_BIN" start e2e --oneshot --name "$OS_RUN" >"$OS_OUT" 2>"$OS_ERR"; then
+    pass "veld start e2e --oneshot exits 0"
+else
+    fail "veld start e2e --oneshot (exit $?)"
+    info "stderr: $(cat "$OS_ERR")"
+fi
+
+# stdout must carry ONLY the terminal node's output: its result line present,
+# veld's chrome (NDJSON progress, teardown banner) absent (that goes to stderr).
+if grep -q "2 passed, 0 failed" "$OS_OUT"; then
+    pass "oneshot: terminal node output present on stdout"
+else
+    fail "oneshot: terminal node output missing from stdout"
+    info "stdout: $(cat "$OS_OUT")"
+fi
+if grep -qE "plan_resolved|node_healthy|Tearing down" "$OS_OUT"; then
+    fail "oneshot: veld chrome leaked onto stdout"
+    info "stdout: $(cat "$OS_OUT")"
+else
+    pass "oneshot: stdout free of veld chrome (chrome routed to stderr)"
+fi
+
+# Teardown ran: the run is gone afterwards.
+if OS_STATUS=$("$VELD_BIN" status --name "$OS_RUN" --json 2>/dev/null); then
+    if echo "$OS_STATUS" | grep -qiE '"(stopped|not.found|exited)"'; then
+        pass "oneshot: environment torn down after run"
+    else
+        fail "oneshot: environment not torn down after run"
+    fi
+else
+    pass "oneshot: environment torn down after run (run gone)"
+fi
+
+# A non-zero terminal exit becomes veld's own exit code.
+OSF_RUN="oneshotfail-$$"
+run_with_timeout 60 "$VELD_BIN" start failtest --oneshot --name "$OSF_RUN" >/dev/null 2>&1
+OSF_RC=$?
+if [ "$OSF_RC" -eq 3 ]; then
+    pass "oneshot: non-zero terminal exit code propagated (exit 3)"
+else
+    fail "oneshot: expected exit 3 from failing terminal node, got $OSF_RC"
+fi
+
+rm -f "$OS_OUT" "$OS_ERR"
+"$VELD_BIN" stop --name "$OS_RUN" >/dev/null 2>&1 || true
+"$VELD_BIN" stop --name "$OSF_RUN" >/dev/null 2>&1 || true
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/website/index.html
+++ b/website/index.html
@@ -362,6 +362,7 @@ veld share <span class="kw">--web</span>
       <div class="grid">
         <div class="cell"><h3>No port numbers</h3><p>Real names like <code>frontend.my-feature.localhost</code> instead of <code>localhost:3847</code>.</p></div>
         <div class="cell"><h3>Starts things in the right order</h3><p>Works out what depends on what, starts it all (in parallel where it can), and shuts down cleanly in reverse.</p></div>
+        <div class="cell"><h3>Run your e2e tests on it</h3><p>Point <code>veld start --oneshot</code> at a test command: it spins up every service the tests need, runs them, prints the results, then tears it all down — and the test's exit code becomes veld's. One line in CI.</p></div>
         <div class="cell"><h3>Real HTTPS, no warnings</h3><p>Every URL is <code>https://</code> with a trusted certificate. Set up once — no browser warnings.</p></div>
         <div class="cell"><h3>Waits until things are ready</h3><p>You don't get a URL until the service actually responds — and veld keeps watching after it's up.</p></div>
         <div class="cell"><h3>Restarts what crashes</h3><p>If a service falls over, veld brings the environment back on its own.</p></div>
@@ -386,6 +387,7 @@ veld share <span class="kw">--web</span>
         <h3>Environments</h3>
         <div class="cli-row"><code>veld start NODE:VARIANT --name N</code><span>Start an environment</span></div>
         <div class="cli-row"><code>veld start PRESET --name N</code><span>Start a preset — a saved selection of nodes (e.g. <code>fullstack</code>)</span></div>
+        <div class="cli-row"><code>veld start NODE --oneshot</code><span>Run a command node as a one-off — start its deps, run it to completion, tear down, exit with its code (e.g. e2e tests)</span></div>
         <div class="cli-row"><code>veld stop [--name N] [--all]</code><span>Stop a running environment</span></div>
         <div class="cli-row"><code>veld restart [--name N]</code><span>Restart an environment</span></div>
         <div class="cli-row"><code>veld status [--name N]</code><span>Show run status</span></div>

--- a/website/llms-full.txt
+++ b/website/llms-full.txt
@@ -116,6 +116,7 @@ veld stop --name dev
 | Command | Description |
 |---------|-------------|
 | `veld start [NODE:VARIANT...] --name <n> [-d]` | Start an environment (`-d` for detached) |
+| `veld start <NODE:VARIANT> --oneshot [--all-logs]` | Run a command node as a one-off: start its dependencies, run it to completion (streaming its output), tear everything down in reverse order, and exit with its exit code. The e2e-test / CI pattern (like `docker compose run --rm --abort-on-container-exit`). Only the terminal node's output goes to stdout unless `--all-logs`. |
 | `veld stop [--name <n>] [--all]` | Stop a running environment |
 | `veld restart [--name <n>]` | Restart an environment |
 | `veld status [--name <n>] [--json]` | Show run status |


### PR DESCRIPTION
## What & why

Adds **`veld start <node> --oneshot`**: turn a `command` node into the run's
**terminal node**. Veld starts the node's dependency closure, waits for it to be
healthy, runs the node to completion **streaming its output live**, and the
moment it exits tears the whole environment down in reverse dependency order and
exits with the node's exit code.

It's the local-dev / CI analog of `docker compose run --rm --abort-on-container-exit
--exit-code-from`, and it makes end-to-end test setups trivial: one command
brings up every backend/web app the tests need, runs the suite, prints results,
and cleans up — with the suite's pass/fail becoming the process exit code.

```sh
veld start e2e --oneshot            # deps up → run e2e → teardown → exit w/ its code
veld start e2e --oneshot --all-logs # also interleave dependency logs (on stderr)
```

## Design decisions

- **Surface:** a boolean `--oneshot` modifier on `veld start` (not a new `veld
  run` subcommand — "run" is already the environment-instance noun). The single
  selected node is the terminal one-off; its deps start automatically.
- **stdout carries only the terminal node's stdout.** All of veld's own chrome
  (startup summary, progress NDJSON, teardown lines) **and tracing logs** now go
  to **stderr**, so CI/agents can capture stdout and get just the program
  output. Dependency logs are recorded (`veld logs --node <dep>`), not streamed;
  `--all-logs` interleaves them on stderr. Codified as an AGENTS.md convention.
- **Exit code is the node's own.** A non-zero exit (failing tests) is the node's
  *result*, not a startup error — captured and propagated, never raised as
  `NodeFailed`. A post-completion `save_state` failure can't override it.
- **Must be a `command` node** (a `start_server` never exits); rejected
  otherwise with a clear message.

## Implementation

- `process::run_command_streaming` — drains stdout/stderr via one spawned task
  each (cancel-safe; prevents pipe-buffer deadlock during kill), lossy-decodes
  lines (a non-UTF-8 byte replaces one char instead of truncating the stream),
  peels `VELD_OUTPUT` control lines off stdout, forwards+timestamps the rest,
  runs the child in its own process group so Ctrl+C is forwarded by killing the
  group (exit 130, bounded post-kill drain).
- `Orchestrator`: the terminal node is skipped during startup stages (its deps
  run) and executed afterward by `run_terminal`, appended last to
  `execution_order` so reverse-order teardown runs its `on_stop` first. A single
  `is_terminal` helper routes every plan pass.
- CLI: `--oneshot` / `--all-logs` on `veld start` with validation.
- `init_tracing` now writes to stderr.

## Tests

- Unit: `run_command_streaming` exit-code propagation, no-output, and non-UTF-8
  survival; `run_terminal` exit-code propagation + persistence + execution-order.
- Integration (`tests/integration.sh`, runs in CI under sudo): a `--oneshot`
  case asserting exit 0, stdout purity (result present, chrome absent), teardown
  ran, and non-zero exit propagation.
- Manual smoke against `testproject` (added an `e2e` example node): stdout is
  pure test output on success, exit 3 propagates on failure.

## Review

Two full adversarial review rounds (5-angle then 3-angle) per
`docs/agentic-review.md`. 0 criticals throughout; all majors fixed and verified
(stdout purity incl. tracing→stderr, exit-code-vs-persist-failure, non-UTF-8
truncation, missing tests, startup-interrupt stdout leak). Deferred (noted, not
blocking): dependencies aren't health-monitored while the node runs; the
mid-flight terminal node shows `Pending` in `veld status`; no `--json` summary
on `start`. Docs updated: README, docs/configuration.md, skills, website +
llms-full.txt, AGENTS.md.

## Known unrelated flakiness

`port::tests::{test_available_port_is_detected,test_reservation_holds_port}`
(pre-existing, in untouched `port.rs`) intermittently fail locally because they
bind real ephemeral ports. Not touched by this PR.
