### PR TITLE
docs(review): autonomous staged multi-angle review loop

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -30,16 +30,25 @@ State the feature/scope in your own words if it isn't already clear, then use
 `AskUserQuestion` for the settings below (skip any the maintainer already stated
 in their request):
 
-1. **Review depth**
-   - *Full loop (recommended)* — repeated 5-angle adversarial review per
-     `docs/agentic-review.md`; fix, re-review on the post-fix diff, loop until a
-     round is clean.
-   - *Trivial (3-angle, round cap 2)* — counterfactual + what-isn't-here +
-     self-consistency, for a small / mechanical change. Still loops (Step 4), just
-     with the lower cap the review doc's tuning note allows for low-risk diffs.
+1. **Review depth** — sets the `SPAWNS` / `ROUNDS` caps of the autonomous review
+   loop in [docs/agentic-review.md](../../../docs/agentic-review.md). Everything
+   else about the loop (staging, model routing, ledger, exit criteria) is the
+   doc's, not yours to negotiate.
+   - *Standard loop (recommended)* — the doc as written: `SPAWNS: 14` (max 6
+     opus), `ROUNDS: auto` (2 low-risk / 3 default / 5 stakes-elevated).
+   - *Deep* — raise the caps (`SPAWNS: 24`, `ROUNDS: 5`) for a change the
+     maintainer flags as expensive-if-wrong beyond what §3.3 auto-detects.
+   - *Light (`SPAWNS: 6`, `ROUNDS: 2`)* — for a small / mechanical change. The
+     doc's own trivia clause (§11) still applies underneath: a sub-50-line,
+     no-stakes diff with a green pre-pass gets angles 4+5 at sonnet, one round.
    - *None* — skip review. AGENTS.md makes the multi-angle review **mandatory for
      every change**, so this is the maintainer explicitly overriding that step;
      confirm they mean it and note the risk in the PR body.
+
+   The stakes override (§3.3 — privileged helper, secrets/relay tokens, gateway
+   auth, proxy headers, daemon API, SQLite migrations) is **not** downgradable by
+   this answer. If *Light* is chosen and the diff turns out to touch one of those
+   paths, run the standard loop and say so in the final report.
 2. **Merge policy** (AGENTS.md's default posture is **ask-first**; bypass is the
    exception and requires the maintainer's explicit upfront authorization, which
    this questionnaire captures)
@@ -88,19 +97,35 @@ call either way. When the change is website-facing, prefer serving it locally
 (`veld start website:local`) and collaborating through `veld feedback` before
 shipping.
 
-## Step 4 — Review rounds
+## Step 4 — Review loop
 
-Run the review at the depth chosen in Step 0, following
-[docs/agentic-review.md](../../../docs/agentic-review.md):
+Run the **autonomous multi-angle review loop** in
+[docs/agentic-review.md](../../../docs/agentic-review.md) at the depth chosen in
+Step 0. That doc is the operative spec — follow it end to end rather than
+improvising a review. The parts most easily skipped, and therefore worth naming
+here:
 
