### PR TITLE
fix(skills): stop /ship from installing into consumer projects

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -8,6 +8,12 @@ description: >
   the run. Use when the maintainer says "ship this", "build and merge X",
   "implement and open a PR", "take this to merge", or hands over a feature/fix to
   carry all the way to main. Not for one-off edits with no PR.
+metadata:
+  # Contributor-only dev tool. `npx skills` scans `.claude/skills/` alongside
+  # `skills/`, so without this flag `npx skills add prosperity-solutions/veld`
+  # would install /ship into unrelated projects. `internal: true` makes the
+  # skills CLI skip it in both its clone and GitHub-tree discovery paths.
+  internal: true
 ---
 
 # ship — carry a veld change to merge

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,16 @@ Veld ships consumer-facing skills in `skills/` for the [npx skills](https://gith
 
 For **contributors** working on this repo with Claude Code, `.claude/skills/ship/` provides a `/ship` workflow skill that wraps the PR Workflow below (kickoff questionnaire → autonomous implement → adversarial review rounds → draft PR → wait for green CI → bypass-merge when authorized). It's a dev tool, not a published consumer skill.
 
+**Every skill under `.claude/skills/` must carry `metadata.internal: true` in its
+SKILL.md frontmatter.** The `npx skills` CLI scans `.claude/skills/` alongside
+`skills/` — it is a built-in discovery prefix, not something the repo opts into —
+so a contributor-only skill without that flag gets installed into unrelated
+projects by `npx skills add prosperity-solutions/veld`. `internal: true` is the
+CLI's supported opt-out and is honoured by both its discovery paths (local clone
+and GitHub tree). Claude Code ignores the field, so `/ship` still loads here.
+Verify with `npx skills add . --list` from the repo root: only the `skills/`
+entries may appear.
+
 ## PR Workflow
 
 Follow this workflow for every feature or fix:


### PR DESCRIPTION
## Problem

`npx skills add prosperity-solutions/veld` installed **three** skills, not two — the contributor-only `/ship` workflow skill was landing in unrelated user projects.

## Root cause

The `npx skills` CLI treats `.claude/skills/` as a **built-in** discovery prefix — it appears in both `AGENT_PROJECT_SKILL_DIRS` (local-clone path, `cli.mjs:1057`) and `PRIORITY_PREFIXES` (GitHub-tree path, `cli.mjs:3758`). This is not something the repo opts into, so `.claude/skills/ship/SKILL.md` was discovered right alongside `skills/veld` and `skills/veld-launch-feedback-loop`.

Confirmed before the fix:

```
$ npx skills add prosperity-solutions/veld --list
◇  Found 3 skills
│    veld
│    veld-launch-feedback-loop
│    ship          <-- should not be here
```

## Fix

Set the CLI's supported opt-out in `ship`'s frontmatter:

```yaml
metadata:
  internal: true
```

Both discovery paths check `metadata.internal === true` and skip the skill (unless `INSTALL_INTERNAL_SKILLS=1`). Claude Code ignores unknown frontmatter fields — the installed `veld-*` skills already ship a `metadata` block — so `/ship` still loads for contributors in this repo.

AGENTS.md now states the rule so any future `.claude/skills/` entry carries the flag, and names the one-line verification command.

## Test evidence

```
$ npx skills add . --list
◇  Found 2 skills
│    veld
│    veld-launch-feedback-loop
```

`/ship` re-listed in this Claude Code session after the edit, so the frontmatter still parses on the consuming side.

## Reviewer scope

Docs/metadata only — two files, +16 lines, no Rust touched. No new config fields, CLI flags, or user-visible behaviour, so the AGENTS.md documentation checklist does not apply; README's Agent Skills section already named only the two consumer skills (it was accurate as intent, wrong only in behaviour, which this fixes). No website change.

## Process notes

Per maintainer instruction at task start: multi-angle review loop skipped and merge proceeds with admin bypass **without waiting for CI**, overriding AGENTS.md PR Workflow steps 3, 5, and 6. Change is docs-only with no compiled surface, so CI exposure is limited to the lint/format jobs.

## Follow-up (not in this PR)

A CI grep gate asserting every `.claude/skills/*/SKILL.md` carries `metadata.internal: true` would make this non-regressable — deliberately left out to keep the diff docs-only.