### PR TITLE
feat(desktop): IDE polish — per-row run controls, emoji picker, ⌘K command palette

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4324,7 +4324,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "veld"
-version = "10.10.0"
+version = "10.11.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4344,7 +4344,7 @@ dependencies = [
 
 [[package]]
 name = "veld-core"
-version = "10.10.0"
+version = "10.11.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -4367,7 +4367,7 @@ dependencies = [
 
 [[package]]
 name = "veld-daemon"
-version = "10.10.0"
+version = "10.11.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4393,7 +4393,7 @@ dependencies = [
 
 [[package]]
 name = "veld-gateway"
-version = "10.10.0"
+version = "10.11.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4424,7 +4424,7 @@ dependencies = [
 
 [[package]]
 name = "veld-helper"
-version = "10.10.0"
+version = "10.11.0"
 dependencies = [
  "anyhow",
  "nix",
@@ -4440,7 +4440,7 @@ dependencies = [
 
 [[package]]
 name = "veld-share"
-version = "10.10.0"
+version = "10.11.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/crates/veld-core/src/db/mod.rs
+++ b/crates/veld-core/src/db/mod.rs
@@ -24,7 +24,10 @@ mod stats;
 mod worktrees;
 
 pub use logs::{LogFilter, LogRow, LogStream, stream_is_per_node};
-pub use worktrees::{DiscoveredWorktree, RepoRecord, WorktreeRecord, default_alias};
+pub use worktrees::{
+    DiscoveredWorktree, RepoRecord, WORKTREE_EMOJI, WorktreeRecord, default_alias,
+    is_worktree_emoji,
+};
 
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, MutexGuard};
@@ -54,6 +57,9 @@ pub enum DbError {
          (this binary supports up to v{supported}) — run `veld update` to upgrade"
     )]
     NewerSchema { found: i64, supported: i64 },