-- Spawn the review angles as **parallel background sub-agents**, `model: opus`,
-  one angle each. Give every angle the exact diff target
-  (`git diff origin/main...HEAD`), the intent in 1-3 sentences, and where to read
-  the real dependency source.
-- Verify every critical/major yourself before acting. Fix all 🔴/🟠 (and cheap
-  🟡). Re-run the angles on the post-fix diff — fixes introduce their own
-  defects. Loop until a round is clean or the round cap hits.
-- Report a deduped, severity-sorted summary — not the raw agent output.
+- **Pre-pass first** (§1.1) — `rustup update stable`, clippy, `cargo fmt --check`,
+  tests, plus the UI checks when `crates/veld-daemon/ui` is touched. Red pre-pass
+  → fix before spawning anything. Its output is out of scope for every subagent.
+- **Build the context pack once** (§1) and hand the same one to every angle:
+  diff target, intent, in/out of scope paths, change shape, and the pinned
+  dependency source paths (`~/.cargo/registry/src/...`).
+- **Stages A → B → C** (§5), angles blind to each other within a stage,
+  `run_in_background: true`, `model:` set explicitly per the §3.2 routing table —
+  not opus for everything.
+- **Verify every 🔴/🟠 yourself before fixing** (§8.3). No unverified finding gets
+  fixed — under autonomy that's how a hallucination becomes a commit.
+- **Ledger** at `notes/review/ledger.md` (gitignored), updated every round —
+  it's your memory across compaction. Keep it out of your commits.
+- **Report once, at the end**, in the §10 format. No per-round narration, no raw
+  subagent dumps.
+
+The loop's hard stops (§2) are the *review's* escalation points and they compose
+with this skill's **When to involve the human** list — a redesign-class 🔴 or a
+deadlock halts the run and comes back to the maintainer; a `DECISION-REQUIRED`
+finding does not halt the loop but must appear in the final report and, if it
+gates the PR, in the PR body.
 
 ## Step 5 — PR
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ Follow this workflow for every feature or fix:
 
 1. **Implement** — Make the code changes.
 2. **Docs audit** — Before considering the work done, check the [documentation checklist](#documentation-checklist) below.
-3. **Review rounds (repeated multi-angle)** — Run the five-angle adversarial review in [docs/agentic-review.md](docs/agentic-review.md) on the diff, fix the findings, then repeat the review on the post-fix diff. Iterate until a round surfaces no critical/major findings (see the doc's stop condition + round cap). Do not run separate single-reviewer warm-up rounds — the multi-angle pass replaces them. (For trivial changes, three angles — counterfactual + what-isn't-here + self-consistency — suffice, per the tuning notes in the review doc.)
+3. **Review loop (autonomous, multi-angle, staged)** — Run the loop in [docs/agentic-review.md](docs/agentic-review.md) on the diff: pre-pass (clippy/fmt/tests) → context pack → staged angles as parallel background subagents with explicit per-angle model tiering → verify each critical/major yourself → fix → re-review the fix delta. Loop until the doc's exit criteria hold or a cap/hard stop fires. Do not run separate single-reviewer warm-up rounds — the multi-angle pass replaces them. Diffs under ~50 lines with no stakes flag take the doc's trivia clause (§11); the stakes override (§3.3) is never downgradable.
 4. **Push to draft PR** — Push the branch and open a draft PR on GitHub.
 5. **Wait for CI** — All checks must be green. Never assume checks are missing just because they haven't started yet.
 6. **Ask before merging** — Ask the maintainer for explicit approval before merging. Only merge with admin bypass if the maintainer explicitly says so upfront at task start.

--- a/docs/agentic-review.md
+++ b/docs/agentic-review.md
@@ -1,245 +1,444 @@
-# Deep Review Methodology
+# Autonomous multi-angle review loop
 
-A multi-angle adversarial review for a diff/PR, run after the normal self-review
-pass (see `AGENTS.md` → PR Workflow → Review rounds) whenever the change is
-non-trivial or the maintainer asks for a deeper look. It's heavier than a single
-review pass — reserve it for changes where a missed edge case is expensive, not
-for typo fixes.
+The review methodology for every veld change (see `AGENTS.md` → PR Workflow →
+Review rounds). You are the orchestrator: review the diff, fix what you find,
+re-review your own fixes, and keep going until the exit criteria in §9 are met.
+Do **not** check in between rounds — the maintainer is not watching. Report once,
+at the end, unless you hit one of the three hard stops in §2.
 
-## Orchestrator instructions
+```
+DIFF:      auto     # auto = committed-but-unpushed + uncommitted, vs. merge-base with default branch
+INTENT:    auto     # auto = derive from branch name, commit messages, PR body
+SPAWNS:    14       # max subagent spawns across all rounds; of which max 6 opus
+ROUNDS:    auto     # 2 low-risk / 3 default / 5 stakes-elevated (§3.3)
+AUTONOMY:  full
+```
 
-Spawn **five** subagents in parallel via the Agent tool, each with one of the
-angle-specific briefs below. Run all five in the background; report when all
-complete, then drive the **review → fix → re-review loop** (see "Iterate until
-confident" at the end) until only minor findings remain.
+Resolve `auto` values yourself in §1. If `DIFF` resolves to nothing, say so and
+stop — don't invent a review target.
 
-**Spawn config (apply to every subagent):**
-
-- `model: opus` — set explicitly. Do not rely on inheritance (it can fall back
-  to a non-Anthropic model).
-- `run_in_background: true` — launch all in one message, then continue other
-  work; you're notified as each completes.
-- One angle per subagent. Do not merge angles — the value is in the separation.
-
-**Diff under review:** state it explicitly (e.g. `git diff origin/main...HEAD`,
-"the staged changes", "the uncommitted working tree", "PR #1234") in every brief
-so every subagent reads the same surface. If the diff is large, also tell each
-subagent which paths are in scope vs. vendored / generated / out of scope.
-
-**Context to hand each subagent:** the diff target, the repo path, and 1-3
-sentences on what the change is *trying* to do (the intent). A reviewer who
-knows the goal finds gaps a context-free reviewer misses.
-
-**Pin the dependency surface.** If the change's correctness depends on a
-library's behavior (error strings, return shapes, enum values, version-specific
-semantics), tell each subagent the exact installed version and where to read its
-source (e.g. an installed crate path under `~/.cargo/registry/src/...`, or a
-`node_modules/.pnpm/...` path). "Verify against the real thing" only works if
-they know where the real thing is.
+**You cannot observe your own token consumption.** Do not estimate it, report it,
+or ration against it. Never shorten a read, skip a verification, or exit a round
+because you feel expensive — a cheap unverified finding is worth less than no
+finding. Cost is controlled by the caps above and the routing in §3, which are
+countable. Count spawns and rounds; ignore tokens.
 
 ---
 
-## Shared rules (every angle)
+## 1. Boot
+
+Resolve config, then build the **context pack**. Build it once; every subagent
+gets the same one. This is the single largest cost lever — subagents that
+re-derive repo context five times in parallel are how this gets expensive.
+
+```
+- Diff target:      <resolved command / ref>
+- Repo path:        <absolute>
+- Intent:           <1-3 sentences: what this change is trying to do>
+- In scope:         <paths>
+- Out of scope:     <vendored, generated, lockfiles, snapshots>
+- Change shape(s):  <§3.1>
+- File inventory:   <path, ±lines, shape, stakes flag>
+- Dependency surface: <lib@exact-version + installed source path> for every
+                    library whose behavior the change's correctness depends on
+                    (error strings, return shapes, enum values, version quirks)
+- Pre-pass results: <§1.1, verbatim>
+- Ledger path:      notes/review/ledger.md
+```
+
+Pin dependency source paths literally — in this repo that means the installed
+crate source under `~/.cargo/registry/src/index.crates.io-*/<crate>-<version>/`
+(or the `[patch]`/path dependency it actually resolves to), and
+`crates/veld-daemon/ui/node_modules/...` for the UI. "Verify against the real
+thing" only works if they know where the real thing is.
+
+The ledger lives under gitignored `notes/` (AGENTS.md → working documents are
+never tracked). This loop creates local commits; an untracked `.review/` would
+get swept into one.
+
+### 1.1 Pre-pass — free signal, zero agents
+
+Run before spawning anything. In this repo:
+
+```
+rustup update stable                      # CI uses floating stable — drift blocks it
+cargo clippy --workspace --all-targets
+cargo fmt --all --check
+cargo test --workspace                    # or the subset covering touched crates
+git diff --stat <diff-target>
+git log --oneline -- <touched paths>
+```
+
+Plus, when the diff touches them: `npm run typecheck` / `npm run lint` in
+`crates/veld-daemon/ui`, and any schema or license drift gate the change is near.
+Capture output verbatim.
+
+- **Pre-pass red → fix that first**, then start. Reviewing a diff that doesn't
+  compile or whose tests fail is a category error.
+- **Everything the pre-pass reports is out of scope for every subagent.** Put
+  this line in every brief: *"The typechecker, linter and tests already ran;
+  their output is in the context pack. Do not re-report it. Findings that
+  duplicate tool output count against you."*
+
+### 1.2 Ledger
+
+Create `notes/review/ledger.md` and update it after every round. You will lose
+context to compaction during a long run; the ledger is your memory.
+
+```
+## Round N — <timestamp> — spawns: <this round: 3O 2S 0H / cumulative: n of 14>
+| id | path:line | sev | angle(s) | status | note |
+|----|-----------|-----|----------|--------|------|
+| F1 | src/a.rs:44 | 🔴 | 1,4 | fixed@<sha-or-desc> | |
+| F2 | src/b.rs:12 | 🟠 | 3 | deferred | out of diff scope → ticket |
+| F3 | src/c.rs:90 | 🟠 | 5 | DECISION-REQUIRED | see §2b |
+```
+
+Statuses: `open` / `fixed` / `verified-fixed` / `deferred` / `dropped-unverified`
+/ `DECISION-REQUIRED` / `RESURFACED`.
+
+---
+
+## 2. Autonomy contract
+
+**Do without asking:** spawn/kill subagents, read anything, run tests and
+linters, apply fixes, re-route angles, add rounds within budget, write to
+`notes/review/`, create local commits on the current branch.
+
+**Never do:** push, force-push, amend or rebase others' commits, touch the
+default branch, modify CI credentials or secrets, delete tests to make them pass,
+widen scope into pre-existing bugs the diff merely exposed, reformat or "improve"
+code outside a finding's fix, change intended product behavior.
+
+**Three hard stops — halt the loop, write the report, ask:**
+
+- **(a) Redesign.** A 🔴 that can't be fixed without changing the approach or
+  architecture. Do not autonomously rewrite someone's design. State the finding,
+  the two or three viable directions, and your recommendation.
+- **(b) Decision required.** A fix requires choosing product behavior (which
+  error the user sees, what the default becomes, whether to break a consumer).
+  Log `DECISION-REQUIRED`, **continue the loop on everything else**, and surface
+  it in the final report. Only halt entirely if it blocks the remaining work.
+- **(c) Deadlock.** Same finding resurfaces after a fix twice, or fixes are
+  ping-ponging (round N's fix reintroduces round N-1's finding). That's a
+  disagreement about what "correct" means, not a loop to grind. Halt, state both
+  positions.
+
+Hitting the spawn or round cap with blockers still open is also a halt — report
+honestly, name what went unreviewed, and ask for a raised cap. Never quietly
+finish a thinner review and present it as a complete one.
+
+---
+
+## 3. Triage & routing
+
+### 3.1 Classify the change shape
+
+Label the diff — multiple labels allowed; route the union, scoping each angle to
+the files that earned it. For diffs over ~30 files, delegate classification to a
+**haiku** agent that returns a file inventory + per-cluster label, then spot-check
+its labels on 2-3 files before trusting them.
+
+`mechanical-refactor` (rename/codemod/extraction, behavior claimed unchanged) ·
+`new-feature` · `bugfix` · `config-infra` · `docs-prompts` · `dep-bump` ·
+`schema-migration` (DB, serialized formats, API contracts, event payloads) ·
+`deletion`
+
+In this repo `schema-migration` covers SQLite migrations (`user_version` steps),
+`schema/v2/veld.schema.json`, `veld.json` wire compatibility, daemon HTTP/WS API
+shapes, and anything a shipped binary must still parse after an update.
+
+If the diff is three unrelated changes in a trenchcoat, review them as separate
+scoped passes rather than one composite.
+
+### 3.2 Routing table
+
+`O` = opus, `S` = sonnet, `H` = haiku, `—` = don't run. Set `model:` explicitly
+on every spawn; never inherit (inheritance can silently fall back and defeats the
+tiering).
+
+| Shape | 1 Counterfactual | 2 Persona | 3 Assumptions | 4 Missing | 5 Self-consist. | 6 Invariance | 7 Threat |
+|---|---|---|---|---|---|---|---|
+| `mechanical-refactor` | — | — | S | S | S | **O→H sweep** | — |
+| `new-feature` | **O** | S | **O** | **O** | S | — | if stakes |
+| `bugfix` | S | — | **O** | S | S | — | if stakes |
+| `config-infra` | S | S | **O** | **O** | S | — | if stakes |
+| `docs-prompts` | S | **O** | S | **O** | S | — | — |
+| `dep-bump` | — | — | **O** | S | H | S | if stakes |
+| `schema-migration` | **O** | S | **O** | **O** | S | **O** | **O** |
+| `deletion` | S | — | S | **O** | S | **O** | — |
+
+Tier by task shape, not diff size: open-ended hypothesis generation (angles 1, 3)
+is what you're paying opus for; closed-form checking against an explicit spec
+(angles 5, 6-sweep) is sonnet/haiku work.
+
+### 3.3 Stakes override — routing cannot drop these
+
+If any touched path matches auth, authn/authz, session, crypto, payment, billing,
+PII, migration, or anything the repo marks security-sensitive:
+
+- Angles 3 and 7 run at **opus** regardless of shape or size.
+- Round cap → 5. No cheap-tier substitution **anywhere** in the diff.
+
+Three lines in middleware outrank three hundred in a fixture.
+
+Veld's stakes-elevated surfaces: the privileged helper and anything it executes,
+Caddy config emission, relay auth tokens / `SecretSource` (including
+`command`-sourced secrets and daemon `PATH`), gateway password + share links and
+public web sharing, proxy header rules, the daemon's HTTP/WS API and PTY
+endpoints, and any SQLite migration.
+
+### 3.4 Reclassification
+
+End every brief with:
+
+> If the diff contradicts its stated classification — you were told mechanical
+> refactor and you find a behavior change, a changed default, a dropped branch, a
+> new external call — **stop your angle and return
+> `RECLASSIFY: <finding at path:line>` immediately** instead of completing the
+> review. Wrong routing is more expensive than your unfinished report.
+
+On `RECLASSIFY`: re-route from §3.2 with the corrected shape, re-run the affected
+stage, log it. If this never fires across a long run, you're rubber-stamping your
+own classifier.
+
+### 3.5 Exemplar-then-sweep (repetitive diffs)
+
+When the same transformation is applied across many files, do **not** review them
+all at depth:
+
+1. **Exemplar (opus, 1 agent):** pick 3-5 files spanning the variation —
+   simplest, most complex, structurally odd. Output is not findings but an
+   **explicit invariant checklist**: what must be true of every correct site,
+   what a partial migration looks like, what the legitimate exceptions are.
+2. **Sweep (haiku, parallel, batched files):** each agent gets the checklist and
+   a batch. Output is closed-form, one line per site:
+   `path:line: MIGRATED | PARTIAL | UNTOUCHED | DEVIATES: <invariant>`. No prose,
+   no severity, no judgment.
+3. Escalate only non-`MIGRATED` lines to a real angle.
+
+If any invariant is expressible as a command (`rg 'oldSymbol'` returns zero
+hits), **run the command instead of asking an agent**. If sweep agents are being
+asked to judge anything, the checklist was underspecified — rewrite the
+checklist, don't upgrade the model.
+
+---
+
+## 4. Spawn rules
+
+- One angle per subagent. Merging angles destroys the separation that makes this
+  work.
+- `run_in_background: true`, all agents of a stage launched in one message.
+  Stages are sequential; angles within a stage are parallel.
+- **Angles within a stage are blind to each other.** Never pass one angle's
+  findings to a peer in the same stage — independent hits on the same `path:line`
+  are only signal if they were actually independent.
+- **Subagents are read-only.** Only you write files. Five background agents
+  editing the same tree is not a review, it's a merge conflict generator.
+
+---
+
+## 5. Staged execution
+
+**Stage A — structural.** Angles 1, 4, 7. Judges *whether the approach is right*.
+Gate: verify and fix 🔴/🟠 before proceeding. A 🔴 implying redesign → hard stop
+(a). Zero 🔴/🟠 on a low-stakes diff → skip to Stage C.
+
+**Stage B — behavioral.** Angles 2, 3, on the post-Stage-A diff. Judges *whether
+the right approach was implemented soundly*. Gate: fix 🔴/🟠 before Stage C.
+
+**Stage C — local.** Angles 5, 6, plus any sweep. Judges *whether the lines are
+internally consistent*. Runs only on a diff that has stopped moving.
+
+Sequencing is not stylistic: local hygiene findings on code that a structural fix
+is about to rewrite are findings you paid for and then deleted.
+
+---
+
+## 6. Shared rules (every angle, every stage)
 
 - **Read the diff as if you didn't write it.** No benefit of the doubt.
-- **Verify before you flag.** If you claim a link is broken, a symbol is
-  undefined, a file is missing, a string doesn't match, or a command fails — run
-  the check (grep, open the file, resolve the anchor, read the installed library
-  source, execute the command). A flagged finding you didn't verify is noise.
-  Say "unverified" if you genuinely can't check.
-- **State old-vs-new for every changed line.** For each meaningful change, name
-  what the behavior/signal/field/payload was *before* and what it is *now*. The
-  most-missed defects are silent **deletions** — a stack trace, a metric, a
-  Sentry signal, a log field, a branch — that vanish without the diff looking
-  like a removal. A review that only judges the new state in isolation misses
-  these.
-- **Don't flag prose nits.** Spelling, wording, formatting — skip, unless it
-  changes meaning or misleads.
-- **Surface only structural / semantic / edge-case / self-consistency
-  findings.** The bar is "this will bite someone", not "I'd have written it
-  differently".
-- **Concrete locations only.** Every finding cites a real `path:line`, not
-  "the doc" or "somewhere in the config".
-- **Don't pad.** Zero findings is a valid, honest result. Do not manufacture
-  low-severity findings to look thorough. Three real findings beat ten
-  speculative ones.
+- **Don't re-report the pre-pass.**
+- **Verify before you flag — but batch it.** Run the check, or mark the finding
+  `unverified` **and state the exact command that would settle it**. The
+  orchestrator batch-runs all unverified checks once, deduped.
+- **State old-vs-new for every changed line.** What the
+  behavior/signal/field/payload was *before* and what it is *now*. The
+  most-missed defects are silent deletions — a stack trace, a metric, a Sentry
+  signal, a log field, a branch — that vanish without the diff looking like a
+  removal.
+- **No prose nits** unless wording changes meaning or misleads.
+- **Concrete `path:line` only.** Never "the doc" or "somewhere in the config".
+- **Don't pad.** Zero findings is a valid, honest result. Budget: ~1 finding per
+  20 changed lines, hard cap 60 output lines. Under autonomy a padded finding
+  becomes an unwanted code change — inflation has teeth here.
+- **Reclassification clause** (§3.4).
 
-**Severity legend (use these exact emojis + words):**
+**Severity:**
 
 - `🔴 critical` — silent breakage, data-correctness bug, security exposure, or
   something that will actively mislead the next person/agent who reads it.
-- `🟠 major` — real fragility with no documented mitigation; will bite under a
+- `🟠 major` — real fragility with no documented mitigation; bites under a
   realistic condition.
-- `🟡 medium` — drift, an unhandled-but-unlikely edge, a missing guard that's
-  defensible to defer.
-- `🟢 minor` — speculative / cosmetic-with-meaning / nice-to-have. (Report
-  sparingly.)
+- `🟡 medium` — drift, unlikely-but-unhandled edge, defensibly deferrable guard.
+- `🟢 minor` — speculative / cosmetic-with-meaning. Sparingly.
 
-**Output format — one finding per line:**
+**Line format:**
 
 ```
-[angle] path:line: <emoji> <severity>: <problem>. <fix>.
+[angle] path:line: <emoji> <severity>: <problem>. <fix>. [verified|unverified: <cmd>]
 ```
 
-The `[angle]` tag (`[counterfactual]` / `[persona]` / `[assumption]` /
-`[whats-missing]` / `[self-consistency]`) lets the orchestrator dedupe
-overlapping findings across the reports.
-
-- **Cap output at ~200 lines.** If you're past that, you're flagging nits —
-  raise the bar.
-- **End with a verdict line:** `ship it` only if you found zero `🔴`/`🟠`
-  findings. Otherwise end with `blocking: <N> critical, <M> major`.
+**Verdict line:** `ship it` only if zero 🔴/🟠, else
+`blocking: <N> critical, <M> major`.
 
 ---
 
-## Angle 1 — Counterfactual reviewer
+## 7. The angles
 
-For every design choice in the diff, imagine the opposite was picked. What edge
-case does the opposite catch that this one misses? What's the cost of each
-choice? Are there choices that look arbitrary (could have gone either way) — and
-is that arbitrariness documented anywhere? Probe load-bearing decisions: the
-ones where, if they're wrong, a lot breaks. For each, state what would have to
-be true for the chosen option to be wrong, and whether the diff would surface
-that.
+**1 — Counterfactual.** For every design choice, imagine the opposite was picked.
+What edge case does the opposite catch that this one misses? What's the cost of
+each? Which choices look arbitrary, and is the arbitrariness documented anywhere?
+Probe load-bearing decisions — the ones where, if wrong, a lot breaks. For each:
+what would have to be true for the chosen option to be wrong, and would the diff
+surface that?
 
-## Angle 2 — Persona-walkthrough reviewer
+**2 — Persona walkthrough.** Three concrete tasks, three personas: (a) new hire,
+zero context, week two, handed one onboarding task — where do they get stuck or
+guess wrong; (b) the engineer editing this file in six months without re-reading
+the PR — what trap do they fall into because the reasoning lives only in the PR;
+(c) the careless contributor who writes the natural-but-wrong thing — does
+anything stop them. Name the task and the gap. "Could be clearer" doesn't count;
+show the failure.
 
-Walk through realistic tasks as three personas:
-
-- **(a) New hire, zero project context**, who'll touch this in week two. Pick one
-  concrete onboarding task they'd be handed; find where they get stuck or guess
-  wrong.
-- **(b) The engineer who edits this file six months from now** without
-  re-reading the PR or its discussion. Pick one realistic edit; find the trap
-  they fall into because the reasoning lives only in the PR, not the code/docs.
-- **(c) The careless contributor** who writes the natural-but-wrong thing
-  because the doc/API didn't pre-empt it. Pick the most-likely wrong move; find
-  whether anything stops them.
-
-For each persona, name the concrete task and the concrete gap. Generic "this
-could be clearer" doesn't count — show the failure.
-
-## Angle 3 — Implicit-assumption hunter
-
-Find unstated assumptions the author didn't realise they made. Probe: tooling
-versions, working directory, shell, file encoding, locale/timezone, OS
-case-sensitivity, path separators, ordering guarantees, idempotency, what
-happens on re-run, partial-failure / interrupted-midway behaviour, concurrency /
-parallel execution, ID/format assumptions (numeric vs string, length, charset),
-and which *other* systems read the same artifacts and could parse them
-differently. Each unsurfaced assumption is a fragility — name it, and name the
+**3 — Implicit assumptions.** Unstated assumptions the author didn't realise they
+made: tooling versions, working directory, shell, encoding, locale/timezone, OS
+case-sensitivity, path separators, ordering guarantees, idempotency, re-run
+behavior, partial-failure / interrupted-midway state, concurrency, ID/format
+assumptions (numeric vs string, length, charset), and which *other* systems read
+the same artifacts and may parse them differently. Name each assumption and the
 condition under which it bites.
 
-## Angle 4 — What-isn't-here reviewer
+**4 — What isn't here.** Undefined corners of the contract. Doc claims with no
+test, example, or source behind them. New load-bearing logic with no test. Rules
+with an obvious unlisted exception. Adjacent systems (CI, IDE, pre-commit hooks,
+generated artifacts, downstream consumers, docs) that interact with this change
+but aren't addressed. New code paths with no error handling. Signals (metrics,
+alerts, breadcrumbs) a downstream team relied on that this change removes or
+bypasses.
 
