### PR TITLE
fix(logs): collect command node and project step output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4462,7 +4462,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "veld"
-version = "12.0.0"
+version = "12.1.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4482,7 +4482,7 @@ dependencies = [
 
 [[package]]
 name = "veld-core"
-version = "12.0.0"
+version = "12.1.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -4506,7 +4506,7 @@ dependencies = [
 
 [[package]]
 name = "veld-daemon"
-version = "12.0.0"
+version = "12.1.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -4535,7 +4535,7 @@ dependencies = [
 
 [[package]]
 name = "veld-gateway"
-version = "12.0.0"
+version = "12.1.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -4566,7 +4566,7 @@ dependencies = [
 
 [[package]]
 name = "veld-helper"
-version = "12.0.0"
+version = "12.1.1"
 dependencies = [
  "anyhow",
  "nix 0.29.0",
@@ -4582,7 +4582,7 @@ dependencies = [
 
 [[package]]
 name = "veld-share"
-version = "12.0.0"
+version = "12.1.1"
 dependencies = [
  "anyhow",
  "dirs",

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ No port numbers. No manual wiring. Just clean, stable, human-readable URLs.
 - **Named ports** — `"ports": { "http": "auto", "debug": "auto" }` for debug adapters and multi-port containers, so nothing needs a hand-picked literal port that breaks parallel worktrees
 - **Structured output** — all commands support `--json` for scripting and CI
 - **Browser dashboard** — management UI at `https://veld.localhost` with service health, logs, search, stop/restart
+- **Every step's output is collected** — `command` nodes (a `docker build`, a `pnpm install`) log to their node's stream exactly like servers do, and project `setup`/`teardown` steps to the run's; nothing a step prints is thrown away. Lines also stream into `veld start`'s progress output as they arrive, instead of scribbling over it
 - **Client-side logs** — captures browser `console.log/warn/error`, exceptions, and promise rejections; view with `veld logs --source client`
 - **Internal logs** — liveness probe outcomes (with stderr), recovery decisions, health state transitions; view with `veld logs --source internal`
 - **Reverse-proxy header rules** — add or strip request/response headers on the local proxy and the public web gateway with a `proxy` config block (project/node/variant). Veld does no header manipulation by default.
@@ -156,7 +157,7 @@ veld stop --name dev
 | `veld urls [--name <n>] [--json]` | Show URLs for a running environment; errors if the environment is stopped (routes are torn down with the run) |
 | `veld action <name> [--name <n>] [--node <n>] [--print] [--json]` | Run a node-defined action (e.g. open the database in a GUI client); `--print` emits the resolved command |
 | `veld actions [--json]` | List the actions defined across the project's nodes |
-| `veld logs [--name <n>] [--node <n>] [--lines <n>] [-f] [--since <d>] [--run <id-prefix>] [-p] [--all-runs] [--source <s>] [-s <term>] [-C <n>] [--json]` | View logs, scoped to the latest run by default (`-f` follow — exits 0 when the followed run ends, `--run` targets a past run by id prefix, `-p`/`--previous` the run before the latest, `--all-runs` restores the old interleaved-across-runs behavior, `-s` search, `-C` context lines) |
+| `veld logs [--name <n>] [--node <n>] [--lines <n>] [-f] [--since <d>] [--run <id-prefix>] [-p] [--all-runs] [--source <s>] [-s <term>] [-C <n>] [--json]` | View logs, scoped to the latest run by default (`-f` follow — exits 0 when the followed run ends, `--run` targets a past run by id prefix, `-p`/`--previous` the run before the latest, `--all-runs` restores the old interleaved-across-runs behavior, `-s` search, `-C` context lines, `--source` is one of `all` (default), `server` — node output, `client`, `setup` — project setup/teardown steps, `internal`) |
 | `veld graph [NODE:VARIANT...]` | Print dependency graph |
 | `veld nodes [--json]` | List all nodes and variants, with the file and line each is defined in |
 | `veld presets [--json] [--pin]` | List presets with their keys, labels, and `when_to_use`. `--pin` prints the current numbering as a block to paste, freezing auto-assigned keys |

--- a/crates/veld-core/src/db/logs.rs
+++ b/crates/veld-core/src/db/logs.rs
@@ -20,7 +20,10 @@ pub enum LogStream {
     Server,
     /// Browser-side client logs (per node).
     Client,
-    /// Setup/command step output (per node).
+    /// Project `setup`/`teardown` step output. Read run-level, but the rows
+    /// carry a pseudo-node (`setup`/`teardown` + the step name as variant) so
+    /// two steps stay distinguishable in one interleaved stream. A `command`
+    /// node's output is *not* here — it goes to `Server`, like any node's.
     Setup,
     /// Orchestration trace (`--debug`, per run).
     Debug,
@@ -151,6 +154,54 @@ impl Db {
             ts_to_str(ts),
             line,
         ])?;
+        Ok(())
+    }
+
+    /// Append many lines that share a scope, as one transaction.
+    ///
+    /// A build tool emits tens of thousands of lines through one sink, and each
+    /// autocommit `INSERT` takes the process-wide connection lock on its own —
+    /// serializing against every other node in the stage and against the daemon.
+    /// Grouping the batch the reader already produced makes that one lock
+    /// acquisition and one commit.
+    #[allow(clippy::too_many_arguments)]
+    pub fn append_logs(
+        &self,
+        project_root: &Path,
+        run_name: &str,
+        run_id: Option<&str>,
+        node: Option<&str>,
+        variant: Option<&str>,
+        stream: LogStream,
+        ts: chrono::DateTime<chrono::Utc>,
+        lines: &[String],
+    ) -> Result<(), DbError> {
+        if lines.is_empty() {
+            return Ok(());
+        }
+        let mut conn = self.lock();
+        let tx = conn.transaction()?;
+        {
+            let mut stmt = tx.prepare_cached(
+                "INSERT INTO log_lines (project_root, run_name, run_id, node, variant, stream, ts, line)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            )?;
+            let root = root_key(project_root);
+            let ts = ts_to_str(ts);
+            for line in lines {
+                stmt.execute(params![
+                    root,
+                    run_name,
+                    run_id,
+                    node,
+                    variant,
+                    stream.as_str(),
+                    ts,
+                    line,
+                ])?;
+            }
+        }
+        tx.commit()?;
         Ok(())
     }
 

--- a/crates/veld-core/src/logging.rs
+++ b/crates/veld-core/src/logging.rs
@@ -103,6 +103,25 @@ impl LogWriter {
         self.write_line(&format!("[VELD] {message}")).await
     }
 
+    /// Write a batch of lines under one timestamp, as one transaction.
+    ///
+    /// The batch is what a pipe reader hands its sink; writing it line by line
+    /// would take the database lock once per line (see [`Db::append_logs`]).
+    pub fn write_lines(&self, ts: chrono::DateTime<Utc>, lines: &[String]) -> Result<(), LogError> {
+        let run_id = self.run_id.map(|id| id.to_string());
+        self.db.append_logs(
+            &self.project_root,
+            &self.run_name,
+            run_id.as_deref(),
+            self.node.as_deref(),
+            self.variant.as_deref(),
+            self.stream,
+            ts,
+            lines,
+        )?;
+        Ok(())
+    }
+
     /// Write a line with an explicit timestamp (client logs carry their own).
     pub fn write_with_ts(&self, ts: chrono::DateTime<Utc>, line: &str) -> Result<(), LogError> {
         let run_id = self.run_id.map(|id| id.to_string());

--- a/crates/veld-core/src/orchestrator.rs
+++ b/crates/veld-core/src/orchestrator.rs
@@ -928,7 +928,7 @@ impl Orchestrator {
             Ok(vars) => {
                 self.resolved_vars = Some(Arc::new(vars));
                 self.resolved_vars_run = Some(run_name.to_owned());
-                self.run_setup_steps(run_name).await
+                self.run_setup_steps(run_name, Some(run.run_id)).await
             }
             Err(e) => Err(e.into()),
         };
@@ -1419,8 +1419,29 @@ impl Orchestrator {
         // Idempotency: if skip_if passes, skip the run entirely (exit 0).
         if let Some(ref skip_if_cmd) = resolved.skip_if {
             let skip_if_resolved = skip_if_cmd.interpolate(&var_ctx)?;
-            if let Ok(out) = process::run_command(&skip_if_resolved, &working_dir, &env, None).await
-            {
+            // No sink: a probe's output is a predicate, not the node's output.
+            let probe = process::run_command(&skip_if_resolved, &working_dir, &env, None, None)
+                .await
+                .inspect_err(|e| {
+                    tracing::warn!(
+                        node = sel.node,
+                        variant = sel.variant,
+                        error = %e,
+                        "skip_if probe could not run — treating the node as not skippable"
+                    );
+                })
+                .inspect(|out| {
+                    if probe_could_not_run(out.exit_code) {
+                        tracing::warn!(
+                            node = sel.node,
+                            variant = sel.variant,
+                            exit_code = out.exit_code,
+                            command = skip_if_resolved.display(),
+                            "skip_if probe could not be executed — treating the node as not skippable"
+                        );
+                    }
+                });
+            if let Ok(out) = probe {
                 if out.exit_code == 0 {
                     tracing::info!(
                         node = sel.node,
@@ -1702,7 +1723,7 @@ impl Orchestrator {
                 // `setup` step does. No run row here, so no node selections and no
                 // run id: project surfaces only.
                 self.ensure_stop_vars(run_name, None, &[]).await;
-                self.run_teardown_steps(run_name).await;
+                self.run_teardown_steps(run_name, None).await;
                 return Ok(StopResult::AlreadyStopped);
             }
         };
@@ -1715,7 +1736,7 @@ impl Orchestrator {
             // Latest run already ended — it is history now, never deleted here.
             // Teardown steps still run so a re-stop stays a cleanup tool.
             self.ensure_stop_vars(run_name, Some(run.run_id), &[]).await;
-            self.run_teardown_steps(run_name).await;
+            self.run_teardown_steps(run_name, Some(run.run_id)).await;
             return Ok(StopResult::AlreadyStopped);
         }
 
@@ -1798,7 +1819,7 @@ impl Orchestrator {
         }
 
         // Run project-level teardown steps after all per-node on_stop hooks.
-        self.run_teardown_steps(run_name).await;
+        self.run_teardown_steps(run_name, Some(run.run_id)).await;
 
         // Persist the final node states while the run is still `stopping`
         // (save_run refuses to touch terminal runs), then finalize it into
@@ -2213,7 +2234,26 @@ impl Orchestrator {
             self.project_root.clone()
         });
 
-        match process::run_command(&resolved_cmd, &working_dir, &env, None).await {
+        // An `on_stop` hook is that node's teardown, so its output goes to that
+        // node's own `server` stream — the container it removed is the last
+        // thing in the node's log, which is where someone debugging a leak
+        // looks. Without a run instance there is nothing to attach rows to.
+        let sink = step_line_sink(
+            run_id.map(|id| {
+                LogWriter::for_node(
+                    self.db.clone(),
+                    &self.project_root,
+                    run_name,
+                    id,
+                    &node_state.node_name,
+                    &node_state.variant,
+                    LogStream::Server,
+                )
+            }),
+            &self.progress_tx,
+            (node_state.node_name.clone(), node_state.variant.clone()),
+        );
+        match process::run_command(&resolved_cmd, &working_dir, &env, None, Some(sink)).await {
             Ok(result) => {
                 if result.exit_code != 0 {
                     tracing::warn!(
@@ -2366,7 +2406,11 @@ impl Orchestrator {
 
     /// Run project-level setup steps sequentially. Returns an error if any
     /// step exits non-zero, aborting startup.
-    async fn run_setup_steps(&self, run_name: &str) -> Result<(), OrchestratorError> {
+    async fn run_setup_steps(
+        &self,
+        run_name: &str,
+        run_id: Option<uuid::Uuid>,
+    ) -> Result<(), OrchestratorError> {
         let steps = match self.config.setup.as_ref() {
             Some(steps) if !steps.is_empty() => steps,
             _ => return Ok(()),
@@ -2412,7 +2456,10 @@ impl Orchestrator {
             };
 
             let env = HashMap::new();
-            match process::run_command(&resolved_cmd, &self.project_root, &env, None).await {
+            let sink = self.project_step_sink(run_name, run_id, "setup", &step.name);
+            match process::run_command(&resolved_cmd, &self.project_root, &env, None, Some(sink))
+                .await
+            {
                 Ok(result) => {
                     if result.exit_code != 0 {
                         let reason = format!("exited with code {}", result.exit_code);
@@ -2450,9 +2497,53 @@ impl Orchestrator {
         Ok(())
     }
 
+    /// Sink for a project-level `setup`/`teardown` step's output.
+    ///
+    /// These steps belong to no node, so their lines go to the run-level
+    /// `setup` stream (`veld logs` reads it by default) and are attributed in
+    /// the UI to a pseudo-node — `setup:<step name>` — which is how a reader
+    /// tells two steps apart in one interleaved stream. A `setup` step runs
+    /// before the run row is written; the rows still carry the run id it is
+    /// about to get, so they are in scope the moment it exists.
+    fn project_step_sink(
+        &self,
+        run_name: &str,
+        run_id: Option<uuid::Uuid>,
+        kind: &str,
+        step_name: &str,
+    ) -> process::LineSink {
+        // `setup` rows are read run-level but carry a node, which is what makes
+        // two steps distinguishable in one interleaved stream: `veld logs`
+        // labels them `setup:<step name>`.
+        //
+        // With no run instance (a `veld stop` on an environment veld has no row
+        // for) nothing is written. Such rows would carry a NULL `run_id`, which
+        // every run-scoped read filters out — `veld logs --all-runs` drops the
+        // `run_id` predicate and would surface them, but that is the only way to
+        // reach them, and a line you can read only under a flag you did not know
+        // to pass is not worth keeping forever. Whoever ran the `stop` sees the
+        // output live: the sink still reports it.
+        let writer = run_id.map(|id| {
+            LogWriter::for_node(
+                self.db.clone(),
+                &self.project_root,
+                run_name,
+                id,
+                kind,
+                step_name,
+                LogStream::Setup,
+            )
+        });
+        step_line_sink(
+            writer,
+            &self.progress_tx,
+            (kind.to_owned(), step_name.to_owned()),
+        )
+    }
+
     /// Run project-level teardown steps sequentially. Best-effort: failures
     /// are logged but never propagated.
-    async fn run_teardown_steps(&self, run_name: &str) {
+    async fn run_teardown_steps(&self, run_name: &str, run_id: Option<uuid::Uuid>) {
         let steps = match self.config.teardown.as_ref() {
             Some(steps) if !steps.is_empty() => steps,
             _ => return,
@@ -2488,7 +2579,10 @@ impl Orchestrator {
             };
 
             let env = HashMap::new();
-            match process::run_command(&resolved_cmd, &self.project_root, &env, None).await {
+            let sink = self.project_step_sink(run_name, run_id, "teardown", &step.name);
+            match process::run_command(&resolved_cmd, &self.project_root, &env, None, Some(sink))
+                .await
+            {
                 Ok(result) => {
                     if result.exit_code != 0 {
                         tracing::warn!(
@@ -2533,6 +2627,67 @@ fn emit_progress(tx: &Option<mpsc::UnboundedSender<ProgressEvent>>, event: Progr
     if let Some(tx) = tx {
         let _ = tx.send(event);
     }
+}
+
+/// Whether a probe's exit code means the shell could not run it at all, rather
+/// than that it ran and answered "no".
+///
+/// A `skip_if` is a predicate, so its output is deliberately not logged — but a
+/// typo'd or missing binary is not an answer, and since the probe's stderr no
+/// longer reaches the terminal, `sh: docker: command not found` would otherwise
+/// be silent in every channel. 126/127 are the shell's conventional
+/// "found but not executable" / "not found".
+fn probe_could_not_run(exit_code: i32) -> bool {
+    exit_code == 126 || exit_code == 127
+}
+
+/// Build the line sink for a step run through [`process::run_command`].
+///
+/// Every line the step prints goes to up to two places: the log stream `writer`
+/// belongs to, so `veld logs` and the management UI can show it after the fact,
+/// and the progress channel, so it is visible while the step runs. Either may be
+/// absent — a step with no run instance to attach rows to has no writer, and a
+/// `veld stop` has no progress channel (see below) — but never both silently:
+/// with no channel the lines go to stderr. It goes to the
+/// progress channel rather than straight to the terminal because the CLI draws
+/// spinners there — a child writing to the inherited stderr (what `command`
+/// steps used to do) scribbles over them.
+///
+/// With no progress channel there are no spinners to protect and nothing else
+/// to show the user the step's output live, so the lines go to stderr instead.
+/// That is the `veld stop` path: teardown steps and `on_stop` hooks used to
+/// print straight to the terminal, and a `docker compose down` that takes
+/// twenty seconds must not become a silent pause.
+///
+/// `label` is the `node:variant` pair the line is attributed to in the UI; for
+/// project-level steps it is a pseudo-node (`setup`, `teardown`) and the step
+/// name, since those have no node.
+fn step_line_sink(
+    writer: Option<LogWriter>,
+    tx: &Option<mpsc::UnboundedSender<ProgressEvent>>,
+    label: (String, String),
+) -> process::LineSink {
+    let tx = tx.clone();
+    let (node, variant) = label;
+    Arc::new(move |lines: &[String]| {
+        if let Some(ref w) = writer {
+            let _ = w.write_lines(chrono::Utc::now(), lines);
+        }
+        match tx {
+            Some(ref tx) => {
+                let _ = tx.send(ProgressEvent::NodeLogLines {
+                    node: node.clone(),
+                    variant: variant.clone(),
+                    lines: lines.to_vec(),
+                });
+            }
+            None => {
+                for line in lines {
+                    eprintln!("  {node}:{variant} {line}");
+                }
+            }
+        }
+    })
 }
 
 /// Write a line to the debug log (no-op when writer is None).
@@ -3102,7 +3257,7 @@ async fn execute_start_server_isolated(
                         }
                         let lines: Vec<String> = rows
                             .into_iter()
-                            .map(|r| format!("[{}] {}", r.ts, r.line))
+                            .map(|r| r.line)
                             .filter(|l| !l.is_empty())
                             .collect();
                         if !lines.is_empty() {
@@ -3362,11 +3517,31 @@ async fn execute_command_isolated(
         .await?;
     }
 
-    // Idempotency check (skip_if).
+    // Idempotency check (skip_if). No sink: a probe's output is a predicate,
+    // not the node's output — logging it would put a "not installed" message in
+    // the log of a node that then installed it. A probe that cannot even be
+    // spawned is a different thing and must not be silent, since its output no
+    // longer reaches the terminal either.
     if let Some(ref skip_if_cmd) = resolved.skip_if {
         let skip_if_resolved = skip_if_cmd.interpolate(var_ctx)?;
         let skip_if_result =
-            process::run_command(&skip_if_resolved, &working_dir, &env, None).await;
+            process::run_command(&skip_if_resolved, &working_dir, &env, None, None).await;
+        match skip_if_result {
+            Err(ref e) => tracing::warn!(
+                node = sel.node,
+                variant = sel.variant,
+                error = %e,
+                "skip_if probe could not run — treating the node as not skippable"
+            ),
+            Ok(ref out) if probe_could_not_run(out.exit_code) => tracing::warn!(
+                node = sel.node,
+                variant = sel.variant,
+                exit_code = out.exit_code,
+                command = skip_if_resolved.display(),
+                "skip_if probe could not be executed — treating the node as not skippable"
+            ),
+            Ok(_) => {}
+        }
         if let Ok(ref out) = skip_if_result {
             if out.exit_code == 0 {
                 tracing::info!(
@@ -3393,8 +3568,31 @@ async fn execute_command_isolated(
     );
     let output_file =
         logging::output_file(&ctx.project_root, &ctx.run_name, &sel.node, &sel.variant);
-    let result =
-        process::run_command(&resolved_cmd, &working_dir, &env, Some(&output_file)).await?;
+    // A command node's output belongs to that node's `server` stream, exactly
+    // like a `start_server` node's — same rows, so `veld logs --node <n>`, the
+    // failure tail and the management UI all show it without knowing which kind
+    // of node produced it.
+    let sink = step_line_sink(
+        Some(LogWriter::for_node(
+            ctx.db.clone(),
+            &ctx.project_root,
+            &ctx.run_name,
+            ctx.run_id,
+            &sel.node,
+            &sel.variant,
+            LogStream::Server,
+        )),
+        &ctx.progress_tx,
+        (sel.node.clone(), sel.variant.clone()),
+    );
+    let result = process::run_command(
+        &resolved_cmd,
+        &working_dir,
+        &env,
+        Some(&output_file),
+        Some(sink),
+    )
+    .await?;
 
     node_state
         .outputs
@@ -3931,13 +4129,79 @@ mod tests {
         assert!(orch.resolved_vars.is_none());
 
         orch.ensure_stop_vars("dev", None, &[]).await;
-        orch.run_teardown_steps("dev").await;
+        orch.run_teardown_steps("dev", None).await;
 
         assert_eq!(
             std::fs::read_to_string(&marker).unwrap_or_default().trim(),
             "saw-the-var",
             "the teardown step must have interpolated its var and run"
         );
+
+        // The `None` run id path writes no rows on purpose: they would carry a
+        // NULL `run_id`, reachable only by `veld logs --all-runs`. The step's
+        // output is reported live instead.
+        let all = LogFilter {
+            streams: Some(vec![LogStream::Setup.as_str()]),
+            ..Default::default()
+        };
+        assert!(
+            orch.db
+                .tail_logs(project_root, "dev", &all, 100)
+                .unwrap()
+                .is_empty(),
+            "a stop with no run instance must not persist unreachable rows"
+        );
+    }
+
+    /// A project step's output lands on the run's `setup` stream, labelled with
+    /// the step it came from.
+    ///
+    /// The label is the whole point of the pseudo-node: `setup` is read
+    /// run-level, so without `node`/`variant` two steps' lines interleave into
+    /// one anonymous blob. Both pipes are covered — stderr is where a build tool
+    /// actually talks, and it is the one that used to be inherited.
+    #[tokio::test]
+    async fn teardown_step_output_is_recorded_under_its_step_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_root = tmp.path();
+
+        let config: VeldConfig = serde_json::from_str(
+            r#"{
+                "schemaVersion": "3",
+                "name": "testcfg",
+                "teardown": [
+                    { "name": "compose-down", "shell": "echo on-stdout; echo on-stderr >&2" }
+                ],
+                "nodes": {
+                    "task": { "default_variant": "local", "variants": {
+                        "local": { "type": "command", "shell": "true" }
+                    }}
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let mut orch = test_orchestrator(project_root, config);
+        let run_id = uuid::Uuid::new_v4();
+        orch.ensure_stop_vars("dev", Some(run_id), &[]).await;
+        orch.run_teardown_steps("dev", Some(run_id)).await;
+
+        let filter = LogFilter {
+            streams: Some(vec![LogStream::Setup.as_str()]),
+            run_id: Some(run_id.to_string()),
+            ..Default::default()
+        };
+        let rows = orch
+            .db
+            .tail_logs(project_root, "dev", &filter, 100)
+            .unwrap();
+        let lines: Vec<&str> = rows.iter().map(|r| r.line.as_str()).collect();
+        assert!(lines.contains(&"on-stdout"), "got {lines:?}");
+        assert!(lines.contains(&"on-stderr"), "got {lines:?}");
+        for row in &rows {
+            assert_eq!(row.node.as_deref(), Some("teardown"));
+            assert_eq!(row.variant.as_deref(), Some("compose-down"));
+        }
     }
 
     /// `veld stop --all` loops one `Orchestrator` over every run, so the var

--- a/crates/veld-core/src/process.rs
+++ b/crates/veld-core/src/process.rs
@@ -96,6 +96,195 @@ pub struct LogTarget {
     pub variant: String,
 }
 
+/// Where a command step's live output goes: one call per batch of lines, from
+/// the reader task that drains the pipe.
+///
+/// A `command` step's output used to be thrown away — stdout was read only for
+/// `VELD_OUTPUT` control lines and stderr was inherited straight onto the
+/// terminal, so a `docker build` or `pnpm install` node scrolled past the
+/// progress bars and was in no log the user could read afterwards. The sink is
+/// how the caller re-attaches that output to something: the database, the
+/// progress channel, or both. `None` keeps a step's output off the record
+/// entirely (`skip_if` probes, which are predicates).
+///
+/// It takes a **batch**, not a line, because the caller's per-call cost is not
+/// free: the progress renderer redraws every spinner per `println`, and a build
+/// tool emits tens of thousands of lines. One call per read from the pipe keeps
+/// that proportional to I/O rather than to line count.
+pub type LineSink = std::sync::Arc<dyn Fn(&[String]) + Send + Sync>;
+
+/// Longest line kept whole before it is split and sinked as-is.
+///
+/// A progress meter that only ever emits `\r` (curl, some installers) has no
+/// line breaks at all from a `\n`-only reader's point of view — without a cap
+/// its output accumulates in memory for the life of the step and lands as one
+/// enormous row. 64 KiB is far past any real log line.
+const MAX_LINE_BYTES: usize = 64 * 1024;
+
+/// How long the pipe readers get to finish after the step's own process exits.
+///
+/// A step that backgrounds something (`sh -c 'server >/dev/null &'`) leaves a
+/// descendant holding the write end of these pipes, so EOF may never come.
+/// Waiting for it wedges the CLI for as long as that descendant lives — and
+/// before this file captured stderr, not wedging is exactly what the daemon
+/// relied on (see `veld-daemon/src/management.rs`, spawn-log capture). Whatever
+/// is still buffered when the child exits drains in microseconds; this bounds
+/// only the pathological case.
+const DRAIN_GRACE: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// The pipe readers, aborted when they go out of scope.
+///
+/// They must not outlive the call that spawned them. A [`LineSink`] captures
+/// whatever the caller wired it to — the orchestrator's progress channel, among
+/// other things — so a reader that survives its `run_command` keeps a sender
+/// alive, and the CLI's progress task, which ends when the last sender drops,
+/// never finishes. Ctrl+C during a `command` node drops this future without
+/// reaching the grace period above, and that is exactly when it matters: the
+/// step's process is still running, so the pipes are still open, and `veld
+/// start` would hang instead of tearing the run down.
+struct DrainTasks(Vec<tokio::task::JoinHandle<()>>);
+
+impl Drop for DrainTasks {
+    fn drop(&mut self) {
+        for task in &self.0 {
+            task.abort();
+        }
+    }
+}
+
+/// How many bytes at the end of `buf` are the start of a multi-byte character
+/// whose remaining bytes have not arrived (0 if it ends on a boundary).
+///
+/// A UTF-8 character is at most 4 bytes, so at most 3 can be pending.
+fn trailing_partial_char(buf: &[u8]) -> usize {
+    for back in 1..=3.min(buf.len()) {
+        let byte = buf[buf.len() - back];
+        // Continuation bytes are 10xxxxxx; anything else starts a character.
+        if byte & 0b1100_0000 != 0b1000_0000 {
+            let width = match byte {
+                0x00..=0x7F => 1,
+                0xC0..=0xDF => 2,
+                0xE0..=0xEF => 3,
+                0xF0..=0xF7 => 4,
+                // Not a lead byte at all — invalid input, nothing to hold back.
+                _ => return 0,
+            };
+            return if width > back { back } else { 0 };
+        }
+    }
+    0
+}
+
+/// Drain one pipe, sinking whole lines in batches.
+///
+/// Splits on `\n` **and** `\r`, because the tools this exists for (build tools,
+/// installers, `curl`) redraw a progress line with a bare carriage return; a
+/// `\r\n` counts once, and a `\r` that follows a line break terminates nothing.
+/// Lines are decoded lossily: a stray non-UTF-8 byte must cost one character,
+/// not the rest of the stream.
+///
+/// `outputs` is `Some` only for stdout, the legacy `VELD_OUTPUT key=value`
+/// channel. Control lines are peeled off either stream and never sinked.
+async fn drain_pipe<R: tokio::io::AsyncRead + Unpin>(
+    reader: R,
+    sink: Option<LineSink>,
+    outputs: Option<tokio::sync::mpsc::UnboundedSender<(String, String)>>,
+) {
+    let mut reader = BufReader::new(reader);
+    let mut pending: Vec<u8> = Vec::new();
+    // Both carried across reads: a `\r\n` can straddle two chunks.
+    let mut last_was_cr = false;
+    // Whether that `\r` ended a line with content in it. It is what separates a
+    // meter redraw from a real blank line: in `100%\r\n` the `\r` terminated
+    // `100%` and the `\n` completes the same terminator, but in `\r\n\r\n` the
+    // second `\r` terminated nothing, so its `\n` completes a blank line.
+    let mut cr_ended_content = false;
+
+    let take_line = |pending: &mut Vec<u8>, batch: &mut Vec<String>| {
+        let line = String::from_utf8_lossy(pending).into_owned();
+        pending.clear();
+        match line.strip_prefix("VELD_OUTPUT ") {
+            Some(kv) => {
+                if let (Some(tx), Some((key, value))) = (outputs.as_ref(), kv.split_once('=')) {
+                    let _ = tx.send((key.trim().to_owned(), value.trim().to_owned()));
+                }
+                // Control line — machinery, never sinked.
+            }
+            None => batch.push(line),
+        }
+    };
+
+    loop {
+        let chunk = match reader.fill_buf().await {
+            Ok([]) => break,
+            // A signal can interrupt the read with nothing wrong with the pipe.
+            // Treating that as EOF would stop draining while the child is still
+            // writing, and it would then block forever on a full pipe.
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(_) => break,
+            Ok(buf) => buf.to_vec(),
+        };
+        reader.consume(chunk.len());
+
+        let mut batch: Vec<String> = Vec::new();
+        for byte in chunk {
+            match byte {
+                b'\r' => {
+                    // A `\r` with nothing before it ends no line: it is a meter
+                    // redrawing (`50%\r\r100%`) or following a break (`\n\r`).
+                    // Whether it nonetheless starts a blank line is decided by
+                    // the next byte — only `\r\n` there means the step really
+                    // printed one.
+                    cr_ended_content = !pending.is_empty();
+                    if cr_ended_content {
+                        take_line(&mut pending, &mut batch);
+                    }
+                    last_was_cr = true;
+                }
+                b'\n' => {
+                    // Emit unless this `\n` is the tail of a `\r\n` whose `\r`
+                    // already ended the line.
+                    if !(last_was_cr && cr_ended_content) {
+                        take_line(&mut pending, &mut batch);
+                    }
+                    last_was_cr = false;
+                    cr_ended_content = false;
+                }
+                b => {
+                    pending.push(b);
+                    last_was_cr = false;
+                    if pending.len() >= MAX_LINE_BYTES {
+                        // Cut on a character boundary: splitting a multi-byte
+                        // char would corrupt one character on each side of a
+                        // break the step never asked for.
+                        let keep = pending.len() - trailing_partial_char(&pending);
+                        let tail = pending.split_off(keep);
+                        take_line(&mut pending, &mut batch);
+                        pending = tail;
+                    }
+                }
+            }
+        }
+        if !batch.is_empty() {
+            if let Some(ref s) = sink {
+                s(&batch);
+            }
+        }
+    }
+
+    // Output that never got its newline (a truncated final line) is still
+    // output — dropping it would hide the last thing a step said.
+    if !pending.is_empty() {
+        let mut batch = Vec::new();
+        take_line(&mut pending, &mut batch);
+        if !batch.is_empty() {
+            if let Some(ref s) = sink {
+                s(&batch);
+            }
+        }
+    }
+}
+
 impl LogTarget {
     fn append(&self, line: &str) {
         let _ = self.db.append_log(
@@ -384,11 +573,41 @@ async fn log_pipe<R: tokio::io::AsyncRead + Unpin>(reader: R, target: LogTarget)
 ///    discouraged because it exposes values in the terminal and logs.
 ///
 /// When both channels produce the same key, the file-based value wins.
+///
+/// Both pipes are captured, never inherited: everything the step prints is
+/// handed to `sink` as it arrives, in batches (see [`LineSink`]). Inheriting
+/// stderr wrote a `docker build` straight over the progress bars and left
+/// nothing behind for `veld logs`.
+///
+/// `VELD_OUTPUT ` control lines are peeled off **both** streams and never
+/// sinked — they can carry secrets, which is the whole reason the file channel
+/// exists. Only the stdout ones become outputs; stderr was never an output
+/// channel, so a control line there is dropped rather than parsed.
+///
+/// The peel is a literal prefix match and nothing more. It does not, and cannot,
+/// find a value a step prints some other way — `set -x` traces the line as
+/// `+ echo 'VELD_OUTPUT token=…'`, which is not a control line and is recorded
+/// like any other output. Steps that handle secrets should use
+/// `$VELD_OUTPUT_FILE`, which never touches a stream at all.
+///
+/// stdin is `/dev/null`: with both outputs captured, a step that prompts would
+/// otherwise block on a prompt nobody can see. Failing fast on EOF is the
+/// legible outcome, and it matches every other spawn path in veld.
+///
+/// **Deliberately different from [`run_command_streaming`]**, which reads like a
+/// near-twin: that one echoes to the CLI's own stdout/stderr (a `--oneshot`
+/// terminal node's output *is* the command's result), splits on `\n` only, and
+/// drains before waiting because it owns the Ctrl+C handling for its child.
+/// This one routes output through a sink instead, splits on `\r` too, and waits
+/// on the child *before* draining — a `command` step is not the run's output,
+/// and it may leave a descendant holding these pipes open. Don't unify them
+/// without deciding which of those each caller needs.
 pub async fn run_command(
     command: &CommandSpec,
     working_dir: &Path,
     env: &HashMap<String, String>,
     output_file: Option<&Path>,
+    sink: Option<LineSink>,
 ) -> Result<CommandOutput, ProcessError> {
     // Prepare the output file and augmented env.
     let mut env = env.clone();
@@ -424,8 +643,9 @@ pub async fn run_command(
         Ok(mut cmd) => cmd
             .current_dir(working_dir)
             .envs(&env)
+            .stdin(Stdio::null())
             .stdout(Stdio::piped())
-            .stderr(Stdio::inherit())
+            .stderr(Stdio::piped())
             .spawn(),
         Err(e) => {
             if let Some(path) = output_file {
@@ -447,20 +667,42 @@ pub async fn run_command(
     };
 
     let stdout = child.stdout.take().expect("stdout should be piped");
+    let stderr = child.stderr.take().expect("stderr should be piped");
 
-    let mut reader = BufReader::new(stdout).lines();
-    let mut outputs = HashMap::new();
+    // Both pipes are drained by their own task. Reading them in sequence would
+    // deadlock the moment a step writes more than a pipe buffer to the stream
+    // we are not reading yet — which is exactly what a build tool does.
+    let (out_tx, mut out_rx) = tokio::sync::mpsc::unbounded_channel::<(String, String)>();
+    let mut drains = DrainTasks(vec![
+        tokio::spawn(drain_pipe(stdout, sink.clone(), Some(out_tx))),
+        tokio::spawn(drain_pipe(stderr, sink, None)),
+    ]);
 
-    // Legacy stdout channel.
-    while let Ok(Some(line)) = reader.next_line().await {
-        if let Some(kv) = line.strip_prefix("VELD_OUTPUT ") {
-            if let Some((key, value)) = kv.split_once('=') {
-                outputs.insert(key.trim().to_owned(), value.trim().to_owned());
-            }
-        }
-    }
-
+    // The step is over when *its* process exits, not when the last descendant
+    // that inherited these pipes closes them — see [`DRAIN_GRACE`]. The readers
+    // keep running while we wait, so the child can never block on a full pipe.
     let status = child.wait().await.map_err(ProcessError::SpawnFailed)?;
+    let drained = tokio::time::timeout(DRAIN_GRACE, async {
+        for task in drains.0.iter_mut() {
+            let _ = task.await;
+        }
+    })
+    .await;
+    if drained.is_err() {
+        tracing::warn!(
+            command = command.display(),
+            "step exited but something it started still holds its output pipes — \
+             stopped collecting its output"
+        );
+    }
+    // Whether the drain finished, timed out, or this whole future was cancelled,
+    // the tasks stop here.
+    drop(drains);
+
+    let mut outputs = HashMap::new();
+    while let Ok((key, value)) = out_rx.try_recv() {
+        outputs.insert(key, value);
+    }
 
     // Read file-based outputs (overrides stdout for duplicate keys).
     if let Some(path) = output_file {
@@ -529,6 +771,11 @@ pub async fn run_command(
 /// `VELD_OUTPUT key=value` control lines on stdout are still parsed (for
 /// declared outputs) but are never echoed or logged — they are machinery, not
 /// program output.
+///
+/// The line splitting here is `\n`-only and the drain is unbounded, unlike
+/// [`run_command`]: this path echoes to a terminal that was never taken away
+/// from it, and its child is one veld owns the interrupt handling for. Those
+/// are the two differences to weigh before sharing code between them.
 ///
 /// The child runs in its own process group so a Ctrl+C delivered to the CLI's
 /// controlling terminal is not auto-forwarded to it; instead we catch the
@@ -1220,5 +1467,331 @@ mod streaming_tests {
         .expect("streaming run should tolerate non-UTF-8 output");
         assert_eq!(out.exit_code, 0);
         assert_eq!(out.outputs.get("foo").map(String::as_str), Some("bar"));
+    }
+}
+
+#[cfg(test)]
+mod command_capture_tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    /// Collect every line a sink is handed.
+    fn recording_sink() -> (LineSink, Arc<Mutex<Vec<String>>>) {
+        let lines: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink_lines = Arc::clone(&lines);
+        let sink: LineSink = Arc::new(move |batch: &[String]| {
+            sink_lines.lock().unwrap().extend_from_slice(batch);
+        });
+        (sink, lines)
+    }
+
+    /// The regression this whole path exists for: a `command` step's output —
+    /// on *both* pipes — reaches the sink. stderr used to be inherited straight
+    /// onto the terminal and stdout was read only for control lines, so a
+    /// `docker build` left nothing behind for `veld logs`.
+    #[tokio::test]
+    async fn captures_stdout_and_stderr() {
+        let (sink, lines) = recording_sink();
+        let out = run_command(
+            &CommandSpec::Shell("echo to-stdout; echo to-stderr >&2".to_owned()),
+            &std::env::temp_dir(),
+            &HashMap::new(),
+            None,
+            Some(sink),
+        )
+        .await
+        .expect("run should succeed");
+
+        assert_eq!(out.exit_code, 0);
+        let lines = lines.lock().unwrap().clone();
+        assert!(lines.contains(&"to-stdout".to_owned()), "got {lines:?}");
+        assert!(lines.contains(&"to-stderr".to_owned()), "got {lines:?}");
+    }
+
+    /// `VELD_OUTPUT` control lines are machinery, not output: they are parsed
+    /// into `outputs` and must never reach the sink, or a value the author
+    /// deliberately kept off the terminal lands in the log instead.
+    #[tokio::test]
+    async fn control_lines_are_parsed_but_never_sinked() {
+        let (sink, lines) = recording_sink();
+        let out = run_command(
+            &CommandSpec::Shell("echo 'VELD_OUTPUT token=s3cret'; echo visible".to_owned()),
+            &std::env::temp_dir(),
+            &HashMap::new(),
+            None,
+            Some(sink),
+        )
+        .await
+        .expect("run should succeed");
+
+        assert_eq!(out.outputs.get("token").map(String::as_str), Some("s3cret"));
+        let lines = lines.lock().unwrap().clone();
+        assert_eq!(lines, vec!["visible".to_owned()]);
+    }
+
+    /// The same peel on **stderr**, where it matters more: stderr is not an
+    /// output channel, so a control line there is not a declared output — it is
+    /// a `set -x` trace, or a script echoing to the wrong stream. Parsing it
+    /// would invent an output; sinking it would put the value in the log the
+    /// file channel exists to keep it out of.
+    #[tokio::test]
+    async fn control_lines_on_stderr_are_dropped_not_parsed() {
+        let (sink, lines) = recording_sink();
+        let out = run_command(
+            &CommandSpec::Shell(
+                "echo 'VELD_OUTPUT token=s3cret' >&2; echo 'real error' >&2".to_owned(),
+            ),
+            &std::env::temp_dir(),
+            &HashMap::new(),
+            None,
+            Some(sink),
+        )
+        .await
+        .expect("run should succeed");
+
+        assert!(out.outputs.is_empty(), "stderr is not an output channel");
+        let lines = lines.lock().unwrap().clone();
+        assert_eq!(lines, vec!["real error".to_owned()]);
+    }
+
+    /// A step that backgrounds something leaves a descendant holding the write
+    /// end of both pipes, so they never reach EOF. The step is over when its own
+    /// process exits — waiting for the pipes wedged the CLI for as long as the
+    /// survivor lived.
+    #[tokio::test]
+    async fn backgrounded_grandchild_does_not_wedge_the_step() {
+        let (sink, lines) = recording_sink();
+        let started = std::time::Instant::now();
+        let out = tokio::time::timeout(
+            DRAIN_GRACE + std::time::Duration::from_secs(8),
+            run_command(
+                &CommandSpec::Shell("sleep 30 & echo done".to_owned()),
+                &std::env::temp_dir(),
+                &HashMap::new(),
+                None,
+                Some(sink),
+            ),
+        )
+        .await
+        .expect("must not wait for the backgrounded process")
+        .expect("run should succeed");
+
+        assert_eq!(out.exit_code, 0);
+        assert!(
+            started.elapsed() < DRAIN_GRACE + std::time::Duration::from_secs(5),
+            "took {:?}",
+            started.elapsed()
+        );
+        // Output printed before the child exited still made it through.
+        assert!(lines.lock().unwrap().contains(&"done".to_owned()));
+    }
+
+    /// A progress meter that redraws with a bare `\r` never emits a newline. A
+    /// `\n`-only reader accumulates its whole run in memory and stores it as one
+    /// row; each redraw is its own line. `\r\n` still counts once.
+    #[tokio::test]
+    async fn carriage_returns_split_lines() {
+        let (sink, lines) = recording_sink();
+        run_command(
+            &CommandSpec::Shell("printf '10%%\\r50%%\\r100%%\\r\\ndone\\n'".to_owned()),
+            &std::env::temp_dir(),
+            &HashMap::new(),
+            None,
+            Some(sink),
+        )
+        .await
+        .expect("run should succeed");
+
+        let lines = lines.lock().unwrap().clone();
+        assert_eq!(
+            lines,
+            vec![
+                "10%".to_owned(),
+                "50%".to_owned(),
+                "100%".to_owned(),
+                "done".to_owned()
+            ],
+        );
+    }
+
+    /// A single line with no break at all is capped rather than buffered
+    /// without bound, and the tail that never got a newline is still sinked.
+    #[tokio::test]
+    async fn unterminated_output_is_capped_and_still_sinked() {
+        let (sink, lines) = recording_sink();
+        let bytes = MAX_LINE_BYTES + 100;
+        run_command(
+            &CommandSpec::Shell(format!("printf 'x%.0s' $(seq 1 {bytes})")),
+            &std::env::temp_dir(),
+            &HashMap::new(),
+            None,
+            Some(sink),
+        )
+        .await
+        .expect("run should succeed");
+
+        let lines = lines.lock().unwrap().clone();
+        assert_eq!(lines.len(), 2, "capped into two lines, got {}", lines.len());
+        assert_eq!(lines[0].len(), MAX_LINE_BYTES);
+        assert_eq!(lines[1].len(), 100);
+    }
+
+    /// Cancelling the call stops the pipe readers.
+    ///
+    /// The sink holds whatever the caller wired into it — for the orchestrator,
+    /// a clone of the progress channel's sender. A reader that outlives its
+    /// `run_command` keeps that sender alive, and the CLI's progress task ends
+    /// only when the last sender drops: Ctrl+C during a `command` node would
+    /// hang `veld start` instead of tearing the run down, with the step's
+    /// process still running and its pipes still open.
+    #[tokio::test]
+    async fn cancelling_the_call_releases_what_the_sink_holds() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+        let sink: LineSink = Arc::new(move |batch: &[String]| {
+            for line in batch {
+                let _ = tx.send(line.clone());
+            }
+        });
+
+        let call = tokio::spawn(async move {
+            // Long-lived: still running when the call is cancelled.
+            let _ = run_command(
+                &CommandSpec::Shell("echo hi; sleep 60".to_owned()),
+                &std::env::temp_dir(),
+                &HashMap::new(),
+                None,
+                Some(sink),
+            )
+            .await;
+        });
+
+        // Let the step start and print, so the readers are live.
+        assert_eq!(rx.recv().await.as_deref(), Some("hi"));
+        call.abort();
+
+        // The channel must close (every sender dropped), not stall.
+        let closed = tokio::time::timeout(std::time::Duration::from_secs(10), rx.recv())
+            .await
+            .expect("sender clones must be released when the call is cancelled");
+        assert!(closed.is_none(), "expected the channel to close");
+    }
+
+    /// A `\r` that ends no line is a meter redraw, not a blank line — but a
+    /// blank line the step really printed survives, in either line ending.
+    ///
+    /// The two halves pull against each other: `\n\r` must not produce a blank
+    /// row, while `\r\n\r\n` must, and only the byte after the `\r` tells them
+    /// apart.
+    #[tokio::test]
+    async fn blank_lines_survive_but_meter_redraws_do_not() {
+        for (script, expected) in [
+            // LF: a redraw after a break, then a real blank line.
+            ("printf 'a\\n\\rb\\n\\n c\\n'", vec!["a", "b", "", " c"]),
+            // CRLF: the blank line between two paragraphs is real.
+            ("printf 'a\\r\\n\\r\\nb\\r\\n'", vec!["a", "", "b"]),
+            // A meter redrawing, CRLF-terminated: three states, no blank.
+            (
+                "printf '10%%\\r50%%\\r100%%\\r\\n'",
+                vec!["10%", "50%", "100%"],
+            ),
+            // Consecutive redraws collapse rather than emitting empties.
+            ("printf '50%%\\r\\r100%%\\n'", vec!["50%", "100%"]),
+        ] {
+            let (sink, lines) = recording_sink();
+            run_command(
+                &CommandSpec::Shell(script.to_owned()),
+                &std::env::temp_dir(),
+                &HashMap::new(),
+                None,
+                Some(sink),
+            )
+            .await
+            .expect("run should succeed");
+
+            let lines = lines.lock().unwrap().clone();
+            assert_eq!(lines, expected, "for {script}");
+        }
+    }
+
+    /// The length cap must not cut a multi-byte character in half: that would
+    /// corrupt one character on each side of a break the step never asked for.
+    #[test]
+    fn the_length_cap_retreats_to_a_character_boundary() {
+        // "é" is two bytes; a buffer ending on its lead byte holds one back.
+        assert_eq!(trailing_partial_char("aé".as_bytes()), 0);
+        assert_eq!(trailing_partial_char(&"aé".as_bytes()[..2]), 1);
+        // Three-byte "€", cut after one and after two bytes.
+        assert_eq!(trailing_partial_char(&"€".as_bytes()[..1]), 1);
+        assert_eq!(trailing_partial_char(&"€".as_bytes()[..2]), 2);
+        assert_eq!(trailing_partial_char("€".as_bytes()), 0);
+        // Invalid input holds nothing back rather than stalling.
+        assert_eq!(trailing_partial_char(&[0xFF]), 0);
+        assert_eq!(trailing_partial_char(b""), 0);
+    }
+
+    /// stdin is `/dev/null`: a step that reads it gets EOF immediately instead
+    /// of blocking on a prompt that, with both pipes captured, nobody can see.
+    #[tokio::test]
+    async fn stdin_is_closed_so_a_prompt_cannot_hang() {
+        let out = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            run_command(
+                &CommandSpec::Shell("read -r answer; echo \"got:${answer:-nothing}\"".to_owned()),
+                &std::env::temp_dir(),
+                &HashMap::new(),
+                None,
+                None,
+            ),
+        )
+        .await
+        .expect("must not block waiting for input")
+        .expect("run should succeed");
+
+        // `read` hits EOF and returns non-zero; the point is that it returns.
+        assert_ne!(out.exit_code, -1);
+    }
+
+    /// Both pipes are drained concurrently. Reading them in sequence deadlocks
+    /// as soon as a step writes more than a pipe buffer (~64 KiB) to the stream
+    /// that is not being read — which is what a build tool does.
+    #[tokio::test]
+    async fn large_output_on_both_pipes_does_not_deadlock() {
+        let (sink, lines) = recording_sink();
+        let script = "i=0; while [ $i -lt 4000 ]; do \
+                      echo \"out-$i\"; echo \"err-$i\" >&2; i=$((i+1)); done";
+        let out = tokio::time::timeout(
+            std::time::Duration::from_secs(60),
+            run_command(
+                &CommandSpec::Shell(script.to_owned()),
+                &std::env::temp_dir(),
+                &HashMap::new(),
+                None,
+                Some(sink),
+            ),
+        )
+        .await
+        .expect("must not deadlock on a full pipe buffer")
+        .expect("run should succeed");
+
+        assert_eq!(out.exit_code, 0);
+        assert_eq!(lines.lock().unwrap().len(), 8000);
+    }
+
+    /// A non-UTF-8 byte costs one character, not the rest of the stream.
+    #[tokio::test]
+    async fn lossy_decode_survives_non_utf8() {
+        let (sink, lines) = recording_sink();
+        let out = run_command(
+            &CommandSpec::Shell("printf '\\377\\n'; echo after".to_owned()),
+            &std::env::temp_dir(),
+            &HashMap::new(),
+            None,
+            Some(sink),
+        )
+        .await
+        .expect("run should tolerate non-UTF-8 output");
+
+        assert_eq!(out.exit_code, 0);
+        assert!(lines.lock().unwrap().contains(&"after".to_owned()));
     }
 }

--- a/crates/veld-core/src/progress.rs
+++ b/crates/veld-core/src/progress.rs
@@ -92,10 +92,19 @@ pub enum ProgressEvent {
     /// A teardown step completed.
     TeardownStepCompleted { name: String },
 
-    /// Service log lines streamed during slow readiness checks.
+    /// Output lines from a node's process, streamed while it runs.
     ///
-    /// Emitted after a delay when readiness checks are taking longer than
-    /// expected, giving the user visibility into what the service is doing.
+    /// For a `start_server` node these appear after a delay when readiness
+    /// checks are taking longer than expected; for a `command` node (and for
+    /// project `setup`/`teardown` steps, attributed to a pseudo-node) every
+    /// line is streamed as it is printed, since a build step has nothing else
+    /// to show for itself while it runs.
+    ///
+    /// Lines are verbatim — no timestamp prefix. The event carries none either:
+    /// it is a live progress signal, delivered as the line is printed, and the
+    /// stored copy in `log_lines` is the timestamped record. A prefix here only
+    /// meant the renderer had to strip it back off, which it did by cutting at
+    /// the first `"] "` — and that truncated any real line containing one.
     NodeLogLines {
         node: String,
         variant: String,

--- a/crates/veld-daemon/assets/management-ui.html
+++ b/crates/veld-daemon/assets/management-ui.html
@@ -557,6 +557,7 @@ function ensureLogPanel(key){
         '<button class="active" data-action="source-filter" data-source="all">All</button>'+
         '<button data-action="source-filter" data-source="server">Server</button>'+
         '<button data-action="source-filter" data-source="client">Client</button>'+
+        '<button data-action="source-filter" data-source="setup">Setup</button>'+
         '<button data-action="source-filter" data-source="internal">Internal</button>'+
       '</div>'+
       '<input class="log-search" type="text" placeholder="Search logs..." data-action="log-search">'+
@@ -651,7 +652,9 @@ async function fetchLogs(key,runName,projectRoot){
 
 function doRenderLogs(key){
   const s=runState[key];if(!s||!s.lastData)return;
-  const data=s.logFilter?{nodes:s.lastData.nodes.filter(n=>n.node===s.logFilter)}:s.lastData;
+  // `_veld:*` sections (internal, setup/teardown) belong to the run, not a
+  // node, so a node filter must not hide them.
+  const data=s.logFilter?{nodes:s.lastData.nodes.filter(n=>n.node===s.logFilter||n.node==='_veld')}:s.lastData;
   renderLogs(key,data,s.lastData.nodes.length);
 }
 

--- a/crates/veld-daemon/src/management.rs
+++ b/crates/veld-daemon/src/management.rs
@@ -437,7 +437,9 @@ struct LogQuery {
     #[serde(default = "default_lines")]
     lines: usize,
     node: Option<String>,
-    /// Filter by source: "all" (default), "server", or "client".
+    /// Filter by source: "all" (default), "server" (node output), "client",
+    /// "setup" (project setup/teardown steps, alias "teardown"), or "internal"
+    /// (alias "veld"). Mirrors `veld logs --source`.
     #[serde(default = "default_source")]
     source: String,
     /// Run instance to read (id prefix). Default: the environment's latest
@@ -553,6 +555,10 @@ async fn get_logs(
     let include_server = q.source == "all" || q.source == "server";
     let include_client = q.source == "all" || q.source == "client";
     let include_internal = q.source == "all" || q.source == "internal" || q.source == "veld";
+    // Project setup/teardown steps: run-level rows that carry a pseudo-node
+    // (`setup`/`teardown`) rather than a real one, so they are not reachable
+    // through the per-node loop below.
+    let include_setup = q.source == "all" || q.source == "setup" || q.source == "teardown";
     let mut nodes = Vec::new();
 
     let tail = |node: Option<&str>, variant: Option<&str>, stream: LogStream| {
@@ -579,6 +585,46 @@ async fn get_logs(
                 node: "_veld".to_owned(),
                 variant: "internal".to_owned(),
                 source: "internal".to_owned(),
+                lines,
+            });
+        }
+    }
+
+    // Project setup/teardown output — shown as _veld:setup, like the internal
+    // stream, since it belongs to the run rather than to any one node.
+    // Not gated on `q.node`: `setup` is a run-level stream, so a node filter
+    // does not apply to it — the same rule `veld logs` follows for the run-level
+    // streams (see `crates/veld/src/commands/logs.rs`, run-level filter branch).
+    if include_setup {
+        // Labelled per step: the rows of every step share one section, and
+        // `setup:install` vs `teardown:compose-down` is the only thing telling
+        // a reader which lines came from where.
+        let filter = LogFilter {
+            node: None,
+            variant: None,
+            streams: Some(vec![LogStream::Setup.as_str()]),
+            run_id: run_scope.clone(),
+        };
+        let lines: Vec<String> = db
+            .tail_logs(&project_root, &run_name, &filter, lines_limit)
+            .map(|rows| {
+                rows.into_iter()
+                    .map(|r| match (&r.node, &r.variant) {
+                        (Some(node), Some(variant)) => {
+                            format!("[{}] [{node}:{variant}] {}", r.ts, r.line)
+                        }
+                        // Every writer of this stream labels its rows; this is
+                        // for a row some other version of veld left behind.
+                        _ => format!("[{}] {}", r.ts, r.line),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        if !lines.is_empty() {
+            nodes.push(NodeLogs {
+                node: "_veld".to_owned(),
+                variant: "setup".to_owned(),
+                source: "setup".to_owned(),
                 lines,
             });
         }
@@ -1011,12 +1057,14 @@ pub(super) fn spawn_veld(project_root: &std::path::Path, args: &[String]) -> Sta
     // trace anywhere and the UI would just never show a run.
     //
     // Captured to a FILE, not a pipe. A pipe would have to be drained to keep
-    // from blocking the child, would not reach EOF when the shell exits (setup
-    // steps and actions inherit stderr via `process::run_command`, so anything
-    // they background holds the write end open), and closing the read end on
-    // such a survivor would hand it EPIPE/SIGPIPE and kill it — a process the
-    // user started. A file blocks nobody, stays writable for any descendant
-    // that inherited it, and needs no reader at all.
+    // from blocking the child, would not reach EOF when the shell exits
+    // (`veld action` inherits stderr, so anything it backgrounds holds the
+    // write end open — `process::run_command` now captures both of a step's own
+    // pipes, but the CLI's stderr, which this file is, is still inherited by
+    // whatever a step leaves running), and closing the read end on such a
+    // survivor would hand it EPIPE/SIGPIPE and kill it — a process the user
+    // started. A file blocks nobody, stays writable for any descendant that
+    // inherited it, and needs no reader at all.
     let (stderr_sink, stderr_path) = match spawn_stderr_file() {
         Some((file, path)) => (std::process::Stdio::from(file), Some(path)),
         None => (std::process::Stdio::null(), None),

--- a/crates/veld-daemon/ui/src/runs/LogsPanel.tsx
+++ b/crates/veld-daemon/ui/src/runs/LogsPanel.tsx
@@ -110,7 +110,12 @@ export function LogsPanel(props: {
   const { rows, matchCount } = useMemo(() => {
     const entries: Entry[] = [];
     for (const n of data?.nodes ?? []) {
-      if (nodeFilter && `${n.node}:${n.variant}` !== nodeFilter) continue;
+      // `_veld:*` sections (internal, setup/teardown steps) belong to the run,
+      // not to a node, so a node filter does not apply to them — same rule the
+      // daemon and `veld logs` follow for run-level streams. Filtering them out
+      // left the Setup view blank whenever a node was picked.
+      const runLevel = n.node === "_veld";
+      if (nodeFilter && !runLevel && `${n.node}:${n.variant}` !== nodeFilter) continue;
       for (const raw of n.lines) {
         entries.push({
           node: n.node,
@@ -198,6 +203,7 @@ export function LogsPanel(props: {
             { value: "all", label: "All" },
             { value: "server", label: "Server" },
             { value: "client", label: "Client" },
+            { value: "setup", label: "Setup" },
             { value: "internal", label: "Internal" },
           ]}
         />

--- a/crates/veld/src/commands/logs.rs
+++ b/crates/veld/src/commands/logs.rs
@@ -10,6 +10,7 @@ pub enum SourceFilter {
     All,
     Server,
     Client,
+    Setup,
     Internal,
 }
 
@@ -19,6 +20,7 @@ impl SourceFilter {
             "all" => Some(Self::All),
             "server" => Some(Self::Server),
             "client" => Some(Self::Client),
+            "setup" | "teardown" => Some(Self::Setup),
             "internal" | "veld" => Some(Self::Internal),
             _ => None,
         }
@@ -40,8 +42,15 @@ impl SourceFilter {
                 LogStream::Debug.as_str(),
                 LogStream::Internal.as_str(),
             ],
-            Self::Server => vec![LogStream::Server.as_str(), LogStream::Setup.as_str()],
+            // Node output only. `Setup` used to be listed here as well, back
+            // when it had no writers at all and the inclusion was inert; now
+            // that project steps write to it, keeping it would mean
+            // `--source server` printed project setup output too.
+            Self::Server => vec![LogStream::Server.as_str()],
             Self::Client => vec![LogStream::Client.as_str()],
+            // Project `setup`/`teardown` steps only — node output, including a
+            // `command` node's, is on the `server` stream.
+            Self::Setup => vec![LogStream::Setup.as_str()],
             Self::Internal => vec![LogStream::Internal.as_str()],
         }
     }

--- a/crates/veld/src/commands/start.rs
+++ b/crates/veld/src/commands/start.rs
@@ -267,11 +267,22 @@ pub async fn run(
                     ..
                 } = e
                 {
+                    // Scoped to this run. Unscoped, the tail spans every run
+                    // ever started under this name — and now that a `command`
+                    // node produces log rows at all, a node that failed after
+                    // three lines would have the other seventeen filled in from
+                    // a previous attempt and presented as this failure's.
+                    let run_id = orchestrator
+                        .db
+                        .get_run(&project_root, run_name_str)
+                        .ok()
+                        .flatten()
+                        .map(|r| r.run_id.to_string());
                     let filter = veld_core::db::LogFilter {
                         node: Some(node.clone()),
                         variant: Some(variant.clone()),
                         streams: Some(vec![veld_core::db::LogStream::Server.as_str()]),
-                        run_id: None,
+                        run_id,
                     };
                     if let Ok(rows) =
                         orchestrator
@@ -608,11 +619,11 @@ fn render_progress_tty(event: &ProgressEvent, ctx: &mut TtyProgressCtx) {
         } => {
             let label = output::dim(&format!("{node}:{variant}"));
             for line in lines {
-                // Strip timestamp prefix for readability.
-                let content = line.find("] ").map(|i| &line[i + 2..]).unwrap_or(line);
+                // Lines are verbatim; printed through `multi` so they interleave
+                // with the spinners instead of overwriting them.
                 let _ = ctx
                     .multi
-                    .println(format!("  {label} {}", output::dim(content)));
+                    .println(format!("  {label} {}", output::dim(line)));
             }
         }
         ProgressEvent::SetupStepStarting { name, index, total } => {

--- a/crates/veld/src/main.rs
+++ b/crates/veld/src/main.rs
@@ -219,7 +219,9 @@ enum Command {
         #[arg(long)]
         json: bool,
 
-        /// Filter by log source: all, server, client, or internal (veld daemon liveness/recovery logs).
+        /// Filter by log source: all, server (node output), client, setup
+        /// (project setup/teardown steps), or internal (veld daemon
+        /// liveness/recovery logs).
         #[arg(long, default_value = "all")]
         source: String,
 
@@ -631,7 +633,7 @@ async fn main() {
                 commands::logs::SourceFilter::from_str(&source).unwrap_or_else(|| {
                     output::print_error(
                         &format!(
-                            "Invalid --source value '{source}'. Use: all, server, client, internal"
+                            "Invalid --source value '{source}'. Use: all, server, client, setup, internal"
                         ),
                         json,
                     );

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -338,6 +338,24 @@ Setup and teardown are project-level lifecycle steps that run outside the depend
 | `argv` / `shell` | array / string | Yes (exactly one) | What to run. See [`argv` and `shell`](#argv-and-shell) |
 | `failureMessage` | string | No       | Message shown when the command fails (non-zero exit) |
 
+#### Step output
+
+Everything a step prints — stdout and stderr — is streamed into `veld start`'s
+progress output as it arrives and recorded under the run's `setup` stream, so
+`veld logs --source setup` (and the management UI's **Setup** filter) shows it
+after the fact. Lines are labelled `setup:<step name>` / `teardown:<step name>`,
+which is what tells two steps apart in one stream.
+
+Because it is recorded, **a value a step prints is in the log**: veld stores
+step output verbatim and does not redact it, the same as it has always done for
+a `start_server`'s output. A secret reaches a step through its environment or a
+`files:` entry (see [`secret`](#secret)) — don't `echo` it, and remember that
+`set -x` echoes the command line for you.
+
+A step's stdin is `/dev/null`, so a command that prompts fails on EOF rather
+than blocking a startup nobody can answer. Steps that need a credential should
+read it from the environment.
+
 #### Variable availability
 
 Setup and teardown steps run outside the node graph, so node-scoped variables —
@@ -507,6 +525,11 @@ Runs a shell command or script to completion. Used for setup tasks such as datab
 - Can declare outputs by writing `key=value` lines to `$VELD_OUTPUT_FILE` (preferred) or via `VELD_OUTPUT key=value` on stdout (legacy, discouraged — exposes values in terminal/logs)
 - Built-in output: `exit_code`
 - Supports the `skip_if` field for idempotency
+- Everything it prints (stdout and stderr, minus the `VELD_OUTPUT` control
+  lines) goes to that node's log stream, exactly like a `start_server`'s: read
+  it live in `veld start`'s progress output, afterwards with
+  `veld logs --node <name>`, or in the management UI. A `skip_if` probe's output
+  is a predicate, not the node's, and is not logged
 
 ```json
 {
@@ -1341,6 +1364,11 @@ Where a secret may go: a child process's environment, or a [file](#files). **Not
 interpolated by Veld into an `argv` element or a `shell` string (both appear in
 the process table, readable by every other user on the machine), not into logs,
 not into `--json` output, not into the share payload.
+
+That is a rule about what *Veld* does with the value. It cannot un-print what a
+process does with it: a node or step that echoes its own environment puts the
+value in that run's log, which `veld logs` and the management UI will show. Veld
+records process output verbatim and never redacts it.
 
 **Two different rules, because there are two different risks.**
 

--- a/skills/veld/SKILL.md
+++ b/skills/veld/SKILL.md
@@ -408,6 +408,20 @@ veld logs --source internal --name my-feature     # shows probe stderr, recovery
 veld logs --source internal -f --name my-feature  # follow mode
 ```
 
+Log sources, and where each kind of output lands:
+
+| `--source` | Contains |
+|---|---|
+| `server` | Node output — both `start_server` processes and `command` steps (a `docker build`'s progress is here, under that node). Read one node with `--node <name>` |
+| `client` | Browser `console.*` from the client-log collector |
+| `setup` | Project-level `setup`/`teardown` step output, labelled `setup:<step name>` |
+| `internal` | Liveness probe outcomes, recovery decisions |
+| `all` (default) | All four, interleaved by timestamp |
+
+Step output is recorded verbatim and never redacted, so a node or step that
+echoes a secret from its environment puts it in that run's log. A `command`
+step's stdin is `/dev/null` — one that prompts fails on EOF instead of hanging.
+
 **Outputs can change after a recovery restart.** When a liveness probe triggers recovery (e.g., SSH tunnel drops and the DB clone restarts), the restarted node may produce new outputs (different port, new password, new connection string). Always re-read outputs with `veld status --outputs` after a restart rather than caching them. If you observe connection failures to a previously-working service, check whether a recovery happened and refresh your outputs.
 
 ## Gotchas

--- a/skills/veld/reference/config.md
+++ b/skills/veld/reference/config.md
@@ -344,6 +344,10 @@ Must bind to `${veld.port}`. Requires a readiness probe (`probes.readiness` or l
 
 Emits outputs by writing `key=value` lines to `$VELD_OUTPUT_FILE`.
 
+Its stdout and stderr go to that node's log stream, like a server's — live in
+`veld start`'s progress output, then `veld logs --node <name>`. A `skip_if`
+probe's output is not logged (it is a predicate, not the node's output).
+
 A `command` node can also be a run's **terminal node** via
 `veld start <node> --oneshot`: veld starts its dependencies, runs it to
 completion (streaming its output), then tears everything down and exits with the

--- a/website/llms-full.txt
+++ b/website/llms-full.txt
@@ -296,10 +296,15 @@ Captured logs appear alongside server logs in `veld logs` and the management UI.
 
 ```sh
 veld logs --source client          # Browser logs only
-veld logs --source server          # Server logs only
+veld logs --source server          # Node output — servers and `command` nodes alike
+veld logs --source setup           # Project setup/teardown step output
 veld logs --source internal        # Liveness probe & recovery logs
 veld logs --source all             # All sources (default)
 ```
+
+Every step's output is collected, not just a server's: a `command` node (a
+`docker build`, a `pnpm install`) logs to that node's stream, and project
+`setup`/`teardown` steps to the run's, labelled `setup:<step name>`.
 
 ### Configuration
 


### PR DESCRIPTION
# fix(logs): collect `command` node and project step output

## The problem

A `command` node's output went nowhere. `process::run_command` piped stdout
only to scrape `VELD_OUTPUT key=value` control lines — every other stdout line
was read and dropped — and inherited stderr straight onto the CLI's terminal.

So a `docker build` or `pnpm install` node printed over `veld start`'s progress
bars (which is how this was noticed) and afterwards existed in no log at all:

- `veld logs --node build` — empty.
- Management UI log view — the node is listed with an empty panel; it reads the
  per-node `server`/`client` streams, and the node wrote to neither.
- Run launched from the daemon/UI — the inherited stderr landed in
  `~/.veld/spawn-logs/<pid>.err`, which is unlinked the moment `veld start`
  exits.

The same function runs project `setup`/`teardown` steps and `on_stop` hooks, so
they lost their output the same way. `LogStream::Setup` had **zero writers**
anywhere in the tree while `veld logs` was already reading it.

## The change

`run_command` captures both pipes and hands every line to a `LineSink`:

| Step | Goes to |
|---|---|
| `command` node | that node's `server` stream — the same rows a `start_server` produces, so every existing reader works unchanged |
| project `setup`/`teardown` | the run's `setup` stream, labelled `setup:<step name>` / `teardown:<step name>` |
| `on_stop` hook | that node's `server` stream |
| `skip_if` probe | nothing — a predicate is not the node's output |

Every sinked line is also a `ProgressEvent::NodeLogLines`, so output is visible
live during `veld start` — rendered through indicatif's `MultiProgress` rather
than a child scribbling on the inherited stderr. On `veld stop`, which has no
progress channel, the sink echoes to stderr instead, so a slow
`docker compose down` is not a silent pause.

`veld logs` gains `--source setup`; `--source server` now means node output only
(it used to list the `setup` stream too, which was inert while that stream had
no writers). The management UI gains a **Setup** filter and a `_veld:setup`
section.

## Reviewer notes

Most of this list came out of the review loop rather than the original change —
capturing a stream that used to be inherited turns out to have sharp edges.

- `drain_pipe` (`crates/veld-core/src/process.rs`) is the new reader. It splits
  on `\n` **and** `\r` — the tools this exists for redraw progress with a bare
  carriage return, and a `\n`-only reader buffers such a stream for the life of
  the step and stores it as one row. Only the byte *after* a `\r` separates a
  meter redraw from a real blank line (`\n\r` vs `\r\n\r\n`), which is what
  `cr_ended_content` tracks. Lines are capped at 64 KiB **on a character
  boundary**, decoded lossily, and `VELD_OUTPUT ` control lines are peeled off
  **both** streams (stderr's are dropped, not parsed — stderr was never an
  output channel). `Interrupted` is not EOF: retiring a reader on it would leave
  the child blocked on a full pipe with nothing waiting on a timeout.
- The sink takes a **batch**, not a line: the progress renderer redraws every
  spinner per `println`, and a build emits tens of thousands of lines. Each
  batch is one `Db::append_logs` transaction rather than one autocommit `INSERT`
  per line against the process-wide connection lock.
- **Two hangs, both introduced by capturing stderr, both now fixed and pinned by
  tests:**
  1. `child.wait()` runs *before* the drain, with a 2s bounded grace. A step
     that backgrounds something (`sh -c 'server >/dev/null &'`) leaves a
     descendant holding the write end of these pipes, so EOF never comes —
     waiting for it wedged the CLI for as long as the survivor lived.
     `veld-daemon`'s spawn-log comment relies on that exact pattern happening.
  2. The readers are aborted when the call ends (`DrainTasks`). They are
     detached tasks holding whatever the sink captured — for the orchestrator, a
     clone of the progress channel's sender, and the CLI's progress task ends
     only when the last sender drops. Ctrl+C during a `command` node dropped the
     `run_command` future without reaching the grace period, so `veld start`
     froze and its cleanup `stop()` never ran. The test for this was confirmed
     to fail without the guard.
- **stdin is now `/dev/null`** for `command` steps. With both outputs captured,
  a step that prompts would block on a prompt nobody can see; EOF fails fast
  instead. Every other spawn path in veld already nulls stdin. If a step needs a
  credential it reads it from the environment.
- `ProgressEvent::NodeLogLines` lines are now verbatim rather than `[ts] line`;
  the renderer's timestamp-stripping (`line.find("] ")`) went with it — it also
  truncated any real line containing `"] "`.
- Two things that were fine only because `command` nodes produced no rows: the
  startup-failure tail was unscoped by run (it would have filled a short
  failure's tail from a previous attempt under the same name), and a `skip_if`
  probe's `sh: docker: command not found` reached the terminal via inherited
  stderr. The tail is now run-scoped, and exit 126/127 warns.

## Security note

Step output is now recorded, so a step that echoes a secret from its environment
puts it in that run's log — same as a `start_server` has always done, but the
node type most likely to `set -x`. veld records process output verbatim and does
not redact. Documented in `docs/configuration.md` (both the step-output section
and the `secret` section, which previously read as a stronger guarantee than it
is) and in `skills/veld/SKILL.md`.

## Test evidence

- `cargo test --workspace` — 628 passed (was 619), 3 ignored.
- New in `crates/veld-core/src/process.rs`: both pipes captured; control lines
  parsed-not-sinked on stdout and dropped-not-parsed on stderr; no deadlock at
  8k lines across both pipes; blank lines surviving in LF *and* CRLF while meter
  redraws don't; the 64 KiB cap, its character-boundary retreat, and the
  unterminated tail; stdin EOF; a backgrounded grandchild not wedging the step;
  and cancellation releasing what the sink holds (verified to fail without the
  guard).
- New in `crates/veld-core/src/orchestrator.rs`: a teardown step's output lands
  on the `setup` stream under `teardown:<step name>` from both pipes, and a stop
  with no run instance persists nothing (those rows would be unreachable —
  `LogFilter`'s `run_id = ?` never matches NULL).
- Live against a scratch project: setup step, `command` node (incl. a `\r`
  progress meter arriving as one batched event), `on_stop`, and teardown all
  appear in `veld logs`; `--source server` and `--source setup` partition them.
- `cargo clippy --workspace --all-targets` clean, `cargo fmt --all --check`
  clean, `tests/validate-schema.sh` 15/15, UI `tsc --noEmit` + 105 UI tests.

## Review

Ran the `docs/agentic-review.md` loop at the standard depth — the maintainer
chose *Light* upfront, but the diff touches the daemon's HTTP API, and §3.3's
stakes override is not downgradable. 3 rounds, 7 subagents (5 opus, 2 sonnet),
**34 findings, 31 fixed and 3 deferred with reasons**. The two hangs above and
the `\r` buffering were all review findings, not test failures.

## Follow-ups (not in this PR)

- `run_command_streaming` (the `--oneshot` path) has the same `\n`-only line
  splitting and the same unbounded drain join. It never replaced an inherited
  tty, so neither is a regression there, but they are the same latent bugs.
  Its docstring now says which asymmetries with `run_command` are deliberate.
- Node names `setup`/`teardown` can collide with the pseudo-nodes used to label
  project steps. Different streams, and `--source` separates them, so the
  collision is cosmetic; reserving the names is a config-validation change with
  its own lint and schema surface.
- Nothing but a doc comment stops a future step type from passing `None` for the
  sink and silently reintroducing this bug. All current call sites are correct;
  making the sink non-optional with an explicit `Discard` is a wider refactor.

## Docs

README (features list + `veld logs` CLI row), `docs/configuration.md` (`command`
node, a new step-output section, the `secret` section), `skills/veld/SKILL.md`
(log-source table), `skills/veld/reference/config.md`, `website/llms-full.txt`.
No config fields or schema changes, so `schema/v3` and `docs/migrating-to-v3.md`
are untouched. `website/index.html` deliberately unchanged: the site already
claims logs, and this restores that claim rather than adding a capability.