+
+    #[error("{0:?} is not one of the curated worktree glyphs")]
+    InvalidEmoji(String),
 
     #[error("database error: {0}")]
     Sqlite(#[from] rusqlite::Error),

--- a/crates/veld-core/src/db/worktrees.rs
+++ b/crates/veld-core/src/db/worktrees.rs
@@ -32,8 +32,13 @@ pub struct WorktreeRecord {
     pub branch: String,
     pub alias: String,
     /// Visual identifier for dense UI (collapsed rail): one emoji from
-    /// [`WORKTREE_EMOJI`], unique across ALL repos' worktrees while free
-    /// choices remain. Assigned at insert, preserved across syncs/renames.
+    /// [`WORKTREE_EMOJI`]. Assigned at insert, preserved across syncs and
+    /// renames.
+    ///
+    /// **Not an identity.** Uniqueness is a property of *assignment* only —
+    /// [`pick_emoji`] probes for a free glyph across all repos, but
+    /// [`Db::patch_worktree`] lets the user pick one that is already taken.
+    /// Don't add a `UNIQUE` index, and don't assume one holder per glyph.
     pub emoji: String,
     pub is_main: bool,
     pub created_at: String,
@@ -247,6 +252,37 @@ impl Db {
         Ok(n > 0)
     }
 
+    /// Update alias and/or emoji in ONE statement. Returns whether the row
+    /// existed.
+    ///
+    /// A single `UPDATE … COALESCE` rather than two writes: applied
+    /// separately, a row deleted between them (concurrent `sync_worktrees`
+    /// prune, or `DELETE /api/worktrees/{id}`) commits the rename and then
+    /// reports "not found" — a partial write the API's contract denies.
+    /// `None` leaves a column untouched; both `None` is a no-op write that
+    /// still reports whether the row exists (the HTTP layer rejects an empty
+    /// patch before reaching here).
+    pub fn patch_worktree(
+        &self,
+        id: i64,
+        alias: Option<&str>,
+        emoji: Option<&str>,
+    ) -> Result<bool, DbError> {
+        if let Some(e) = emoji {
+            if !is_worktree_emoji(e) {
+                return Err(DbError::InvalidEmoji(e.to_owned()));
+            }
+        }
+        let conn = self.lock();
+        let n = conn.execute(
+            "UPDATE worktrees
+                SET alias = COALESCE(?1, alias), emoji = COALESCE(?2, emoji)
+              WHERE id = ?3",
+            params![alias, emoji, id],
+        )?;
+        Ok(n > 0)
+    }
+
     /// Delete a worktree row (DB only — `git worktree remove` is the caller's
     /// job). Returns whether the row existed.
     pub fn remove_worktree(&self, id: i64) -> Result<bool, DbError> {
@@ -285,6 +321,21 @@ pub const WORKTREE_EMOJI: &[&str] = &[
     "🦖", "🦕", "🐙", "🦑", "🦐", "🦞", "🦀", "🐡", "🐠", "🐟", "🐬", "🐳", "🐋", "🦈", "🐊", "🐅",
     "🐆", "🦓", "🦍", "🦧", "🐘", "🦛", "🦏", "🐪", "🐫", "🦒", "🦘", "🐃", "🐂", "🐄", "🐎", "🐐",
 ];
+
+/// Whether `emoji` is one of the curated glyphs.
+///
+/// An allowlist rather than a "is this a single grapheme?" test: it keeps the
+/// rail visually uniform and leaves no room for a multi-codepoint sequence or
+/// a zero-width payload. Every entry is a single code point, so plain string
+/// equality is sufficient — no normalization surface.
+///
+/// Entries may be **appended but never removed or replaced**: the value is
+/// persisted per worktree, so dropping one orphans every row holding it (the
+/// picker would show no current selection and the glyph could never be
+/// re-picked).
+pub fn is_worktree_emoji(emoji: &str) -> bool {
+    WORKTREE_EMOJI.contains(&emoji)
+}
 
 /// Pick an emoji for a new worktree: hash the alias into the curated list
 /// and probe forward for one not used by ANY worktree row (uniqueness across
@@ -464,6 +515,109 @@ mod tests {
             db.get_worktree(wa[0].id).unwrap().unwrap().emoji,
             wa[0].emoji
         );
+    }
+
+    #[test]
+    fn explicit_emoji_survives_sync_and_rename() {
+        let (_dir, db) = test_db();
+        let root = Path::new("/tmp/repoEmojiSet");
+        db.upsert_repo(root, "set").unwrap();
+        let wts = db
+            .sync_worktrees(root, &[wt("/tmp/repoEmojiSet", "main", true)])
+            .unwrap();
+        let id = wts[0].id;
+
+        // Pick a glyph the assigner did not hand out, so the assertion can't
+        // pass by coincidence.
+        let chosen = WORKTREE_EMOJI
+            .iter()
+            .find(|e| **e != wts[0].emoji)
+            .expect("curated set has more than one glyph");
+        assert!(db.patch_worktree(id, None, Some(chosen)).unwrap());
+        assert_eq!(&db.get_worktree(id).unwrap().unwrap().emoji, chosen);
+
+        // Reconciliation backfills only empty emoji — an explicit choice must
+        // not be clobbered by the UI's 5s refresh poll.
+        db.sync_worktrees(root, &[wt("/tmp/repoEmojiSet", "main", true)])
+            .unwrap();
+        assert_eq!(&db.get_worktree(id).unwrap().unwrap().emoji, chosen);
+
+        db.rename_worktree(id, "renamed").unwrap();
+        assert_eq!(&db.get_worktree(id).unwrap().unwrap().emoji, chosen);
+    }
+
+    #[test]
+    fn patch_rejects_glyphs_outside_the_curated_set() {
+        // The EMOJI rule lives here, not only in the HTTP handler, so a CLI
+        // or IPC caller can't persist an arbitrary glyph. Note the asymmetry:
+        // `alias` is still validated only by the handler (`validate_alias`).
+        let (_dir, db) = test_db();
+        for bad in ["", "🍕", "🦊🦊", "👨‍👩‍👧", "not-an-emoji"] {
+            assert!(
+                matches!(
+                    db.patch_worktree(1, None, Some(bad)),
+                    Err(DbError::InvalidEmoji(_))
+                ),
+                "{bad:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn curated_emoji_set_has_no_duplicates() {
+        // `pick_emoji`'s uniqueness probe and the picker's React `key` both
+        // assume this; a duplicate would be a silent runtime defect.
+        let unique: std::collections::HashSet<_> = WORKTREE_EMOJI.iter().collect();
+        assert_eq!(unique.len(), WORKTREE_EMOJI.len());
+    }
+
+    #[test]
+    fn patch_worktree_applies_fields_independently_and_atomically() {
+        let (_dir, db) = test_db();
+        let root = Path::new("/tmp/repoPatch");
+        db.upsert_repo(root, "patch").unwrap();
+        let id = db
+            .sync_worktrees(root, &[wt("/tmp/repoPatch", "main", true)])
+            .unwrap()[0]
+            .id;
+        let original = db.get_worktree(id).unwrap().unwrap();
+        let glyph = WORKTREE_EMOJI
+            .iter()
+            .find(|e| **e != original.emoji)
+            .unwrap();
+
+        // None leaves a column untouched.
+        assert!(db.patch_worktree(id, Some("renamed"), None).unwrap());
+        let after = db.get_worktree(id).unwrap().unwrap();
+        assert_eq!(after.alias, "renamed");
+        assert_eq!(after.emoji, original.emoji);
+
+        assert!(db.patch_worktree(id, None, Some(glyph)).unwrap());
+        let after = db.get_worktree(id).unwrap().unwrap();
+        assert_eq!(after.alias, "renamed");
+        assert_eq!(&after.emoji, glyph);
+
+        // Both at once.
+        assert!(
+            db.patch_worktree(id, Some("both"), Some(&original.emoji))
+                .unwrap()
+        );
+        let after = db.get_worktree(id).unwrap().unwrap();
+        assert_eq!(after.alias, "both");
+        assert_eq!(after.emoji, original.emoji);
+
+        // A rejected emoji must not commit the alias that travelled with it.
+        assert!(db.patch_worktree(id, Some("nope"), Some("🍕")).is_err());
+        assert_eq!(db.get_worktree(id).unwrap().unwrap().alias, "both");
+
+        // Neither field: a no-op write that still reports row existence.
+        assert!(db.patch_worktree(id, None, None).unwrap());
+        let after = db.get_worktree(id).unwrap().unwrap();
+        assert_eq!(after.alias, "both");
+        assert_eq!(after.emoji, original.emoji);
+
+        assert!(!db.patch_worktree(4242, Some("x"), None).unwrap());
+        assert!(!db.patch_worktree(4242, None, None).unwrap());
     }
 
     #[test]

--- a/crates/veld-daemon/src/desktop.rs
+++ b/crates/veld-daemon/src/desktop.rs
@@ -237,7 +237,17 @@ fn db_err(e: impl std::fmt::Display) -> ApiError {
 /// This keeps the DB-layer rejection honest either way.
 fn write_err(e: veld_core::db::DbError) -> ApiError {
     match e {
-        veld_core::db::DbError::InvalidEmoji(_) => err(StatusCode::BAD_REQUEST, e.to_string()),
+        // Fixed message, value only to the log: the variant's Display
+        // Debug-formats the rejected string, and echoing unbounded
+        // client-supplied input back into a response body is a habit worth
+        // not starting.
+        veld_core::db::DbError::InvalidEmoji(_) => {
+            warn!("rejected worktree emoji: {e}");
+            err(
+                StatusCode::BAD_REQUEST,
+                "emoji must be one of the curated worktree glyphs",
+            )
+        }
         other => db_err(other),
     }
 }

--- a/crates/veld-daemon/src/desktop.rs
+++ b/crates/veld-daemon/src/desktop.rs
@@ -27,8 +27,13 @@ use super::management::{check_csrf, is_safe_identifier, open_db, spawn_veld, val
 /// HTTP server alongside the management routes).
 ///
 /// CSRF is enforced as a LAYER, not per handler: every non-GET request on
-/// this router must carry `X-Veld-Request` (see `check_csrf`), so a future
-/// mutating route cannot ship ungated by forgetting a call.
+/// this router must carry `X-Veld-Request` (see `check_csrf`), so a mutating
+/// route cannot ship ungated by forgetting a per-handler call.
+///
+/// **Add new routes ABOVE the `.layer(...)` call.** axum applies middleware
+/// only to routes registered before it — "Additional routes added after
+/// `layer` is called will not have the middleware added" — so a `.route()`
+/// appended after it would be silently unprotected.
 pub fn routes() -> Router {
     Router::new()
         .route("/api/repos", get(list_repos).delete(remove_repo))
@@ -37,9 +42,10 @@ pub fn routes() -> Router {
         .route("/api/worktrees", post(create_worktree))
         .route(
             "/api/worktrees/{id}",
-            patch(rename_worktree).delete(delete_worktree),
+            patch(patch_worktree).delete(delete_worktree),
         )
         .route("/api/worktrees/{id}/start", post(start_worktree_run))
+        .route("/api/worktree-emoji", get(worktree_emoji))
         .route("/api/pick-directory", post(pick_directory))
         .layer(axum::middleware::from_fn(csrf_layer))
 }
@@ -223,6 +229,19 @@ fn db_err(e: impl std::fmt::Display) -> ApiError {
     err(StatusCode::INTERNAL_SERVER_ERROR, "database error")
 }
 
+/// Like [`db_err`], but reports a rejected value as the client error it is.
+///
+/// The handlers validate before writing, so `InvalidEmoji` shouldn't surface
+/// here — but that makes the handler-side check look redundant, and deleting
+/// it would silently downgrade a helpful 400 into a "database error" 500.
+/// This keeps the DB-layer rejection honest either way.
+fn write_err(e: veld_core::db::DbError) -> ApiError {
+    match e {
+        veld_core::db::DbError::InvalidEmoji(_) => err(StatusCode::BAD_REQUEST, e.to_string()),
+        other => db_err(other),
+    }
+}
+
 fn open_desktop_db() -> Result<Db, ApiError> {
     open_db().map_err(|code| err(code, "failed to open the veld database"))
 }
@@ -349,6 +368,26 @@ fn validate_alias(alias: &str) -> Result<(), ApiError> {
         return Err(err(
             StatusCode::BAD_REQUEST,
             "alias must be 1-64 characters: letters, digits, '-', '_', '.'",
+        ));
+    }
+    Ok(())
+}
+
+/// The glyphs `validate_emoji` accepts, for the UI's picker. Served rather
+/// than duplicated in TypeScript so the two can never drift; static, so the
+/// picker fetches it once on open instead of riding the 5s poll.
+async fn worktree_emoji() -> Json<serde_json::Value> {
+    Json(serde_json::json!({ "emoji": veld_core::db::WORKTREE_EMOJI }))
+}
+
+/// Turn the curated-set check into a 400 before any DB work. The rule itself
+/// lives in `veld_core::db::is_worktree_emoji`, next to the constant — this
+/// is only the HTTP shape of it.
+fn validate_emoji(emoji: &str) -> Result<(), ApiError> {
+    if !veld_core::db::is_worktree_emoji(emoji) {
+        return Err(err(
+            StatusCode::BAD_REQUEST,
+            "emoji must be one of the curated worktree glyphs",
         ));
     }
     Ok(())
@@ -688,18 +727,56 @@ async fn create_worktree(
     Ok(Json(worktree_view(created)))
 }
 
+/// Partial update. Both fields are optional so the alias-only callers that
+/// predate the emoji field stay wire-compatible; at least one must be present
+/// or the request is a no-op worth rejecting.
+///
+/// `deny_unknown_fields` so a client-side typo (`{"emojii": "🦊"}`) is a 422
+/// (axum rejects at deserialization) rather than a silent 200 that changed
+/// nothing — with every field optional there is otherwise no signal at all.
 #[derive(Deserialize)]
-struct RenameBody {
-    alias: String,
+#[serde(deny_unknown_fields)]
+struct PatchWorktreeBody {
+    #[serde(default)]
+    alias: Option<String>,
+    #[serde(default)]
+    emoji: Option<String>,
 }
 
-async fn rename_worktree(
+impl PatchWorktreeBody {
+    /// Derived from the fields, so adding a third can't leave the
+    /// "nothing to update" guard silently behind.
+    fn is_empty(&self) -> bool {
+        let Self { alias, emoji } = self;
+        alias.is_none() && emoji.is_none()
+    }
+}
+
+async fn patch_worktree(
     Path(id): Path<i64>,
-    Json(body): Json<RenameBody>,
+    Json(body): Json<PatchWorktreeBody>,
 ) -> Result<Json<WorktreeView>, ApiError> {
-    validate_alias(&body.alias)?;
+    if body.is_empty() {
+        return Err(err(
+            StatusCode::BAD_REQUEST,
+            "nothing to update: send an alias, an emoji, or both",
+        ));
+    }
+    // Validate everything before touching the database: a request carrying a
+    // good alias and a bad emoji must change neither.
+    if let Some(alias) = &body.alias {
+        validate_alias(alias)?;
+    }
+    if let Some(emoji) = &body.emoji {
+        validate_emoji(emoji)?;
+    }
+
     let db = open_desktop_db()?;
-    if !db.rename_worktree(id, &body.alias).map_err(db_err)? {
+    // One statement for both columns — see `Db::patch_worktree`.
+    let existed = db
+        .patch_worktree(id, body.alias.as_deref(), body.emoji.as_deref())
+        .map_err(write_err)?;
+    if !existed {
         return Err(err(StatusCode::NOT_FOUND, "worktree not found"));
     }
     let wt = db
@@ -871,6 +948,18 @@ mod tests {
         assert!(validate_alias("").is_err());
     }
 
+    #[test]
+    fn emoji_validation_is_an_allowlist() {
+        assert!(validate_emoji(veld_core::db::WORKTREE_EMOJI[0]).is_ok());
+        assert!(validate_emoji("").is_err());
+        // Not in the curated set, though a perfectly valid emoji.
+        assert!(validate_emoji("🍕").is_err());
+        // Multi-codepoint sequences and zero-width payloads stay out.
+        assert!(validate_emoji("🦊🦊").is_err());
+        assert!(validate_emoji("👨‍👩‍👧").is_err());
+        assert!(validate_emoji("🦊\u{200b}").is_err());
+    }
+
     // Handler-level guards. These paths reject before any database access, so
     // they run against the real router with no test DB.
     mod handler_guards {
@@ -922,6 +1011,38 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn misspelled_patch_field_is_rejected_not_silently_ignored() {
+            // Every field is optional, so without `deny_unknown_fields` a
+            // client typo would 200 having changed nothing. axum's Json
+            // extractor rejects at deserialization, hence 422 rather than
+            // the 400 the hand-written guards return.
+            let res = super::super::routes()
+                .oneshot(req("PATCH", "/api/worktrees/1", true, r#"{"emojii":"🦊"}"#))
+                .await
+                .unwrap();
+            assert_eq!(res.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        }
+
+        #[tokio::test]
+        async fn worktree_emoji_is_a_public_get_returning_the_curated_set() {
+            // Pins the route, the CSRF exemption, and the `emoji` key the UI
+            // destructures (`api.ts` declares `{ emoji: string[] }`) —
+            // renaming either side would otherwise fail silently at runtime.
+            let res = super::super::routes()
+                .oneshot(req("GET", "/api/worktree-emoji", false, ""))
+                .await
+                .unwrap();
+            assert_eq!(res.status(), StatusCode::OK);
+            let body = axum::body::to_bytes(res.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+            let list = json["emoji"].as_array().expect("`emoji` array");
+            assert_eq!(list.len(), veld_core::db::WORKTREE_EMOJI.len());
+            assert!(veld_core::db::is_worktree_emoji(list[0].as_str().unwrap()));
+        }
+
+        #[tokio::test]
         async fn invalid_inputs_are_400_before_side_effects() {
             for (method, uri, body) in [
                 // relative import path
@@ -934,6 +1055,17 @@ mod tests {
                 ),
                 // dot alias
                 ("PATCH", "/api/worktrees/1", r#"{"alias":".."}"#),
+                // emoji outside the curated set
+                ("PATCH", "/api/worktrees/1", r#"{"emoji":"🍕"}"#),
+                // a valid alias must not smuggle an invalid emoji past
+                // validation — both are checked before any write
+                (
+                    "PATCH",
+                    "/api/worktrees/1",
+                    r#"{"alias":"ok","emoji":"nope"}"#,
+                ),
+                // empty patch
+                ("PATCH", "/api/worktrees/1", "{}"),
             ] {
                 let res = super::super::routes()
                     .oneshot(req(method, uri, true, body))

--- a/crates/veld-daemon/ui/src/App.tsx
+++ b/crates/veld-daemon/ui/src/App.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   api,
+  type EmojiHolder,
   type EnvironmentList,
   type Repo,
   type RepoList,
@@ -8,10 +9,16 @@ import {
 } from "./api";
 import {
   activeRun,
-  filterWorktrees,
+  bestFuzzyMatch,
+  fuzzyMatch,
+  prunePending,
+  runSignature,
   runsForWorktree,
   sortedUrls,
   worktreeStatus,
+  type PendingAction,
+  type PendingMap,
+  type WorktreeStatus,
 } from "./model";
 import { Wordmark } from "./components/Wordmark";
 import {
@@ -54,10 +61,15 @@ import { theme as mantineTheme } from "./theme";
 import { RunsMode } from "./runs/RunsMode";
 import {
   StartConfig,
-  type StartSelection,
   defaultStartSelection,
+  parseStartSelection,
+  pruneStartSelection,
+  resolveStartSelection,
+  startBody,
+  startStorageKey,
 } from "./components/StartConfig";
 import {
+  ChangeEmojiDialog,
   ImportRepoDialog,
   Modal,
   NewWorktreeDialog,
@@ -68,6 +80,11 @@ import {
 import { topbarClass } from "./shell";
 
 const POLL_MS = 5000;
+
+/** How long an optimistic pending marker survives without an observed run
+ *  signature change. Several polls' worth, so a slow `veld start` isn't cut
+ *  off. */
+const PENDING_TTL_MS = 60_000;
 
 function usePersisted(key: string, initial: string): [string, (v: string) => void] {
   const [value, setValue] = useState(
@@ -123,10 +140,6 @@ function useUrlSelection(): {
       setWtState(key);
     },
   };
-}
-
-function canRunWorktree(w: Worktree): boolean {
-  return w.has_veld_config;
 }
 
 /**
@@ -234,6 +247,12 @@ function AppInner(props: {
   const [envs, setEnvs] = useState<EnvironmentList | null>(null);
   const [offline, setOffline] = useState(false);
 
+  // Known, accepted: refreshes are not sequenced. A poll issued before a
+  // mutation but resolving after it writes the pre-mutation payload back, so
+  // a rename or emoji change can visibly revert for up to one poll before
+  // settling. Fixing it needs a monotonic request counter guarding the
+  // setters; not worth it while every mutation is followed by its own
+  // `refresh()`.
   const refresh = useCallback(async () => {
     try {
       // refreshRepos (not the plain GET): reconciles worktree rows with git
@@ -250,9 +269,16 @@ function AppInner(props: {
     }
   }, []);
 
+  // Tick counter, bumped per poll. Effects that must re-evaluate on a
+  // schedule (not only when the payload changes) depend on it — a failed
+  // refresh leaves `envs`/`repoList` at the same identity.
+  const [poll, setPoll] = useState(0);
   useEffect(() => {
     void refresh();
-    const t = window.setInterval(() => void refresh(), POLL_MS);
+    const t = window.setInterval(() => {
+      setPoll((n) => n + 1);
+      void refresh();
+    }, POLL_MS);
     return () => window.clearInterval(t);
   }, [refresh]);
 
@@ -306,65 +332,111 @@ function AppInner(props: {
   // Start configuration (preset or explicit node selections), remembered
   // per worktree. Falls back to a sensible default: first preset, else all
   // nodes at their default variants.
-  const startKey = worktree ? `veld.start.${worktree.path}` : "veld.start._";
+  // Reactive copy for the top bar's StartConfig; the rail's per-row controls
+  // read the same storage through `resolveStartSelection` instead, since a
+  // hook can't be called per row.
+  const startKey = startStorageKey(worktree?.path ?? "_");
   const [startRaw, setStartRaw] = usePersisted(startKey, "");
-  let startSel: StartSelection | null = null;
-  try {
-    startSel = startRaw ? (JSON.parse(startRaw) as StartSelection) : null;
-  } catch {
-    startSel = null;
-  }
-  // Prune stale stored choices (preset renamed away, node removed).
-  if (startSel && worktree) {
-    if (startSel.kind === "preset" && !worktree.presets.includes(startSel.name)) {
-      startSel = null;
-    }
-    if (startSel?.kind === "nodes") {
-      const valid = new Set(
-        worktree.nodes.flatMap((n) => n.variants.map((v) => `${n.name}:${v}`)),
-      );
-      startSel = {
-        kind: "nodes",
-        selections: startSel.selections.filter((s) => valid.has(s)),
-      };
-      if (startSel.selections.length === 0) startSel = null;
-    }
-  }
-  const effectiveStart =
-    startSel ?? (worktree ? defaultStartSelection(worktree) : null);
+  const effectiveStart = worktree
+    ? (pruneStartSelection(worktree, parseStartSelection(startRaw)) ??
+      defaultStartSelection(worktree))
+    : null;
 
-  // Optimistic pending marker while a 202'd start/stop/restart takes effect —
-  // keyed to the worktree it was fired on (NOT a single global flag), so
-  // future per-row controls can't strand a spinner: it clears when THAT
-  // worktree's status changes.
-  const [pending, setPendingState] = useState<{
-    worktreeId: number;
-    label: string;
-    statusAtSet: string;
-  } | null>(null);
+  // Optimistic pending markers while 202'd start/stop/restarts take effect,
+  // keyed by worktree: the rail can fire actions on several rows at once, and
+  // a single global slot would let the second overwrite the first's marker
+  // and strand its spinner. Each entry clears when THAT worktree's run
+  // signature moves off the value it had when the action was fired.
+  const [pending, setPending] = useState<PendingMap>({});
+  // Every loaded worktree, not just the selected repo's: switching projects
+  // mid-action must not look like the worktree vanished, or the marker is
+  // dropped and the re-enabled control invites a double fire.
+  const allWorktrees = useMemo(
+    () => repos.flatMap((r) => r.worktrees),
+    [repos],
+  );
   useEffect(() => {
-    if (!pending) return;
-    const wt = worktrees.find((w) => w.id === pending.worktreeId);
-    const current = wt ? worktreeStatus(runsForWorktree(envs, wt)) : "gone";
-    if (current !== pending.statusAtSet) setPendingState(null);
-  }, [envs, worktrees, pending]);
-  const pendingFor = (w: Worktree | null) =>
-    pending && w && pending.worktreeId === w.id ? pending.label : null;
+    setPending((cur) =>
+      prunePending(cur, Date.now(), (id) => {
+        const wt = allWorktrees.find((w) => w.id === id);
+        return wt ? runSignature(runsForWorktree(envs, wt)) : null;
+      }),
+    );
+    // `poll` is a dependency so the TTL is re-checked on every tick, not only
+    // when the payload changes: a failed refresh leaves `envs` identical, and
+    // without this a marker could never expire while the daemon is down.
+  }, [envs, allWorktrees, poll]);
+  const pendingFor = (w: Worktree | null): PendingAction | null =>
+    w ? (pending[w.id]?.label ?? null) : null;
+
+  /** Run actions make sense only for a worktree of an on-disk repo. */
+  const canRunWorktreeNow = (w: Worktree) =>
+    w.has_veld_config && (repo?.available ?? false);
+
+  /**
+   * Whether ▶ can do anything for this worktree. One predicate for ALL FOUR
+   * entry points (top bar, rail row, context menu, palette) — they disagreed
+   * before: some checked "is anything in flight", others "is there anything
+   * to start", so one surface offered an enabled button whose click was a
+   * silent no-op while another allowed a double-spawned `veld start`.
+   * Declared after `canRunWorktreeNow` on purpose: it closes over it, and
+   * TypeScript does not flag use-before-declaration through a closure.
+   */
+  const canStartWorktree = (w: Worktree) =>
+    canRunWorktreeNow(w) &&
+    pendingFor(w) === null &&
+    resolveStartSelection(w) !== null;
 
   const [actionError, setActionError] = useState<string | null>(null);
-  const act = async (w: Worktree, label: string, fn: () => Promise<void>) => {
+  const act = async (
+    w: Worktree,
+    label: PendingAction,
+    fn: () => Promise<void>,
+  ) => {
     setActionError(null);
-    setPendingState({
-      worktreeId: w.id,
-      label,
-      statusAtSet: worktreeStatus(runsForWorktree(envs, w)),
-    });
+    const sigAtSet = runSignature(runsForWorktree(envs, w));
+    setPending((cur) => ({
+      ...cur,
+      [w.id]: { label, sigAtSet, expiresAt: Date.now() + PENDING_TTL_MS },
+    }));
     try {
       await fn();
     } catch (e) {
-      setPendingState(null);
-      setActionError(e instanceof Error ? e.message : String(e));
+      setPending((cur) => {
+        const next = { ...cur };
+        delete next[w.id];
+        return next;
+      });
+      // Name the worktree: actions now fire from the rail, the context menu
+      // and the palette on ANY row, so an unattributed banner leaves the user
+      // guessing which one failed.
+      const message = e instanceof Error ? e.message : String(e);
+      setActionError(`${w.alias}: ${label} failed — ${message}`);
     }
+  };
+
+  // Run actions for ANY worktree, not just the selected one — the rail rows,
+  // the context menu and the palette all drive these.
+  const startWorktree = (w: Worktree) => {
+    const sel = resolveStartSelection(w);
+    if (!sel) {
+      // Defence in depth: all four ▶ surfaces gate on `canStartWorktree`,
+      // which rejects exactly this case, so this should be unreachable. If a
+      // future caller skips the guard, say what's wrong instead of no-opping.
+      setActionError(
+        `${w.alias}: nothing to start — no presets or startable nodes in its veld.json.`,
+      );
+      return;
+    }
+    void act(w, "start", () => api.startRun(w.id, startBody(sel)));
+  };
+  const stopWorktree = (w: Worktree) => {
+    const r = activeRun(runsForWorktree(envs, w));
+    if (r) void act(w, "stop", () => api.stopRun(r.name));
+  };
+  const restartWorktree = (w: Worktree) => {
+    const r = activeRun(runsForWorktree(envs, w));
+    if (r) void act(w, "restart", () => api.restartRun(r.name));
   };
 
   // ---- dialogs ------------------------------------------------------------
@@ -373,17 +445,66 @@ function AppInner(props: {
     | { kind: "import" }
     | { kind: "new-worktree" }
     | { kind: "rename"; worktree: Worktree; deleteFocus?: boolean }
+    | { kind: "emoji"; worktree: Worktree }
     | { kind: "remove-repo"; repo: Repo }
     | { kind: "search" }
   >({ kind: "none" });
 
+  /**
+   * emoji → every worktree holding it, across all repos. Keyed by id and
+   * carrying ALL holders, not the first alias: aliases are unique only within
+   * a repo (`unique_alias` scopes to one `repo_root`), so two projects both
+   * checked out on `main` — the default case — would otherwise let the picker
+   * mistake another project's glyph for the current worktree's own.
+   */
+  const emojiUsedBy = useMemo(() => {
+    const used: Record<string, EmojiHolder[]> = {};
+    for (const r of repos) {
+      for (const w of r.worktrees) {
+        if (!w.emoji) continue;
+        (used[w.emoji] ??= []).push({ id: w.id, alias: w.alias });
+      }
+    }
+    return used;
+  }, [repos]);
+
   const { showContextMenu } = useContextMenu();
-  const worktreeMenu = (w: Worktree) =>
-    showContextMenu([
+  const worktreeMenu = (w: Worktree) => {
+    const running = worktreeStatus(runsForWorktree(envs, w)) !== "stopped";
+    // Run entries live here as well as on the row, because the collapsed rail
+    // has no space for inline controls and right-click is its only affordance.
+    // `pendingFor` gates every entry: `running` lags a fired action by up to
+    // one poll, so without it the menu keeps offering "Start run" while a
+    // start is already in flight and `veld start` gets spawned twice.
+    const busy = pendingFor(w) !== null;
+    const runItems = canRunWorktreeNow(w)
+      ? [
+          {
+            key: "run",
+            title: running ? "Stop run" : "Start run",
+            disabled: busy || (!running && !canStartWorktree(w)),
+            onClick: () => (running ? stopWorktree(w) : startWorktree(w)),
+          },
+          {
+            key: "restart",
+            title: "Restart run",
+            disabled: busy || !running,
+            onClick: () => restartWorktree(w),
+          },
+          { key: "run-divider" },
+        ]
+      : [];
+    return showContextMenu([
+      ...runItems,
       {
         key: "rename",
         title: "Rename…",
         onClick: () => setDialog({ kind: "rename", worktree: w }),
+      },
+      {
+        key: "emoji",
+        title: "Change emoji…",
+        onClick: () => setDialog({ kind: "emoji", worktree: w }),
       },
       {
         key: "copy-path",
@@ -405,6 +526,7 @@ function AppInner(props: {
           setDialog({ kind: "rename", worktree: w, deleteFocus: true }),
       },
     ]);
+  };
   const closeDialog = () => setDialog({ kind: "none" });
 
   useEffect(() => {
@@ -437,6 +559,171 @@ function AppInner(props: {
       onHover={setSwitchHover}
     />
   );
+
+  /**
+   * Everything ⌘K can reach. Built on demand (only while the palette is open)
+   * rather than memoised: it closes over most of this component's state, and
+   * a correct dependency list would be longer than the function.
+   */
+  const buildPaletteItems = (): PaletteItem[] => {
+    const items: PaletteItem[] = [];
+
+    for (const w of worktrees) {
+      items.push({
+        id: `wt:${w.id}`,
+        group: "Worktrees",
+        label: w.alias,
+        hint: w.branch,
+        alt: [w.branch],
+        emoji: w.emoji,
+        status: worktreeStatus(runsForWorktree(envs, w)),
+        run: () => selectWorktree(w),
+      });
+    }
+
+    if (worktree && canRunWorktreeNow(worktree)) {
+      const w = worktree;
+      const running = status !== "stopped";
+      // Same guard as the rail and the context menu: an action already in
+      // flight must not be offered again a second time.
+      const busy = pendingFor(w) !== null;
+      if (running && !busy) {
+        items.push({
+          id: "run:stop",
+          group: "Run",
+          label: `Stop ${w.alias}`,
+          run: () => stopWorktree(w),
+        });
+        items.push({
+          id: "run:restart",
+          group: "Run",
+          label: `Restart ${w.alias}`,
+          run: () => restartWorktree(w),
+        });
+      } else if (!running && canStartWorktree(w)) {
+        items.push({
+          id: "run:start",
+          group: "Run",
+          label: `Start ${w.alias}`,
+          run: () => startWorktree(w),
+        });
+      }
+      for (const [name, url] of urls) {
+        items.push({
+          id: `url:${name}`,
+          group: "Run",
+          label: `Open ${name}`,
+          hint: url,
+          alt: [url],
+          run: () => window.open(url, "_blank"),
+        });
+      }
+      if (urls.length > 0) {
+        items.push({
+          id: "url:copy-all",
+          group: "Run",
+          label: "Copy all run URLs",
+          run: () =>
+            void navigator.clipboard.writeText(
+              urls.map(([, u]) => u).join("\n"),
+            ),
+        });
+      }
+    }
+
+    if (repo) {
+      items.push({
+        id: "wt:new",
+        group: "Worktree",
+        label: "New worktree…",
+        run: () => setDialog({ kind: "new-worktree" }),
+      });
+    }
+    if (worktree) {
+      const w = worktree;
+      items.push({
+        id: "wt:rename",
+        group: "Worktree",
+        label: `Rename ${w.alias}…`,
+        run: () => setDialog({ kind: "rename", worktree: w }),
+      });
+      items.push({
+        id: "wt:emoji",
+        group: "Worktree",
+        label: `Change emoji for ${w.alias}…`,
+        hint: w.emoji,
+        run: () => setDialog({ kind: "emoji", worktree: w }),
+      });
+      items.push({
+        id: "wt:copy-path",
+        group: "Worktree",
+        label: `Copy path of ${w.alias}`,
+        hint: w.path,
+        alt: [w.path],
+        run: () => void navigator.clipboard.writeText(w.path),
+      });
+      if (!w.is_main) {
+        items.push({
+          id: "wt:remove",
+          group: "Worktree",
+          label: `Remove worktree ${w.alias}…`,
+          run: () =>
+            setDialog({ kind: "rename", worktree: w, deleteFocus: true }),
+        });
+      }
+    }
+
+    for (const r of repos) {
+      if (r.root === repo?.root) continue;
+      items.push({
+        id: `repo:${r.root}`,
+        group: "Projects",
+        label: `Switch to ${r.name}`,
+        hint: r.available ? r.root : "unavailable",
+        alt: [r.root],
+        run: () => {
+          setActiveRepoRoot(r.root);
+          setActiveWtKey("");
+        },
+      });
+    }
+    items.push({
+      id: "repo:import",
+      group: "Projects",
+      label: "Import repository…",
+      run: () => setDialog({ kind: "import" }),
+    });
+    if (repo) {
+      const r = repo;
+      items.push({
+        id: "repo:remove",
+        group: "Projects",
+        label: `Remove project ${r.name}…`,
+        run: () => setDialog({ kind: "remove-repo", repo: r }),
+      });
+    }
+
+    items.push({
+      id: "view:mode",
+      group: "View",
+      label: "Switch to Runs",
+      run: () => setMode("runs"),
+    });
+    items.push({
+      id: "view:rail",
+      group: "View",
+      label: railWide ? "Collapse the worktree rail" : "Expand the worktree rail",
+      run: () => setRailWide((v) => !v),
+    });
+    items.push({
+      id: "view:theme",
+      group: "View",
+      label: "Cycle theme",
+      hint: themePref,
+      run: onCycleTheme,
+    });
+    return items;
+  };
 
   // ---- render -------------------------------------------------------------
   const themeButton = (
@@ -471,7 +758,7 @@ function AppInner(props: {
         repo={repo}
         worktree={worktree}
         startConfig={
-          worktree && canRunWorktree(worktree) ? (
+          worktree && canRunWorktreeNow(worktree) ? (
             <StartConfig
               worktree={worktree}
               value={effectiveStart}
@@ -479,7 +766,7 @@ function AppInner(props: {
             />
           ) : null
         }
-        canStart={effectiveStart !== null}
+        canStart={worktree ? canStartWorktree(worktree) : false}
         running={status !== "stopped"}
         pending={pendingFor(worktree)}
         run={run}
@@ -492,24 +779,9 @@ function AppInner(props: {
         }}
         onImport={() => setDialog({ kind: "import" })}
         onRemoveRepo={() => repo && setDialog({ kind: "remove-repo", repo })}
-        onStart={() => {
-          if (!worktree || !effectiveStart) return;
-          const body =
-            effectiveStart.kind === "preset"
-              ? { preset: effectiveStart.name }
-              : { selections: effectiveStart.selections };
-          void act(worktree, "start", () => api.startRun(worktree.id, body));
-        }}
-        onStop={() =>
-          run &&
-          worktree &&
-          void act(worktree, "stop", () => api.stopRun(run.name))
-        }
-        onRestart={() =>
-          run &&
-          worktree &&
-          void act(worktree, "restart", () => api.restartRun(run.name))
-        }
+        onStart={() => worktree && startWorktree(worktree)}
+        onStop={() => worktree && stopWorktree(worktree)}
+        onRestart={() => worktree && restartWorktree(worktree)}
         onSearch={() => setDialog({ kind: "search" })}
         themeButton={themeButton}
       />
@@ -567,10 +839,15 @@ function AppInner(props: {
             active={worktree}
             envs={envs}
             wide={railWide}
+            canRun={canRunWorktreeNow}
+            canStart={canStartWorktree}
+            pendingFor={pendingFor}
             onToggle={() => setRailWide((v) => !v)}
             onSelect={selectWorktree}
             onAdd={() => setDialog({ kind: "new-worktree" })}
             onMenu={(e, w) => worktreeMenu(w)(e)}
+            onStart={startWorktree}
+            onStop={stopWorktree}
           />
           <TerminalPlaceholder worktree={worktree} />
           <UrlLauncher worktree={worktree} urls={urls} />
@@ -623,7 +900,7 @@ function AppInner(props: {
           deleteFocus={dialog.deleteFocus ?? false}
           onClose={closeDialog}
           onRename={async (alias) => {
-            await api.renameWorktree(dialog.worktree.id, alias);
+            await api.patchWorktree(dialog.worktree.id, { alias });
             await refresh();
             closeDialog();
           }}
@@ -634,15 +911,24 @@ function AppInner(props: {
           }}
         />
       )}
-      {dialog.kind === "search" && (
-        <SearchOverlay
-          project={repo?.name ?? ""}
-          worktrees={worktrees}
-          envs={envs}
-          onSelect={(w) => {
-            selectWorktree(w);
+      {dialog.kind === "emoji" && (
+        <ChangeEmojiDialog
+          current={dialog.worktree.emoji}
+          alias={dialog.worktree.alias}
+          worktreeId={dialog.worktree.id}
+          usedBy={emojiUsedBy}
+          onClose={closeDialog}
+          onPick={async (emoji) => {
+            await api.patchWorktree(dialog.worktree.id, { emoji });
+            await refresh();
             closeDialog();
           }}
+        />
+      )}
+      {dialog.kind === "search" && (
+        <CommandPalette
+          project={repo?.name ?? ""}
+          items={buildPaletteItems()}
           onClose={closeDialog}
         />
       )}
@@ -654,6 +940,14 @@ function AppInner(props: {
 // Top bar
 // ---------------------------------------------------------------------------
 
+/** A single run's status as one of the rail's `.dot` classes. */
+function runStatusClass(status: string): WorktreeStatus {
+  if (status === "running") return "running";
+  if (status === "failed") return "failed";
+  if (status === "stopped") return "stopped";
+  return "partial";
+}
+
 function TopBar(props: {
   modeSwitch: React.ReactNode;
   repos: Repo[];
@@ -662,7 +956,7 @@ function TopBar(props: {
   startConfig: React.ReactNode;
   canStart: boolean;
   running: boolean;
-  pending: string | null;
+  pending: PendingAction | null;
   run: { name: string; status: string } | null;
   urls: Array<[string, string]>;
   urlsOpen: boolean;
@@ -681,12 +975,6 @@ function TopBar(props: {
   // No run controls for a repo we can't see on disk — git/veld actions would
   // only fail later with a worse error.
   const canRun = !!worktree?.has_veld_config && repoAvailable;
-  const statusColor =
-    run?.status === "running"
-      ? "var(--live)"
-      : run?.status === "failed"
-        ? "var(--danger)"
-        : "var(--warn)";
   return (
     <div className={topbarClass}>
       {props.modeSwitch}
@@ -738,13 +1026,19 @@ function TopBar(props: {
           {canRun && props.startConfig}
           {canRun && (
             <>
+              {/* The spinner belongs on the button that was pressed. Putting
+                  it on play/stop for every action made a restart look like a
+                  stop in progress. */}
               <Tooltip label={props.running ? "Stop run" : "Start run"}>
                 <ActionIcon
                   size="md"
                   variant="light"
                   color={props.running ? "red" : "green"}
-                  loading={props.pending !== null}
-                  disabled={!props.running && !props.canStart}
+                  loading={props.pending === "start" || props.pending === "stop"}
+                  disabled={
+                    props.pending !== null ||
+                    (!props.running && !props.canStart)
+                  }
                   onClick={props.running ? props.onStop : props.onStart}
                 >
                   {props.running ? (
@@ -758,20 +1052,30 @@ function TopBar(props: {
                 <ActionIcon
                   size="md"
                   variant="default"
+                  loading={props.pending === "restart"}
                   disabled={!props.running || props.pending !== null}
                   onClick={props.onRestart}
                 >
                   <IconRefresh size={13} />
                 </ActionIcon>
               </Tooltip>
+              {/* Status is a dot, not a word: the text was long enough to be
+                  clipped in a crowded bar, and it duplicated what the
+                  start/stop icon already says. */}
               {run && (
-                <span
-                  className="mono"
-                  style={{ fontSize: 10.5, color: statusColor }}
-                  title={`Run ${run.name}: ${run.status}`}
+                <Tooltip
+                  label={
+                    props.pending
+                      ? `Run ${run.name}: ${props.pending}…`
+                      : `Run ${run.name}: ${run.status}`
+                  }
                 >
-                  {props.pending ? `${props.pending}…` : run.status}
-                </span>
+                  <span
+                    className={`dot ${runStatusClass(run.status)}`}
+                    role="img"
+                    aria-label={`Run ${run.name}: ${props.pending ?? run.status}`}
+                  />
+                </Tooltip>
               )}
               {run && (
                 <>
@@ -875,15 +1179,42 @@ function TopBar(props: {
 // Worktree rail
 // ---------------------------------------------------------------------------
 
+/**
+ * Mantine colour for an in-flight action: what it is doing, not where it ends
+ * up — "stop" is red while it runs, restart reads as a (re)start.
+ *
+ * Exhaustive on purpose. Widening [`PendingAction`] (to cover share actions,
+ * say) must fail the build here rather than silently fall through to green —
+ * the same class of bug as the literal comparisons in `TopBar`.
+ */
+function actionColor(label: PendingAction): string {
+  switch (label) {
+    case "stop":
+      return "red";
+    case "start":
+    case "restart":
+      return "green";
+    default: {
+      const exhaustive: never = label;
+      return exhaustive;
+    }
+  }
+}
+
 function Rail(props: {
   worktrees: Worktree[];
   active: Worktree | null;
   envs: EnvironmentList | null;
   wide: boolean;
+  canRun: (w: Worktree) => boolean;
+  canStart: (w: Worktree) => boolean;
+  pendingFor: (w: Worktree) => PendingAction | null;
   onToggle: () => void;
   onSelect: (w: Worktree) => void;
   onAdd: () => void;
   onMenu: (e: React.MouseEvent, w: Worktree) => void;
+  onStart: (w: Worktree) => void;
+  onStop: (w: Worktree) => void;
 }) {
   return (
     <div className={`rail${props.wide ? " wide" : ""}`}>
@@ -910,36 +1241,99 @@ function Rail(props: {
       <div className="rail-list">
         {props.worktrees.map((w) => {
           const status = worktreeStatus(runsForWorktree(props.envs, w));
+          const running = status !== "stopped";
+          const pending = props.pendingFor(w);
+          // Inline controls are wide-only — a 64px collapsed row has no space
+          // for them. Right-click reaches the same actions in either mode.
+          const showRunControl = props.wide && props.canRun(w);
           return (
-            <button
+            /* A div with role=button, not a <button>: the row carries nested
+               controls of its own, and a <button> inside a <button> violates
+               the content model (the HTML parser closes the OUTER button when
+               it meets the inner start tag; React's createElement path builds
+               the invalid tree instead). Cost of the workaround: role=button
+               takes presentational children, so the nested ▶ and ⋮ are not
+               exposed to assistive tech. The honest fix is role=listbox on
+               .rail-list with role=option rows — deferred, see issue #167. */
+            <div
               key={w.id}
+              role="button"
+              tabIndex={0}
+              /* Selection is "which one am I looking at", not a toggle that
+                 can be un-pressed — aria-current, not aria-pressed. */
+              aria-current={props.active?.id === w.id ? true : undefined}
               className={`wt-row${props.active?.id === w.id ? " active" : ""}${props.wide ? "" : " slim"}`}
               title={`${w.alias} — ${w.branch}`}
               onClick={() => props.onSelect(w)}
+              onKeyDown={(e) => {
+                // Only the row's OWN key events. Keydown bubbles from the
+                // nested buttons, and preventDefault() here would cancel
+                // their native activation — Enter on ▶ would silently select
+                // the row instead of starting the run.
+                if (e.target !== e.currentTarget) return;
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  props.onSelect(w);
+                }
+              }}
               onContextMenu={(e) => props.onMenu(e, w)}
             >
               <span className={`dot ${status}`} />
               {w.emoji && <span className="wt-emoji">{w.emoji}</span>}
               {props.wide && <span className="wt-alias">{w.alias}</span>}
               {props.wide && <span className="wt-branch">{w.branch}</span>}
-              {/* Row is a <button>; nested controls must be role=button
-                  spans with stopPropagation to avoid button-in-button.
-                  Same menu as right-click. */}
+              {showRunControl && (
+                <button
+                  type="button"
+                  className={`wt-run${running ? " on" : ""}`}
+                  title={
+                    pending
+                      ? `${pending}…`
+                      : running
+                        ? `Stop ${w.alias}`
+                        : `Start ${w.alias}`
+                  }
+                  aria-label={running ? `Stop ${w.alias}` : `Start ${w.alias}`}
+                  // Mirrors the context menu and the palette. Without the
+                  // start guard the button looked live but its click hit a
+                  // no-op for a worktree with no presets and no nodes.
+                  disabled={
+                    pending !== null || (!running && !props.canStart(w))
+                  }
+                  onClick={(e) => {
+                    // The row is clickable too; without this, starting a run
+                    // would also switch the selection out from under the user.
+                    e.stopPropagation();
+                    if (running) props.onStop(w);
+                    else props.onStart(w);
+                  }}
+                >
+                  {pending ? (
+                    // The spinner carries the action's colour, so a row that
+                    // is stopping reads as stopping and not as starting.
+                    <Loader size={10} color={actionColor(pending)} />
+                  ) : running ? (
+                    <IconPlayerStopFilled size={10} />
+                  ) : (
+                    <IconPlayerPlayFilled size={10} />
+                  )}
+                </button>
+              )}
               {props.wide && (
-                <span
+                <button
+                  type="button"
                   className="wt-edit"
                   title="Worktree menu"
-                  role="button"
-                  tabIndex={0}
+                  aria-label={`Menu for ${w.alias}`}
                   onClick={(e) => {
                     e.stopPropagation();
                     props.onMenu(e, w);
                   }}
                 >
                   <IconDotsVertical size={12} />
-                </span>
+                </button>
               )}
-            </button>
+            </div>
           );
         })}
       </div>
@@ -1060,48 +1454,191 @@ function ServiceCard(props: { name: string; url: string }) {
 // URLs popover + search overlay
 // ---------------------------------------------------------------------------
 
-function SearchOverlay(props: {
+/** Header order for the idle (no-query) list. Also the grouping key. */
+const PALETTE_GROUPS = ["Worktrees", "Run", "Worktree", "Projects", "View"] as const;
+type PaletteGroup = (typeof PALETTE_GROUPS)[number];
+
+/** One ⌘K entry: a worktree to jump to, or an action to run. */
+interface PaletteItem {
+  id: string;
+  /** Must be one of PALETTE_GROUPS — the idle list is sorted by that order,
+   *  so items need not be declared contiguously by group. */
+  group: PaletteGroup;
+  label: string;
+  /** Dim right-hand detail (branch, URL, path). */
+  hint?: string;
+  /** Extra haystacks the query may match, beyond the label. */
+  alt?: string[];
+  emoji?: string;
+  status?: WorktreeStatus;
+  run: () => void;
+}
+
+/** The label with the fuzzy-matched characters marked. */
+function Highlighted(props: { text: string; positions: number[] }) {
+  if (props.positions.length === 0) return <>{props.text}</>;
+  const hit = new Set(props.positions);
+  const parts: React.ReactNode[] = [];
+  let run = "";
+  let runIsHit = hit.has(0);
+  const flush = (key: number) => {
+    if (!run) return;
+    parts.push(runIsHit ? <mark key={key}>{run}</mark> : run);
+    run = "";
+  };
+  for (let i = 0; i < props.text.length; i++) {
+    const isHit = hit.has(i);
+    if (isHit !== runIsHit) {
+      flush(i);
+      runIsHit = isHit;
+    }
+    run += props.text[i];
+  }
+  flush(props.text.length);
+  return <>{parts}</>;
+}
+
+/**
+ * ⌘K palette: fuzzy search over worktrees *and* commands.
+ *
+ * With no query the items stay in their declared order under group headers —
+ * that reads as a menu of what's available. Once the user types, grouping is
+ * dropped for a single score-ordered list (the group becomes the right-hand
+ * hint), because a global ranking is what "I know what I want" wants.
+ */
+function CommandPalette(props: {
   project: string;
-  worktrees: Worktree[];
-  envs: EnvironmentList | null;
-  onSelect: (w: Worktree) => void;
+  items: PaletteItem[];
   onClose: () => void;
 }) {
   const [query, setQuery] = useState("");
-  const matches = filterWorktrees(props.worktrees, query);
+  // Tracked by item id, not index: `items` is rebuilt on every 5s poll, and a
+  // run transition inserts or removes the Stop/Restart entries — an index
+  // would silently slide onto a different command between the user reading
+  // the row and pressing Enter. `null` = "first match".
+  const [cursorId, setCursorId] = useState<string | null>(null);
+  // Only arrow keys should scroll the list. Following the pointer as well
+  // would yank the view out from under a user who is merely moving the mouse
+  // across it.
+  const scrollToCursor = useRef(false);
+
+  const searching = query.trim().length > 0;
+  const matches = searching
+    ? props.items
+        .map((item) => ({
+          item,
+          match: bestFuzzyMatch([item.label, ...(item.alt ?? [])], query),
+          // Highlight only what matched in the label itself; a hit that came
+          // from a branch or URL has no positions to mark here.
+          label: fuzzyMatch(item.label, query),
+        }))
+        .filter((r) => r.match !== null)
+        .sort((a, b) => b.match!.score - a.match!.score)
+    : // Group the idle list explicitly rather than trusting declaration
+      // order: the single `lastGroup` cursor below would emit a duplicate
+      // header for any item appended out of group order.
+      PALETTE_GROUPS.flatMap((g) =>
+        props.items
+          .filter((item) => item.group === g)
+          .map((item) => ({ item, match: null, label: null })),
+      );
+
+  // Resolve the id back to a position; an id that filtered out falls back to
+  // the top match, which is what a user who just typed expects.
+  const found = matches.findIndex((m) => m.item.id === cursorId);
+  const active = found === -1 ? 0 : found;
+
+  const choose = (item: PaletteItem) => {
+    props.onClose();
+    item.run();
+  };
+
+  const move = (delta: number) => {
+    if (matches.length === 0) return;
+    scrollToCursor.current = true;
+    const next = (active + delta + matches.length) % matches.length;
+    setCursorId(matches[next].item.id);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (matches.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      move(1);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      move(-1);
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      choose(matches[active].item);
+    }
+  };
+
+  let lastGroup = "";
   return (
-    <Modal title={`Search ${props.project}`} onClose={props.onClose}>
+    <Modal
+      title={props.project ? `Search ${props.project}` : "Search"}
+      onClose={props.onClose}
+    >
       <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
         <TextInput
-          placeholder="Search worktrees…"
+          placeholder="Jump to a worktree, or run a command…"
           value={query}
-          onChange={(e) => setQuery(e.currentTarget.value)}
+          onChange={(e) => {
+            setQuery(e.currentTarget.value);
+            setCursorId(null);
+          }}
+          onKeyDown={onKeyDown}
           styles={{
             input: { fontFamily: "var(--mantine-font-family-monospace)" },
           }}
           data-autofocus
         />
-        <div className="section-label">Worktrees</div>
-        {matches.map((w) => {
-          const status = worktreeStatus(runsForWorktree(props.envs, w));
-          return (
-            <button
-              key={w.id}
-              className="wt-row"
-              onClick={() => props.onSelect(w)}
-            >
-              <span className={`dot ${status}`} />
-              {w.emoji && <span className="wt-emoji">{w.emoji}</span>}
-              <span className="wt-alias">{w.alias}</span>
-              <span className="wt-branch">{w.branch}</span>
-              <span style={{ fontSize: 11, color: "var(--faint)" }}>
-                {status}
-              </span>
-            </button>
-          );
-        })}
+        <div className="palette-list">
+          {matches.map(({ item, label }, i) => {
+            const header = !searching && item.group !== lastGroup;
+            if (header) lastGroup = item.group;
+            return (
+              <div key={item.id}>
+                {header && <div className="section-label">{item.group}</div>}
+                <button
+                  type="button"
+                  className={`wt-row${i === active ? " sel" : ""}`}
+                  style={{ width: "100%" }}
+                  ref={
+                    i === active
+                      ? (el) => {
+                          if (!el || !scrollToCursor.current) return;
+                          scrollToCursor.current = false;
+                          el.scrollIntoView({ block: "nearest" });
+                        }
+                      : undefined
+                  }
+                  /* No onMouseEnter cursor sync: scrollIntoView slides rows
+                     under a stationary pointer, whose mouseenter would drag
+                     the cursor back and stall arrow-key navigation. Enter and
+                     click can't disagree anyway — onClick uses this row's own
+                     item, not matches[active]. Hover is :hover in CSS. */
+                  onClick={() => choose(item)}
+                >
+                  {item.status && <span className={`dot ${item.status}`} />}
+                  {item.emoji && <span className="wt-emoji">{item.emoji}</span>}
+                  <span className="pal-label">
+                    <Highlighted
+                      text={item.label}
+                      positions={label?.positions ?? []}
+                    />
+                  </span>
+                  <span className="pal-hint">
+                    {item.hint ?? (searching ? item.group : "")}
+                  </span>
+                </button>
+              </div>
+            );
+          })}
+        </div>
         {matches.length === 0 && (
-          <div className="note-card">No matching worktrees.</div>
+          <div className="note-card">Nothing matches “{query.trim()}”.</div>
         )}
       </div>
     </Modal>

--- a/crates/veld-daemon/ui/src/api.ts
+++ b/crates/veld-daemon/ui/src/api.ts
@@ -79,7 +79,12 @@ export interface Worktree {
   path: string;
   branch: string;
   alias: string;
-  /** Stable one-emoji identifier (animal set), unique across all projects. */
+  /**
+   * One-glyph identifier from a curated animal set. Unique *when assigned*
+   * — the picker lets the user choose a glyph another worktree already holds,
+   * so never treat it as an identity: several worktrees can share one. (An
+   * emoji-keyed index is fine as long as its values are collections.)
+   */
   emoji: string;
   is_main: boolean;
   created_at: string;
@@ -87,6 +92,12 @@ export interface Worktree {
   presets: string[];
   /** Startable nodes (hidden excluded) for custom selections. */
   nodes: NodeOption[];
+}
+
+/** A worktree holding a given emoji — id, because aliases repeat across repos. */
+export interface EmojiHolder {
+  id: number;
+  alias: string;
 }
 
 export interface NodeOption {
@@ -229,11 +240,18 @@ export const api = {
       method: "POST",
       body: JSON.stringify(body),
     }),
-  renameWorktree: (id: number, alias: string) =>
+  /** Partial update — send an alias, an emoji, or both. */
+  patchWorktree: (id: number, patch: { alias?: string; emoji?: string }) =>
     request<Worktree>(`/api/worktrees/${id}`, {
       method: "PATCH",
-      body: JSON.stringify({ alias }),
+      body: JSON.stringify(patch),
     }),
+  /**
+   * The glyphs the emoji picker may offer. Served by the daemon rather than
+   * duplicated here so the picker and the server-side allowlist can't drift.
+   */
+  worktreeEmoji: () =>
+    request<{ emoji: string[] }>("/api/worktree-emoji"),
   deleteWorktree: (id: number, force: boolean) =>
     request<void>(`/api/worktrees/${id}?force=${force}`, { method: "DELETE" }),
   /**

--- a/crates/veld-daemon/ui/src/components/StartConfig.test.ts
+++ b/crates/veld-daemon/ui/src/components/StartConfig.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Worktree } from "../api";
+import {
+  defaultStartSelection,
+  parseStartSelection,
+  pruneStartSelection,
+  resolveStartSelection,
+  startBody,
+  startStorageKey,
+} from "./StartConfig";
+
+const wt = (over: Partial<Worktree> = {}): Worktree => ({
+  id: 1,
+  repo_root: "/repo",
+  path: "/wts/chk",
+  branch: "feat/checkout-v2",
+  alias: "chk",
+  emoji: "🦊",
+  is_main: false,
+  created_at: "2026-01-01T00:00:00Z",
+  has_veld_config: true,
+  presets: [],
+  nodes: [],
+  ...over,
+});
+
+describe("parseStartSelection", () => {
+  it("round-trips both shapes", () => {
+    expect(parseStartSelection(JSON.stringify({ kind: "preset", name: "a" })))
+      .toEqual({ kind: "preset", name: "a" });
+    expect(
+      parseStartSelection(
+        JSON.stringify({ kind: "nodes", selections: ["api:dev"] }),
+      ),
+    ).toEqual({ kind: "nodes", selections: ["api:dev"] });
+  });
+
+  it("rejects anything that isn't a selection", () => {
+    // Stored values outlive schema changes and survive hand-editing; a throw
+    // here would take down the whole app on boot.
+    expect(parseStartSelection("")).toBeNull();
+    expect(parseStartSelection("not json")).toBeNull();
+    expect(parseStartSelection("null")).toBeNull();
+    expect(parseStartSelection('{"kind":"bogus"}')).toBeNull();
+    expect(parseStartSelection('{"kind":"preset"}')).toBeNull();
+    expect(parseStartSelection('{"kind":"nodes","selections":"api"}')).toBeNull();
+  });
+});
+
+describe("pruneStartSelection", () => {
+  const w = wt({
+    presets: ["full"],
+    nodes: [{ name: "api", variants: ["dev", "prod"], default_variant: "dev" }],
+  });
+
+  it("keeps selections the config still offers", () => {
+    expect(pruneStartSelection(w, { kind: "preset", name: "full" })).toEqual({
+      kind: "preset",
+      name: "full",
+    });
+    expect(
+      pruneStartSelection(w, { kind: "nodes", selections: ["api:prod"] }),
+    ).toEqual({ kind: "nodes", selections: ["api:prod"] });
+  });
+
+  it("drops a preset that was renamed away", () => {
+    expect(pruneStartSelection(w, { kind: "preset", name: "gone" })).toBeNull();
+  });
+
+  it("drops node selections the config no longer has", () => {
+    // Partial survival: the valid half is kept.
+    expect(
+      pruneStartSelection(w, {
+        kind: "nodes",
+        selections: ["api:dev", "removed:dev", "api:gone"],
+      }),
+    ).toEqual({ kind: "nodes", selections: ["api:dev"] });
+    // Nothing valid left → null, so the caller falls back to the default
+    // rather than sending an empty list `veld start` would reject.
+    expect(
+      pruneStartSelection(w, { kind: "nodes", selections: ["removed:dev"] }),
+    ).toBeNull();
+  });
+
+  it("passes null through", () => {
+    expect(pruneStartSelection(w, null)).toBeNull();
+  });
+});
+
+describe("defaultStartSelection", () => {
+  it("prefers the first preset", () => {
+    expect(defaultStartSelection(wt({ presets: ["a", "b"] }))).toEqual({
+      kind: "preset",
+      name: "a",
+    });
+  });
+
+  it("falls back to every node at its default variant", () => {
+    expect(
+      defaultStartSelection(
+        wt({
+          nodes: [
+            { name: "api", variants: ["dev", "prod"], default_variant: "prod" },
+            { name: "web", variants: ["dev"] },
+          ],
+        }),
+      ),
+    ).toEqual({ kind: "nodes", selections: ["api:prod", "web:dev"] });
+  });
+
+  it("is null when there is nothing to start", () => {
+    expect(defaultStartSelection(wt())).toBeNull();
+  });
+});
+
+/**
+ * Minimal localStorage for the node test environment (the UI suite runs
+ * without a DOM). `resolveStartSelection` reads through `globalThis`, so
+ * installing this is enough to exercise the real code path.
+ */
+const store = (() => {
+  const map = new Map<string, string>();
+  return {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => void map.set(k, v),
+    removeItem: (k: string) => void map.delete(k),
+    clear: () => map.clear(),
+    key: (i: number) => [...map.keys()][i] ?? null,
+    get length() {
+      return map.size;
+    },
+  } satisfies Storage;
+})();
+
+describe("resolveStartSelection", () => {
+  beforeEach(() => {
+    globalThis.localStorage = store;
+    store.clear();
+  });
+
+  const w = wt({
+    presets: ["full"],
+    nodes: [{ name: "api", variants: ["dev"], default_variant: "dev" }],
+  });
+
+  it("reads the worktree's stored choice", () => {
+    store.setItem(
+      startStorageKey(w.path),
+      JSON.stringify({ kind: "preset", name: "full" }),
+    );
+    expect(resolveStartSelection(w)).toEqual({ kind: "preset", name: "full" });
+  });
+
+  it("keys storage per worktree", () => {
+    store.setItem(
+      startStorageKey("/other"),
+      JSON.stringify({ kind: "nodes", selections: ["api:dev"] }),
+    );
+    // Another worktree's choice must not leak in — the rail starts rows
+    // independently and would otherwise launch the wrong configuration.
+    expect(resolveStartSelection(w)).toEqual({ kind: "preset", name: "full" });
+  });
+
+  it("falls back to the default for stale or absent storage", () => {
+    expect(resolveStartSelection(w)).toEqual({ kind: "preset", name: "full" });
+    store.setItem(
+      startStorageKey(w.path),
+      JSON.stringify({ kind: "preset", name: "deleted-preset" }),
+    );
+    expect(resolveStartSelection(w)).toEqual({ kind: "preset", name: "full" });
+    store.setItem(startStorageKey(w.path), "garbage");
+    expect(resolveStartSelection(w)).toEqual({ kind: "preset", name: "full" });
+  });
+
+  it("is null when the worktree has nothing to start", () => {
+    expect(resolveStartSelection(wt())).toBeNull();
+  });
+});
+
+describe("startBody", () => {
+  it("sends exactly one of preset / selections", () => {
+    // `veld start` treats the two as mutually exclusive; sending both, or
+    // neither, fails with "No selections provided".
+    expect(startBody({ kind: "preset", name: "full" })).toEqual({
+      preset: "full",
+    });
+    expect(startBody({ kind: "nodes", selections: ["api:dev"] })).toEqual({
+      selections: ["api:dev"],
+    });
+  });
+});

--- a/crates/veld-daemon/ui/src/components/StartConfig.tsx
+++ b/crates/veld-daemon/ui/src/components/StartConfig.tsx
@@ -36,6 +36,78 @@ export function defaultStartSelection(w: Worktree): StartSelection | null {
   return null;
 }
 
+/** Parse a stored selection, tolerating anything that isn't one. */
+export function parseStartSelection(raw: string): StartSelection | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as StartSelection;
+    if (parsed?.kind === "preset" && typeof parsed.name === "string") {
+      return parsed;
+    }
+    if (parsed?.kind === "nodes" && Array.isArray(parsed.selections)) {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Drop stored choices the worktree's config no longer offers (preset renamed
+ * away, node removed) — `veld start` would reject them. `null` means nothing
+ * usable survived and the caller should fall back to
+ * [`defaultStartSelection`].
+ */
+export function pruneStartSelection(
+  w: Worktree,
+  sel: StartSelection | null,
+): StartSelection | null {
+  if (!sel) return null;
+  if (sel.kind === "preset") {
+    return w.presets.includes(sel.name) ? sel : null;
+  }
+  const valid = new Set(
+    w.nodes.flatMap((n) => n.variants.map((v) => `${n.name}:${v}`)),
+  );
+  const selections = sel.selections.filter((s) => valid.has(s));
+  return selections.length > 0 ? { kind: "nodes", selections } : null;
+}
+
+/** localStorage key holding a worktree's remembered start configuration. */
+export function startStorageKey(path: string): string {
+  return `veld.start.${path}`;
+}
+
+/**
+ * What ▶ would start for `w`, resolved straight from localStorage. The rail's
+ * per-row controls need this for worktrees other than the selected one, where
+ * the `usePersisted` hook backing the top bar isn't available.
+ */
+export function resolveStartSelection(w: Worktree): StartSelection | null {
+  let raw = "";
+  try {
+    // `globalThis`, not `window`: identical in the browser, but it also lets
+    // this run under the node test environment without pulling in a DOM.
+    raw = globalThis.localStorage?.getItem(startStorageKey(w.path)) ?? "";
+  } catch {
+    // Private-mode / disabled storage: fall through to the default.
+  }
+  return (
+    pruneStartSelection(w, parseStartSelection(raw)) ?? defaultStartSelection(w)
+  );
+}
+
+/** Request body for `POST /api/worktrees/{id}/start`. */
+export function startBody(sel: StartSelection): {
+  preset?: string;
+  selections?: string[];
+} {
+  return sel.kind === "preset"
+    ? { preset: sel.name }
+    : { selections: sel.selections };
+}
+
 export function startSelectionLabel(sel: StartSelection | null): string {
   if (!sel) return "nothing to start";
   if (sel.kind === "preset") return sel.name;

--- a/crates/veld-daemon/ui/src/components/dialogs.tsx
+++ b/crates/veld-daemon/ui/src/components/dialogs.tsx
@@ -1,14 +1,15 @@
-import { type FormEvent, type ReactNode, useState } from "react";
+import { type FormEvent, type ReactNode, useEffect, useState } from "react";
 import {
   Button,
   Checkbox,
   Group,
+  Loader,
   Modal as MantineModal,
   Stack,
   Text,
   TextInput,
 } from "@mantine/core";
-import { api, type Repo } from "../api";
+import { api, type EmojiHolder, type Repo } from "../api";
 
 /**
  * Shared dialog shell on Mantine's Modal (scrim, esc, focus trap, a11y) —
@@ -196,6 +197,123 @@ export function NewWorktreeDialog(props: {
           </Button>
         </Stack>
       </form>
+    </Modal>
+  );
+}
+
+/**
+ * Emoji picker for a worktree's rail identifier.
+ *
+ * The choices come from the daemon (`/api/worktree-emoji`) rather than a
+ * TypeScript copy, because the same list is the server-side allowlist. Glyphs
+ * already in use elsewhere stay selectable — the assigner keeps them unique,
+ * but an explicit choice is the user's to make — and are only labelled, so
+ * the ambiguity is visible before it's created.
+ */
+export function ChangeEmojiDialog(props: {
+  current: string;
+  alias: string;
+  /** Identifies "this worktree" among the holders — aliases can't, since
+   *  they are unique only within one repo. */
+  worktreeId: number;
+  /** emoji → every worktree holding it, across all projects. */
+  usedBy: Record<string, EmojiHolder[]>;
+  onPick: (emoji: string) => Promise<void>;
+  onClose: () => void;
+}) {
+  const [choices, setChoices] = useState<string[] | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void api
+      .worktreeEmoji()
+      .then((r) => {
+        if (cancelled) return;
+        // A malformed payload would otherwise store `undefined` and leave the
+        // Loader spinning forever with no error and no way out.
+        if (Array.isArray(r?.emoji)) setChoices(r.emoji);
+        else setLoadError("The daemon returned an unexpected emoji list.");
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) {
+          setLoadError(e instanceof Error ? e.message : String(e));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const pick = async (emoji: string) => {
+    setBusy(emoji);
+    setError(null);
+    try {
+      await props.onPick(emoji);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setBusy(null);
+    }
+  };
+
+  return (
+    <Modal title={`Emoji for ${props.alias}`} onClose={props.onClose}>
+      <Stack gap="sm">
+        {loadError && <ErrorText error={loadError} />}
+        {!choices && !loadError && (
+          <Group justify="center" py="lg">
+            <Loader size="sm" aria-label="Loading emoji" />
+          </Group>
+        )}
+        {choices && (
+          <div className="emoji-grid">
+            {choices.map((e) => {
+              const isCurrent = e === props.current;
+              // Every holder that isn't this worktree. Compared by id, not
+              // alias, and covering all holders rather than the first: a
+              // collision with another project's identically-named worktree
+              // is precisely what the picker exists to surface.
+              const others = (props.usedBy[e] ?? []).filter(
+                (h) => h.id !== props.worktreeId,
+              );
+              const taken = others.map((h) => h.alias).join(", ");
+              return (
+                <button
+                  key={e}
+                  type="button"
+                  className={`emoji-cell${isCurrent ? " current" : ""}`}
+                  disabled={busy !== null}
+                  aria-pressed={isCurrent}
+                  aria-label={taken ? `${e} — in use by ${taken}` : e}
+                  title={
+                    [
+                      isCurrent ? "Current" : "",
+                      taken ? `In use by ${taken}` : "",
+                    ]
+                      .filter(Boolean)
+                      .join(" · ") || undefined
+                  }
+                  onClick={() => void pick(e)}
+                >
+                  {busy === e ? (
+                    <Loader size={14} />
+                  ) : (
+                    <span aria-hidden="true">{e}</span>
+                  )}
+                  {taken && <span className="emoji-taken" />}
+                </button>
+              );
+            })}
+          </div>
+        )}
+        <ErrorText error={error} />
+        <Text size="xs" c="dimmed">
+          A dot marks a glyph another worktree already uses. Picking it is
+          allowed — the rail just won&apos;t identify them apart.
+        </Text>
+      </Stack>
     </Modal>
   );
 }

--- a/crates/veld-daemon/ui/src/model.test.ts
+++ b/crates/veld-daemon/ui/src/model.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 import type { EnvironmentList, RunInfo, Worktree } from "./api";
 import {
   activeRun,
-  filterWorktrees,
+  bestFuzzyMatch,
+  fuzzyMatch,
+  prunePending,
+  runSignature,
   runsForWorktree,
   sortedUrls,
   worktreeStatus,
@@ -84,6 +87,80 @@ describe("activeRun / worktreeStatus", () => {
   });
 });
 
+describe("runSignature", () => {
+  it("changes when a restart swaps the run id but not the status", () => {
+    // The regression this exists for: `veld restart` tears down and starts a
+    // fresh run, so a quick restart reads running → running. A status-only
+    // check never observes it and the pending spinner runs to its timeout.
+    const before = run("dev", "running");
+    const after = { ...run("dev", "running"), run_id: "a-different-uuid" };
+    expect(runSignature([before])).not.toBe(runSignature([after]));
+  });
+
+  it("changes across start and stop", () => {
+    const stopped = runSignature([]);
+    const starting = runSignature([run("dev", "starting")]);
+    const running = runSignature([run("dev", "running")]);
+    expect(new Set([stopped, starting, running]).size).toBe(3);
+  });
+
+  it("is stable while nothing happens", () => {
+    const runs = [run("dev", "running")];
+    expect(runSignature(runs)).toBe(runSignature([...runs]));
+  });
+
+  it("collapses non-live history to the same value as no runs at all", () => {
+    // History must not read as an in-flight action.
+    expect(runSignature([run("dev", "failed", false)])).toBe(runSignature([]));
+  });
+});
+
+describe("prunePending", () => {
+  const marker = (sig: string, expiresAt = 10_000) => ({
+    label: "start" as const,
+    sigAtSet: sig,
+    expiresAt,
+  });
+
+  it("keeps a marker whose action has not landed yet", () => {
+    const cur = { 1: marker("stopped") };
+    expect(prunePending(cur, 0, () => "stopped")).toBe(cur);
+  });
+
+  it("drops a marker once the signature moves", () => {
+    const cur = { 1: marker("stopped") };
+    expect(prunePending(cur, 0, () => "running:abc")).toEqual({});
+  });
+
+  it("drops a marker for a worktree that no longer exists", () => {
+    // It can never report a transition, so it would spin until the TTL.
+    expect(prunePending({ 1: marker("stopped") }, 0, () => null)).toEqual({});
+  });
+
+  it("expires a marker whose action never produced a transition", () => {
+    const cur = { 1: marker("stopped", 5_000) };
+    expect(prunePending(cur, 4_999, () => "stopped")).toBe(cur);
+    expect(prunePending(cur, 5_000, () => "stopped")).toEqual({});
+  });
+
+  it("prunes per worktree, leaving the others alone", () => {
+    const cur = { 1: marker("stopped"), 2: marker("running:x") };
+    const next = prunePending(cur, 0, (id) =>
+      id === 1 ? "running:new" : "running:x",
+    );
+    expect(Object.keys(next)).toEqual(["2"]);
+  });
+
+  it("returns the SAME object when nothing changed", () => {
+    // Load-bearing: the caller runs this from a useState updater inside an
+    // effect, so a fresh object every poll would loop forever.
+    const cur = { 1: marker("stopped") };
+    expect(prunePending(cur, 0, () => "stopped")).toBe(cur);
+    const empty = {};
+    expect(prunePending(empty, 0, () => null)).toBe(empty);
+  });
+});
+
 describe("sortedUrls", () => {
   it("sorts by service name", () => {
     const r = run("a", "running");
@@ -96,11 +173,120 @@ describe("sortedUrls", () => {
   });
 });
 
-describe("filterWorktrees", () => {
-  it("matches alias and branch, case-insensitively", () => {
-    const list = [wt("/a"), { ...wt("/b"), alias: "main", branch: "main" }];
-    expect(filterWorktrees(list, "CHECKOUT")).toHaveLength(1);
-    expect(filterWorktrees(list, "main")).toHaveLength(1);
-    expect(filterWorktrees(list, "")).toHaveLength(2);
+const score = (text: string, query: string) => fuzzyMatch(text, query)?.score;
+
+describe("fuzzyMatch", () => {
+  it("matches subsequences, case-insensitively", () => {
+    expect(fuzzyMatch("checkout-v2", "CHECKOUT")).not.toBeNull();
+    expect(fuzzyMatch("checkout-v2", "ckv")).not.toBeNull();
+    expect(fuzzyMatch("checkout-v2", "zz")).toBeNull();
+    // Order matters — a subsequence, not a bag of characters.
+    expect(fuzzyMatch("checkout", "kc")).toBeNull();
+  });
+
+  it("matches everything on an empty query, at score 0", () => {
+    expect(fuzzyMatch("anything", "")).toEqual({ score: 0, positions: [] });
+    expect(fuzzyMatch("anything", "   ")).toEqual({ score: 0, positions: [] });
+  });
+
+  it("treats spaces as separators, not characters to find", () => {
+    expect(fuzzyMatch("New worktree…", "new wt")).not.toBeNull();
+  });
+
+  it("reports the matched positions for highlighting", () => {
+    // c-h-e-c-k-o-u-t: the second 'c' is skipped, the scan is leftmost-greedy.
+    expect(fuzzyMatch("checkout", "cko")?.positions).toEqual([0, 4, 5]);
+  });
+
+  it("ranks consecutive runs above scattered hits", () => {
+    expect(score("checkout", "chk")!).toBeLessThan(score("checkout", "che")!);
+  });
+
+  it("ranks word-boundary hits above mid-word ones", () => {
+    // 'v' starts a segment in the first, sits inside a word in the second.
+    expect(score("checkout-v2", "v")!).toBeGreaterThan(score("review", "v")!);
+  });
+
+  it("never loses a match that is genuinely a subsequence", () => {
+    // The property the boundary anchor must not break. Anchoring the first
+    // character forward can strand the rest of the query past the boundary
+    // it jumped to ("switch to veld-web" + `wt` anchors `w` to "-(w)eb",
+    // after which there is no `t`) — so the anchored scan is an alternative
+    // to the plain leftmost scan, never a replacement. A mis-ranked item is
+    // still findable by scrolling; an unmatched one vanishes from ⌘K.
+    const labels = [
+      "main",
+      "desktop-app-2",
+      "Switch to veld-web",
+      "Copy path of api",
+      "Copy all run URLs",
+      "Rename api…",
+      "Collapse the worktree rail",
+      "Change emoji for chk…",
+      "New worktree…",
+      "Remove project veld…",
+      "feat/api-v2",
+    ];
+    const alphabet = "abcdefghijklmnopqrstuvwxyz0123456789-";
+    const isSubsequence = (text: string, query: string) => {
+      let i = 0;
+      for (const c of text.toLowerCase()) if (c === query[i]) i++;
+      return i === query.length;
+    };
+
+    // Named cases the reviewers hit: typing the middle of a word is an
+    // ordinary palette query, and each of these returned null under a
+    // replace-the-scan anchor.
+    expect(fuzzyMatch("Copy path of main", "opy")).not.toBeNull();
+    expect(fuzzyMatch("feat/deploy-prod", "ploy")).not.toBeNull();
+    expect(fuzzyMatch("Switch to veld-web", "wt")).not.toBeNull();
+    expect(fuzzyMatch("Rename api…", "am")).not.toBeNull();
+
+    const lost: string[] = [];
+    for (const label of labels) {
+      for (const a of alphabet) {
+        for (const b of alphabet) {
+          for (const c of alphabet) {
+            for (const q of [a + b, a + b + c]) {
+              if (!isSubsequence(label, q)) continue;
+              if (fuzzyMatch(label, q) === null) lost.push(`${label} + ${q}`);
+            }
+          }
+        }
+      }
+    }
+    expect(lost).toEqual([]);
+  });
+
+  it("anchors the first character to a word start when one exists", () => {
+    // Regression: plain greedy took the 'w' in "s(w)itch" and ranked
+    // "Switch to Runs" ABOVE "New worktree…" for the query `wt` — the
+    // acronym-ish shape most palette queries have.
+    expect(score("New worktree…", "wt")!).toBeGreaterThan(
+      score("Switch to Runs", "wt")!,
+    );
+    // The anchor applies to the first character only; later ones stay greedy.
+    expect(fuzzyMatch("new worktree", "wt")?.positions).toEqual([4, 8]);
+  });
+
+  it("breaks ties toward the shorter, earlier-matching haystack", () => {
+    expect(score("main", "main")!).toBeGreaterThan(
+      score("main-experiment", "main")!,
+    );
+    expect(score("api", "api")!).toBeGreaterThan(score("legacy-api", "api")!);
+  });
+});
+
+describe("bestFuzzyMatch", () => {
+  it("takes the highest-scoring haystack", () => {
+    // 'main' hits the branch, not the alias.
+    const m = bestFuzzyMatch(["chk", "feat/main-rewrite"], "main");
+    expect(m).not.toBeNull();
+    expect(m!.score).toBe(fuzzyMatch("feat/main-rewrite", "main")!.score);
+  });
+
+  it("is null only when no haystack matches", () => {
+    expect(bestFuzzyMatch(["chk", "feat/x"], "zzz")).toBeNull();
+    expect(bestFuzzyMatch([], "a")).toBeNull();
   });
 });

--- a/crates/veld-daemon/ui/src/model.ts
+++ b/crates/veld-daemon/ui/src/model.ts
@@ -229,8 +229,12 @@ export function fuzzyMatch(text: string, query: string): FuzzyMatch | null {
     }
   }
 
-  if (!plain) return anchored;
+  // A failed plain scan means no subsequence exists at all, and the anchored
+  // scan starts no earlier — so it cannot rescue one. Returning `anchored`
+  // here would read as if it could, inverting the invariant above.
+  if (!plain) return null;
   if (!anchored) return plain;
+  // Ties keep the anchored positions: same score, better highlight.
   return anchored.score >= plain.score ? anchored : plain;
 }
 

--- a/crates/veld-daemon/ui/src/model.ts
+++ b/crates/veld-daemon/ui/src/model.ts
@@ -54,21 +54,195 @@ export function worktreeStatus(runs: RunInfo[]): WorktreeStatus {
   return "partial";
 }
 
+/**
+ * A value that changes whenever a fired action has visibly landed — what the
+ * optimistic pending markers watch.
+ *
+ * Status alone is not enough: `veld restart` tears the run down and starts a
+ * fresh one, so a fast restart goes `running` → `running` and a status-only
+ * check would never observe it (the spinner then runs until its timeout).
+ * The run id covers that case, because a restart mints a new one
+ * (`RunState::new`); the status covers start/stop, where the id is absent on
+ * one side.
+ */
+export function runSignature(runs: RunInfo[]): string {
+  const run = activeRun(runs);
+  return run ? `${run.status}:${run.run_id}` : "none";
+}
+
 /** URL list of a run, service-name-sorted, as [name, url] pairs. */
 export function sortedUrls(run: RunInfo | null): Array<[string, string]> {
   if (!run) return [];
   return Object.entries(run.urls).sort(([a], [b]) => a.localeCompare(b));
 }
 
-/** Case-insensitive substring filter over worktree alias + branch. */
-export function filterWorktrees(
-  worktrees: Worktree[],
+// ---------------------------------------------------------------------------
+// Optimistic pending action markers
+// ---------------------------------------------------------------------------
+
+/**
+ * Actions that move [`runSignature`], and so can be tracked as pending.
+ *
+ * Only add a member if the action actually changes the run's status or id —
+ * a marker for anything else (a share, say) never clears and leaves its
+ * control disabled until the TTL.
+ *
+ * Widening this breaks the build in `actionColor` (App.tsx), which is
+ * deliberately exhaustive. Two other sites enumerate members by literal and
+ * will NOT fail to compile — fix them in the same change:
+ * `TopBar`'s play/stop `loading` and its restart `loading`.
+ */
+export type PendingAction = "start" | "stop" | "restart";
+
+export interface PendingMarker {
+  label: PendingAction;
+  /** `runSignature` at the moment the action was fired. */
+  sigAtSet: string;
+  /** Epoch ms after which the marker is abandoned. */
+  expiresAt: number;
+}
+
+/** Markers keyed by worktree id. */
+export type PendingMap = Record<number, PendingMarker>;
+
+/**
+ * Drop markers whose signature has moved, or whose deadline has passed.
+ *
+ * A moved signature means *something* happened, not necessarily the thing
+ * that was fired — this is a change detector, not an acknowledgement. Firing
+ * Stop against a run that is still `starting` clears the marker as soon as it
+ * reaches `running` on its own, while the stop is still in flight. Correlating
+ * properly would need the daemon to hand back an action token.
+ *
+ * `sigFor` returns the worktree's current [`runSignature`], or `null` when the
+ * worktree can't be found at all — a worktree that no longer exists can never
+ * report a transition, so its marker is dropped rather than left spinning.
+ *
+ * Returns the SAME object when nothing changed. That identity is load-bearing:
+ * the caller runs this from a `useState` updater inside an effect, and a fresh
+ * object every poll would re-trigger the effect forever.
+ */
+export function prunePending(
+  cur: PendingMap,
+  now: number,
+  sigFor: (worktreeId: number) => string | null,
+): PendingMap {
+  const ids = Object.keys(cur);
+  if (ids.length === 0) return cur;
+  const next: PendingMap = {};
+  for (const key of ids) {
+    const id = Number(key);
+    const sig = sigFor(id);
+    // An action that 202'd but never produced a transition (the CLI died on
+    // startup, say) would otherwise leave the control disabled for the rest
+    // of the session. Expiring beats a permanently dead button.
+    if (sig !== null && sig === cur[id].sigAtSet && now < cur[id].expiresAt) {
+      next[id] = cur[id];
+    }
+  }
+  return Object.keys(next).length === ids.length ? cur : next;
+}
+
+// ---------------------------------------------------------------------------
+// Fuzzy matching (command palette + worktree search)
+// ---------------------------------------------------------------------------
+
+export interface FuzzyMatch {
+  score: number;
+  /** Indices in the haystack that the query matched, for highlighting. */
+  positions: number[];
+}
+
+/**
+ * Score `query` as a subsequence of `text`, or `null` when it isn't one.
+ *
+ * Two left-to-right scans rather than an optimal alignment — the haystacks
+ * here are worktree aliases and command labels, a few dozen short strings, so
+ * full backtracking buys nothing a user would notice:
+ *
+ * 1. **Plain leftmost**, the completeness guarantee: if the query is a
+ *    subsequence at all, this finds it.
+ * 2. **Boundary-anchored**, starting the first character at the earliest word
+ *    start. Without it, plain greedy takes the `w` in "s(w)itch" and ranks
+ *    "Switch to Runs" above "New worktree…" for `wt` — the acronym-ish shape
+ *    most palette queries have.
+ *
+ * The higher-scoring of the two wins. Anchoring must stay an *alternative*,
+ * never a replacement: jumping the first character forward can strand the
+ * rest of the query ("switch to veld-web" + `wt` anchors `w` to "-(w)eb",
+ * after which there is no `t`), and an item that fails to match vanishes from
+ * ⌘K entirely — strictly worse than being mis-ranked.
+ *
+ * Bonuses do the rest of the ranking:
+ *
+ * - consecutive characters, so `chk` beats `c…h…k` scattered across a name
+ * - matches at a word boundary, so `cv` ranks `checkout-v2` above a mid-word
+ *   hit (a plain subsequence scan finds it either way)
+ * - a small penalty for a late first match and for long haystacks, which
+ *   breaks ties toward the tighter, shorter candidate
+ *
+ * An empty query matches everything with score 0 (callers keep input order).
+ */
+export function fuzzyMatch(text: string, query: string): FuzzyMatch | null {
+  // Spaces are separators the user types between words, not characters to
+  // find — "new wt" should match "New worktree…".
+  const q = Array.from(query.trim().toLowerCase()).filter((c) => c !== " ");
+  if (q.length === 0) return { score: 0, positions: [] };
+  const t = text.toLowerCase();
+  const atBoundary = (i: number) => i === 0 || !/[a-z0-9]/.test(t[i - 1]);
+
+  /** One left-to-right pass; `firstAt` fixes where the first char matches. */
+  const scan = (firstAt: number): FuzzyMatch | null => {
+    const positions: number[] = [];
+    let score = 0;
+    let prev = -2;
+    let from = firstAt;
+    for (let qi = 0; qi < q.length; qi++) {
+      const at = qi === 0 ? firstAt : t.indexOf(q[qi], from);
+      if (at === -1) return null;
+      positions.push(at);
+      score += 1;
+      if (at === prev + 1) score += 4;
+      if (atBoundary(at)) score += 3;
+      prev = at;
+      from = at + 1;
+    }
+    return { score: score - positions[0] * 0.1 - t.length * 0.01, positions };
+  };
+
+  const leftmost = t.indexOf(q[0]);
+  if (leftmost === -1) return null;
+
+  // The plain leftmost scan is the completeness guarantee: if the query is a
+  // subsequence at all, this finds it. Never return null while it succeeds.
+  const plain = scan(leftmost);
+
+  // The anchored scan ranks better when it works, but it can strand the rest
+  // of the query past the boundary it jumped to — "switch to veld-web" + `wt`
+  // anchors `w` to "-(w)eb", after which there is no `t`. So it's an
+  // *alternative*, not a replacement: take whichever scores higher.
+  let anchored: FuzzyMatch | null = null;
+  for (let p = leftmost; p !== -1; p = t.indexOf(q[0], p + 1)) {
+    if (atBoundary(p)) {
+      anchored = p === leftmost ? plain : scan(p);
+      break;
+    }
+  }
+
+  if (!plain) return anchored;
+  if (!anchored) return plain;
+  return anchored.score >= plain.score ? anchored : plain;
+}
+
+/** Best score across several haystacks (e.g. a worktree's alias and branch). */
+export function bestFuzzyMatch(
+  texts: string[],
   query: string,
-): Worktree[] {
-  const q = query.trim().toLowerCase();
-  if (!q) return worktrees;
-  return worktrees.filter(
-    (w) =>
-      w.alias.toLowerCase().includes(q) || w.branch.toLowerCase().includes(q),
-  );
+): FuzzyMatch | null {
+  let best: FuzzyMatch | null = null;
+  for (const text of texts) {
+    const m = fuzzyMatch(text, query);
+    if (m && (!best || m.score > best.score)) best = m;
+  }
+  return best;
 }

--- a/crates/veld-daemon/ui/src/styles.css
+++ b/crates/veld-daemon/ui/src/styles.css
@@ -228,7 +228,8 @@ select:focus {
   width: 64px;
 }
 
-/* Collapsed rows: status dot + emoji only, centered. */
+/* Collapsed rows: status dot + emoji only, centered. Height comes from
+   .wt-row's min-height, so rows don't resize when the rail expands. */
 .wt-row.slim {
   justify-content: center;
   padding: 5px 4px;
@@ -267,6 +268,12 @@ select:focus {
   min-width: 0;
   max-width: 100%;
   overflow: hidden;
+  cursor: pointer;
+  /* Fixed so collapsing the rail doesn't reflow the list: expanded rows are
+     as tall as their 17px controls, collapsed ones only as tall as the
+     emoji. Must clear the tallest expanded child plus vertical padding. */
+  min-height: 28px;
+  box-sizing: border-box;
 }
 .wt-row:hover {
   background: var(--panel);
@@ -329,16 +336,63 @@ select:focus {
   flex: 1;
 }
 
+/* Flex-centred, not baseline: an inline SVG in a text box sits on the
+   baseline and rides visibly high against the row's centre. */
 .wt-edit {
   flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 17px;
+  height: 17px;
   border: none;
+  border-radius: 5px;
   background: none;
   color: var(--faint);
   font-size: 11px;
   padding: 0;
+  cursor: pointer;
 }
 .wt-edit:hover {
+  background: var(--elev);
   color: var(--text);
+}
+
+/* Per-row run control, coloured by the action it performs: green to start,
+   red to stop. The colour is the affordance — you should not have to hover
+   to learn what the button will do. */
+.wt-run {
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 17px;
+  height: 17px;
+  border: none;
+  border-radius: 5px;
+  background: none;
+  color: var(--accent);
+  padding: 0;
+  cursor: pointer;
+}
+.wt-run.on {
+  color: var(--danger);
+}
+.wt-run:hover {
+  background: var(--elev);
+}
+.wt-run:disabled {
+  cursor: default;
+  background: none;
+}
+
+/* The row is a role=button div, so its nested controls can be real buttons
+   without invalid nesting — but they need their own visible focus ring. */
+.wt-row:focus-visible,
+.wt-run:focus-visible,
+.wt-edit:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -1px;
 }
 
 /* ---- panes ---------------------------------------------------------------- */
@@ -627,6 +681,96 @@ select:focus {
   transform: translateX(-50%);
 }
 
+
+/* ---- emoji picker ---------------------------------------------------------- */
+
+.emoji-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(42px, 1fr));
+  gap: 4px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.emoji-cell {
+  position: relative;
+  aspect-ratio: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  line-height: 1;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: none;
+  cursor: pointer;
+}
+.emoji-cell:hover:not(:disabled) {
+  background: var(--panel);
+  border-color: var(--border2);
+}
+.emoji-cell.current {
+  border-color: var(--accent);
+  background: var(--elev);
+}
+.emoji-cell:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+.emoji-cell:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+/* Marks a glyph another worktree already uses — advisory, not a block. */
+.emoji-taken {
+  position: absolute;
+  right: 4px;
+  bottom: 4px;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--faint);
+}
+
+/* ---- command palette ------------------------------------------------------- */
+
+.palette-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  max-height: 46vh;
+  overflow-y: auto;
+}
+
+/* Keyboard cursor. Distinct from :hover so moving the mouse across the list
+   doesn't visually compete with the arrow-key position. */
+.wt-row.sel {
+  background: var(--elev);
+  box-shadow: inset 0 0 0 1px var(--border2);
+}
+
+.pal-hint {
+  margin-left: auto;
+  flex: none;
+  padding-left: 10px;
+  font-size: 10.5px;
+  color: var(--faint);
+  white-space: nowrap;
+}
+
+.pal-label {
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+.pal-label mark {
+  background: none;
+  color: var(--accent);
+  font-weight: 700;
+}
 
 /* Monospace form controls (project switcher etc.) — hard override, not the
    Mantine variable, so the input value is mono regardless of slot styling. */

--- a/desktop/ARCHITECTURE.md
+++ b/desktop/ARCHITECTURE.md
@@ -7,10 +7,11 @@ later increments.
 
 This document covers the foundation increment: what exists, why it's shaped
 this way, and how to run it locally. The visual design source of truth is the
-Claude Design handoff (kept outside the repo under `tmp/`, gitignored); the
-stripped add-ons listed there (command palette, PR badges, extension system,
-isolated browser sessions, pinned agent session, overview board) are
-deliberately **not** part of this foundation.
+Claude Design handoff (kept outside the repo under `tmp/`, gitignored); of the
+stripped add-ons listed there, PR badges, the extension system, isolated
+browser sessions, the pinned agent session and the overview board are
+deliberately **not** part of this foundation. (The command palette was also
+stripped from the foundation, but has since shipped — see below.)
 
 ## Decision log
 
@@ -78,6 +79,37 @@ requests at runtime — branding rule.
 - The v1 dashboard at `/` is untouched until the runs-mode rebuild reaches
   parity and takes it over.
 
+#### Worktree rail and command palette
+
+- **Rail rows** carry inline start/stop controls, but only while the rail is
+  expanded — a 64px collapsed row has no space, so right-click is its
+  affordance in both states. Rows are `div[role=button]`, not `<button>`,
+  because they contain real nested buttons and a button inside a button is
+  invalid HTML that browsers resolve by dropping the inner one. The row's
+  `onKeyDown` must therefore ignore events bubbling from those children, or it
+  cancels their activation. Known cost: `role="button"` takes presentational
+  children, so the nested controls aren't exposed to assistive tech — the
+  honest shape is `role="listbox"` on the rail with `role="option"` rows,
+  deferred to a later increment.
+- **One start predicate.** `canStartWorktree` gates all four surfaces that can
+  fire a run action — top bar, rail row, context menu and palette. They
+  disagreed before: some checked "is anything already in flight", others "is
+  there anything to start", so one surface offered an enabled control whose
+  click was a silent no-op while another allowed a double-spawned
+  `veld start`.
+- **Pending markers** (`prunePending`, `crates/veld-daemon/ui/src/model.ts`)
+  are optimistic per-worktree flags cleared when the worktree's *run signature*
+  (`status:run_id`) moves — status alone is not enough, because `veld restart`
+  returns to `running` and would never register. A 60s TTL bounds an action
+  that 202s and then never lands.
+- **⌘K** fuzzy-searches worktrees *and* commands. With no query the items are
+  grouped in `PALETTE_GROUPS` order; once the user types, grouping gives way to
+  a single score-ordered list. The matcher runs two scans — plain leftmost and
+  one anchoring the query's first character to a word start — and keeps the
+  better: plain greedy alone ranks "Switch to Runs" above "New worktree…" for
+  `wt`, while anchoring alone can strand the rest of the query and drop the
+  item from the list entirely.
+
 Why not join `crates/veld-daemon/frontend/`? That package builds IIFE snippets
 (feedback overlay, client-log) with esbuild and no framework; the management UI
 is an application with a different toolchain (Vite, React, HMR). Two small
@@ -136,6 +168,15 @@ alias, probed to stay unique across ALL repos' worktrees, assigned at
 insert, backfilled for pre-v6 rows on sync, preserved across renames. It is
 the collapsed rail's identifier.
 
+Uniqueness is a property of *assignment*, not an invariant: "Change emoji…"
+lets the user pick a glyph another worktree already holds (the picker marks
+which, so the ambiguity is visible before it's created) — an explicit choice
+outranks the heuristic. Sync only backfills an *empty* emoji, so a chosen one
+survives every later reconciliation **of an unmoved worktree** — `git worktree
+move` changes the path, which is the sync key, so the row is pruned and
+re-inserted with a fresh id, a re-assigned emoji and a default alias (the
+path-keyed `veld.start.<path>` entry is orphaned by the same move).
+
 Run/health/URL state is **not** duplicated: the UI joins a worktree to veld
 state by path (`worktrees.path` = veld `projects.root`, string equality) via
 `/api/environments`. Both sides are physical (symlink-resolved) paths — git
@@ -163,7 +204,8 @@ on mutations, JSON errors, `202 Accepted` for fire-and-forget CLI spawns.
 | `POST /api/repos/import` `{path}` | Accepts any directory inside the repo; resolves the main checkout via `git worktree list --porcelain`, derives the name, registers it, and syncs the worktree rows. Idempotent. |
 | `DELETE /api/repos` `{root}` | Unregisters (never touches the filesystem). |
 | `POST /api/worktrees` `{repo_root, branch, alias?, path?, create_branch?}` | `git worktree add`. Default path: `<repo_parent>/_worktrees/<alias>`. |
-| `PATCH /api/worktrees/{id}` `{alias}` | Rename the alias (DB only). |
+| `PATCH /api/worktrees/{id}` `{alias?, emoji?}` | Partial update, DB only. Both fields optional (alias-only callers stay wire-compatible); an empty patch is a `400` and an unknown field a `422` (`deny_unknown_fields` — with everything optional, a client typo would otherwise be a silent `200`). Both columns are written in one `UPDATE … COALESCE`, so the pair can't half-apply. `emoji` is checked against the curated set — an allowlist rather than a "one grapheme?" test, which keeps the rail uniform and leaves no room for a multi-codepoint or zero-width payload; the rule lives in `veld_core::db::is_worktree_emoji`, beside the constant, so no caller can bypass it. |
+| `GET /api/worktree-emoji` | The curated glyph list, for the picker. Served rather than duplicated in TypeScript, because the same constant is the server-side allowlist; the picker fetches it once on open instead of riding the 5s poll. |
 | `DELETE /api/worktrees/{id}?force=` | `git worktree remove` (`--force` discards a dirty tree); prunes git bookkeeping if the checkout was already removed by hand. Never deletes the main checkout. |
 | `POST /api/worktrees/{id}/start` `{preset?, selections?, run_name?}` | Spawns `veld start` with the worktree as cwd (the CLI resolves veld.json from there). Two mutually-exclusive start modes: `preset` (`--preset <p>`) or explicit `selections` (`node:variant` positionals, validated per half) — a non-TTY bare start fails "No selections provided", so the UI always sends one. Default run name: the alias. `202 Accepted`; progress observed via `/api/environments`. |
 | `POST /api/repos/refresh` | The UI's poll target: reconciles every repo's worktree rows with `git worktree list`, then returns the same payload as `GET /api/repos`. POST (CSRF-gated) because it spawns git and writes; debounced daemon-side. The plain GET stays a pure read. |
@@ -247,6 +289,8 @@ already lives in the URL, so modes are just routes.
 3. Terminal panes (PTY over WebSocket from the daemon, or node-pty in the
    Electron main process — decision deferred).
 4. Start-run UX beyond preset picking; `veld share` from the UI.
-5. Command palette / fuzzy search beyond the overlay shell.
-6. Extension system (`veld-ui.json` badges), PR/CI badges, overview board.
-7. Packaging, auto-update, CLI installation from the app.
+5. Extension system (`veld-ui.json` badges), PR/CI badges, overview board.
+6. Packaging, auto-update, CLI installation from the app.
+
+The sequencing and the transport/renderer decisions for these live in
+[issue #167](https://github.com/prosperity-solutions/veld/issues/167).


### PR DESCRIPTION
Batch 1 of the Veld Desktop roadmap (#167) — the IDE-polish increment.

## What's in it

**Per-row run controls in the worktree rail.** Start/stop on each expanded row, coloured by the action (green to start, red to stop) so the affordance doesn't need a hover to read. The collapsed 64px rail has no space for inline controls, so right-click reaches the same actions in both states.

**"Change emoji…"** in the worktree context menu and in ⌘K. The picker marks glyphs other worktrees already hold — pickable anyway, since an explicit choice outranks the assignment heuristic — and the choice survives every later git sync.

**⌘K became a command palette.** Fuzzy rather than substring, over worktrees *and* commands (start/stop/restart, open or copy run URLs, rename, emoji, import, project switch, mode, theme, rail). Grouped when idle, globally score-ranked once you type.

## Notable implementation decisions

- **The pending marker watches a run *signature* (`status:run_id`), not status.** `veld restart` stops and starts, minting a fresh `run_id` (`RunState::new`), so a quick restart reads `running → running` and a status-only check never observes it — the spinner ran until its timeout. Markers are also per-worktree rather than one global slot, because the rail can fire actions on several rows at once.
- **One `canStartWorktree` predicate for all four surfaces** that can fire a run action. They disagreed: some checked "is anything already in flight", others "is there anything to start", so one surface offered an enabled control whose click was a silent no-op while another allowed a double-spawned `veld start`.
- **`PATCH /api/worktrees/{id}` writes both columns in one `UPDATE … COALESCE`** so alias and emoji can't half-apply, and rejects unknown fields (`deny_unknown_fields`) — with every field optional, a client typo would otherwise be a silent `200` that changed nothing.
- **Emoji validation lives in `veld_core::db::is_worktree_emoji`, beside the constant**, not only in the HTTP handler, so a future CLI or IPC caller can't persist an arbitrary string into a column the rail renders in a 17px slot. The glyph list is *served* (`GET /api/worktree-emoji`) rather than duplicated in TypeScript, so the picker and the allowlist can't drift.
- **Rail rows are `div[role=button]`.** They carry real nested buttons, and a `<button>` inside a `<button>` violates the content model. Known cost, now documented rather than papered over: `role="button"` takes presentational children, so the nested controls aren't exposed to assistive tech. The honest shape is `role="listbox"` with `role="option"` rows — deferred.

## Review

Three rounds of the five-angle adversarial review in `docs/agentic-review.md`. Final round: zero critical, zero major.

Two of the bugs it caught were introduced by *earlier fixes in this same PR*, which is the argument for the loop rather than a single pass:

1. **The fuzzy matcher's first-character word-boundary anchor destroyed recall.** It fixed the ranking (`wt` was surfacing "Switch to Runs" above "New worktree…") but could jump past the only position from which the rest of the query matched — returning `null` and removing the item from ⌘K entirely. One reviewer enumerated 44 two-char queries that silently stopped matching. Strictly worse than the bug being fixed: a mis-ranked item is still findable, a vanished one isn't. Now runs both scans and keeps the better, with a brute-force property test asserting no genuine subsequence ever fails to match — the previous test only asserted relative scores, which is exactly why the suite stayed green through the regression.
2. **The emoji-collision fix compared holders by alias.** Aliases are unique only within a repo, so two projects both checked out on `main` — the default case — made the picker report a taken glyph as free. Now compared by worktree id, listing all holders.

Also fixed during review: `DbError::InvalidEmoji` surfacing as a `500 "database error"`; the top bar being a fourth start surface outside the shared predicate; a TDZ hazard from declaration order; `actionColor` made exhaustive so widening the action union fails the build; and several comments that were confidently wrong — including a claim that browsers "drop the inner button" in nested-button HTML (the parser closes the *outer* one; React does neither).

## Tests

47 UI tests (was 39) and 406 Rust tests, clippy clean. New coverage: the `prunePending` reducer's three contracts including the referential-identity guard whose failure mode is an infinite effect loop; the fuzzy matcher's completeness property; start-selection parsing/pruning/resolution; `patch_worktree` field independence and atomicity; the emoji endpoint's route, CSRF exemption and JSON key; and that the curated glyph set is duplicate-free (`pick_emoji`'s probe and the picker's React `key` both depend on it).

## Documentation

`desktop/ARCHITECTURE.md` gains a "Worktree rail and command palette" section plus an updated API table, and no longer claims the command palette is deliberately out of scope while shipping it.

Per the AGENTS.md checklist: no config fields, CLI flags or subcommands change, so `docs/configuration.md`, `skills/veld/*` and `schema/v2/veld.schema.json` are N/A. **The website deliberately does not change** — `README.md` and `website/llms-full.txt` each carry one summary paragraph about `/ide` that this diff doesn't make false, and `website/index.html` never mentions `/ide`. Veld Desktop gets its marketing section once the Electron app is actually installable (batch 10 of #167).

## Deferred, deliberately

- **#168 — run names are not globally unique but stop/restart resolve them globally.** Pre-existing at the API level; this PR only multiplies the surfaces that reach it. Filed with three fix options rather than scope-crept into UI polish.
- **Palette and rail ARIA** (listbox/option, roving tabindex, arrow keys bound to the dialog body rather than the input). The cheap half landed (`aria-current`, keyboard activation of the nested buttons); the structural rework didn't.
- **Refresh ordering.** Polls aren't sequenced, so a mutation can visibly revert for up to one poll. Now documented in a code comment instead of being silently unknown.
- **`actionError` is still a single slot**, now with worktree attribution (`alias: action failed — …`). A second failure still overwrites an unread first one; judged acceptable rather than building a per-worktree error map.

Closes nothing on its own — ticks the "IDE polish" batch of #167.