-What's NOT in the diff that should be? Silently undefined corners of the
-contract. Documentation claims with no test, no example, no source backing them.
-New load-bearing logic with no test. Rules stated with an obvious exception the
-author didn't list. Adjacent systems (CI, IDE, pre-commit hooks, generated
-artifacts, downstream consumers, docs, future work) that interact with this
-change but aren't addressed. New code paths with no error handling. Signals
-(metrics, alerts, breadcrumbs) that a downstream team relied on and this change
-removes or bypasses. The diff is the visible iceberg — describe what's under the
-waterline.
+**5 — Self-consistency / literal hygiene.** Only the added/changed lines, no
+downstream reasoning. (a) Does every comment still match the code it sits on — if
+it enumerates cases, does the code produce all of them, no more, no fewer?
+(b) Does each call match the callee's declared types, shapes, conventions?
+(c) What field, signal, metric, stack trace, or log detail existed on this exact
+path before and is now silently dropped? (d) Anything that can be `0`, empty,
+`undefined`, or negative handled as if it can't — off-by-one, nullish-coalescing
+preserving a wrong zero, fallbacks masking real state? (e) Branches, regex
+alternations, or conditions that can never fire on real inputs. Cite the
+contradicting neighbor line every time. Do not speculate about production impact.
 
-## Angle 5 — Diff self-consistency / literal-hygiene reviewer
+**6 — Invariance** (refactors, deletions, dep bumps). The change *claims*
+behavior is unchanged. Disprove it. Enumerate every call site / consumer: fully
+migrated, partially, or untouched? Where the transformation is "equivalent," name
+the input class for which it isn't — evaluation order, short-circuiting,
+exception types, coercion, default args, mutation vs copy, async timing. What did
+the old path emit (logs, metrics, errors, traces) that the new one doesn't? For
+deletions: who still reads this — dashboards, alerts, downstream jobs, external
+consumers, docs, dangling flags? Prefer commands over prose.
 
-Read **only the added/changed lines**, with no downstream reasoning — the
-narrow, local, literal pass. This is the lens the "will it bite in production"
-angles structurally under-weight. For each changed line, check:
-
-- **(a) Comment ↔ code agreement.** Does every comment/docstring on the change
-  still match the code it sits on? If a comment enumerates values, ranges, or
-  cases ("first / retry / exhausted"), does the code actually produce all of
-  them — no more, no fewer?
-- **(b) API-convention conformance.** Does each call match the callee's declared
-  parameter types, expected shapes, and conventions? Wrong-but-tolerated
-  argument types, values that violate a documented contract, etc.
-- **(c) Before/after payload delta.** What field, signal, metric, stack trace,
-  or log detail existed on this exact path before and is now silently dropped or
-  changed? (This overlaps the shared "old-vs-new" rule — here, apply it
-  line-locally and exhaustively.)
-- **(d) Degenerate / boundary values.** Any value that can be `0`, empty,
-  `undefined`, or negative that the changed line handles as if it can't?
-  Off-by-one, nullish-coalescing that preserves a wrong zero, fallbacks that
-  mask a real state.
-- **(e) Dead or unreachable sub-expressions.** Branches, regex alternations, or
-  conditions in the new code that can never fire given the real inputs.
-
-Cite the contradicting neighbor line for every finding. This angle does NOT
-speculate about production impact — it reports local contradictions and lets the
-orchestrator weigh severity.
+**7 — Threat model** (stakes-elevated). Where does this move a trust boundary?
+New input reaching a privileged path, new deserialization, new external call,
+widened permission, weakened validation, secret in a new place, new log line that
+might carry PII, timing or error-message oracle. State the attacker, the required
+capability, and the concrete diff line that enables it.
 
 ---
 
-## Consuming the reports (orchestrator)
+## 8. Consume → fix → verify
 
-When all five complete:
-
-1. **Dedupe by location.** The same `path:line` flagged by multiple angles is a
-   strong signal — promote it, don't list it five times. Record how many angles
-   independently hit it.
-2. **Sort by severity**, then by independent-angle count.
-3. **Verify the criticals and majors yourself** before acting — the subagent's
-   summary describes what it intended to find, not necessarily what's true. Open
-   the file, read the installed library source, run the check. Downgrade or drop
-   anything that doesn't survive your own verification; upgrade anything a
-   subagent under-rated.
-4. **Decide fix-now vs. defer.** Criticals and majors block; mediums/minors can
-   become tracked follow-ups. Honor any explicit "only fix critical stuff"
-   instruction — don't over-correct on speculative findings. Findings that are
-   real but out of the diff's scope (a pre-existing bug the change merely made
-   visible) become their own ticket, not scope creep into this change.
-5. **Report a deduped, severity-sorted summary** to the human. Don't dump the
-   raw reports.
-
----
-
-## Iterate until confident (review → fix → re-review loop)
-
-A single review pass is a snapshot, and fixes introduce their own defects. Loop:
-
-1. **Round 1:** run all five angles, consume as above, produce the deduped
-   finding list.
-2. **Fix:** apply fixes for every `🔴` and `🟠` (and any `🟡` cheap enough to
-   fold in). Where a fix is a design choice with real downstream consequence,
-   surface it to the human before applying rather than guessing.
-3. **Re-review:** re-run the angles **on the post-fix diff**. This catches
-   regressions the fixes introduced — a fix for one finding routinely creates
-   another. Give each angle the previous round's findings as context so it can
-   confirm they're resolved and hunt for what the fix broke.
-4. **Repeat** until the **stop condition** is met.
-
-**Stop condition — stop when ANY of these holds:**
-
-- A full round surfaces **zero `🔴` and zero `🟠`** findings, and the remaining
-  `🟡`/`🟢` are ones you've consciously chosen to defer or accept. This is the
-  target: "only minor stuff left, confidence high."
-- A round adds **only speculative / cosmetic findings** and no new real defect —
-  diminishing returns; stop even if some `🟡` remain.
-- You hit a **round cap** (default: 3 rounds; raise to 4-5 only for
-  security-sensitive or data-correctness-critical diffs). Expect sharply
-  diminishing returns after round 2.
-
-**Escalate instead of looping forever.** If a `🔴`/`🟠` keeps resurfacing across
-two rounds because the fix and the review disagree on what "correct" is, that's
-not a loop to grind — it's a design question. Stop and surface the disagreement
-to the human with both positions stated. Same if fixes are ping-ponging (each
-round's fix reintroduces a prior round's finding).
-
-**Report per round.** After each round tell the human: findings this round
-(deduped, severity-sorted), what you fixed, what you deferred and why, and the
-current confidence level ("2 majors → 0 majors, 1 medium deferred to ticket
-#X, high confidence"). The human can halt the loop at any round.
+1. **Dedupe by location.** Same `path:line` from multiple angles *in the same
+   stage* is real signal — promote it, record the count. Cross-stage agreement is
+   not independent; don't count it as corroboration.
+2. **Batch-run unverified checks** in one pass. Drop what doesn't survive; log as
+   `dropped-unverified`.
+3. **Verify every 🔴 and 🟠 yourself** before touching code. A subagent's summary
+   describes what it intended to find, not necessarily what's true. Open the
+   file, read the installed library source, run the command. Downgrade what
+   fails, upgrade what was under-rated. **No unverified finding gets fixed** —
+   under autonomy that's how a hallucination becomes a commit.
+4. **Fix discipline:**
+   - Minimal fix for the stated finding. No adjacent refactoring, no
+     reformatting, no drive-by improvements.
+   - After each fix, re-run the pre-pass. **If a fix turns the pre-pass red,
+     revert it** and log the finding as `DECISION-REQUIRED`.
+   - A fix that would change intended product behavior is not a fix — log it
+     `DECISION-REQUIRED` (§2b) and move on.
+   - Real-but-out-of-scope findings (pre-existing bugs the diff merely exposed) →
+     `deferred`, collected into a follow-up list. Not scope creep.
+   - Dispatch mechanical fixes (renames, missing guards, comment/code
+     reconciliation) to a **sonnet** fixer with the finding line as its entire
+     brief. Reserve your own context for judgment.
+   - Commit per finding-cluster with the finding id in the message. Locally only.
+5. **Update the ledger.**
 
 ---
 
-## Optional tuning
+## 9. Loop & exit
 
-- **Fewer/more angles.** Five is the default breadth. For a tiny diff, three
-  (counterfactual + what-isn't-here + self-consistency) often suffice. For a
-  security-sensitive diff, add a sixth dedicated threat-model angle.
-- **Round cap** scales with stakes: 2 for a low-risk change, 3 default, 4-5 for
-  money/PII/auth paths.
-- **Skip the loop** only when explicitly told "one pass, findings only, no
-  fixes" — then run round 1, report, and stop.
+**Round N+1 reviews the fix delta, not the whole diff.** Hand each angle: the
+diff of the fixes only, the prior findings with claimed resolution (confirm or
+refute), and an instruction to hunt for what the fixes broke. Re-run the full
+diff only if fixes touched more than ~30% of the changed surface or altered the
+design. Otherwise you're re-reading stable code at full price.
+
+**Exit when all of these hold:**
+
+- A full round produced zero 🔴 and zero 🟠;
+- pre-pass is green;
+- no open `RECLASSIFY`;
+- every remaining 🟡/🟢 is explicitly `deferred` with a one-line reason.
+
+**Or exit early when any of these holds** — these are successes, not failures:
+
+- A round produced only speculative findings and no new real defect (diminishing
+  returns).
+- Marginal yield fell below one new 🔴/🟠 per round.
+- Round cap (§3.3) or spawn cap reached — report state honestly, per §2.
+- Hard stop (a), (b-blocking), or (c) fired.
+
+---
+
+## 10. Final report (one, at the end)
+
+```
+## Verdict: ship it | blocking: <N> critical, <M> major | halted: <reason>
+
+**Rounds:** <n>   **Spawns:** <n opus / n sonnet / n haiku>   **Confidence:** <high/medium/low + why>
+
+### Fixed
+<id> path:line 🔴 <one line: what was wrong, what you changed>
+
+### Needs your decision
+<id> path:line — <the choice, the options, your recommendation>
+
+### Deferred (with reason)
+<id> path:line 🟡 <why it's safe to defer>
+
+### Follow-up tickets (out of scope for this diff)
+<one line each>
+
+### What I did not review
+<paths excluded and why>
+```
+
+No raw subagent dumps. No per-round narration. If the verdict is `ship it`, the
+first three sections should be short and the last one honest.
+
+---
+
+## 11. Trivia clause
+
+If the diff is under ~50 lines, carries no stakes flag, and the pre-pass is
+green: skip staging, run angles 4 and 5 at sonnet, one round, report. The
+machinery costs more than the change.


### PR DESCRIPTION
## What

Replaces `docs/agentic-review.md` (five parallel opus angles, one flat loop) with the **autonomous staged multi-angle review loop**, and rewires `/ship` + AGENTS.md to it.

Docs/skills only — no code, no config, no schema. `git diff --stat`: `.claude/skills/ship/SKILL.md`, `AGENTS.md`, `docs/agentic-review.md`.

## Why

The old doc had three cost/quality problems the new one fixes:

- **Everything at opus, all angles at once.** No tiering by task shape, so closed-form checking (self-consistency, sweep) was billed like open-ended hypothesis generation. The new §3.2 routing table sets `model:` per angle per change shape.
- **No staging.** Local hygiene findings landed on code a structural fix was about to rewrite. Stages A (structural) → B (behavioral) → C (local) mean Stage C only runs on a diff that stopped moving.
- **No memory, no pre-pass gate, no fix discipline.** Long runs lost findings to compaction; subagents re-reported clippy output; unverified findings could become commits.

Added: seven angles (invariance + threat model are new), spawn/round caps, exemplar-then-sweep for repetitive diffs, a reclassification escape hatch, an autonomy contract with three hard stops, and a single end-of-run report format.

## Veld-specific adaptations

- **Pre-pass is concrete** — `rustup update stable`, `cargo clippy --workspace --all-targets`, `cargo fmt --all --check`, `cargo test --workspace`, plus UI typecheck/lint when `crates/veld-daemon/ui` is touched. Red pre-pass blocks spawning; its output is explicitly out of scope for every subagent.
- **Ledger at `notes/review/ledger.md`**, not `.review/`. Two reasons: `notes/` is already gitignored per AGENTS.md ("working documents are never tracked"), and §8.4 has the loop making local commits per finding-cluster — an untracked `.review/` would get swept into one.
- **Dependency surface** pins `~/.cargo/registry/src/index.crates.io-*/<crate>-<version>/` and the UI `node_modules`.
- **`schema-migration` shape** spelled out for this repo: SQLite `user_version` steps, `schema/v2/veld.schema.json`, `veld.json` wire compat, daemon HTTP/WS shapes, anything a shipped binary must still parse after `veld update`.
- **Stakes override** enumerates the real sensitive surfaces: privileged helper and what it executes, Caddy config emission, relay auth tokens / `SecretSource` (incl. `command` secrets + daemon `PATH`), gateway password / share links / public web sharing, proxy header rules, daemon HTTP/WS + PTY endpoints, any migration.

## `/ship` changes

- **Step 0 review depth** now picks `SPAWNS`/`ROUNDS` caps (Standard 14/auto · Deep 24/5 · Light 6/2 · None) instead of angle counts. Explicit: the §3.3 stakes override is **not** downgradable by this answer — Light + a stakes path runs the standard loop anyway and says so in the report.
- **Step 4** delegates to the doc and names the parts an agent skips first: pre-pass gate, build the context pack once, staged angles with explicit per-angle `model:` (the old text said `model: opus` for every angle), verify-every-🔴/🟠-yourself-before-fixing, ledger, report-once in the §10 format. Loop hard stops composed with the skill's existing "When to involve the human".

## Test evidence

Prose-only change to contributor docs and a `.claude/` dev skill. Nothing compiles or executes from these files, so there is nothing to test beyond CI's own markdown/link handling. Not part of the published `skills/` consumer surface.

## Reviewer scope

The methodology text itself is the deliverable — read `docs/agentic-review.md` whole rather than diffing it line-by-line against the old version; it's a replacement, not an edit. Worth a second opinion on: the §3.2 tier assignments, and whether the §3.3 veld stakes list is missing a surface.

## Follow-ups

- The docs checklist in AGENTS.md wasn't touched — this change adds no user-visible surface, so `README.md` / `docs/configuration.md` / `skills/` / schema / website stay as-is.