### PR TITLE
ci: only run checks on PRs that are ready for review

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -221,11 +221,18 @@ opening the PR.
   `ci.yml` and `release.yml` skips while `draft == true`, so pushing here buys you
   a workflow run in which nothing executes. Don't poll it, don't push extra
   commits to "kick" it, and don't read the absence of checks as a problem — this
-  is the design. Five macOS legs at 10× billing plus a four-target release matrix
-  are what a draft run used to cost per intermediate commit.
+  is the design. Five macOS legs plus a four-target release matrix are what a
+  draft run occupies.
 - **Those skipped jobs report as passing checks.** The draft PR you just opened
   will show a green tick. It means nothing ran. See step 6.3 before you ever
   report a CI result.
+- Note what this does and does not save *for this flow*: /ship pushes once, at
+  this step, with the review already done — so the guard's payoff here is the
+  `opened` run plus any push made before you mark ready (a checkpoint iteration, a
+  post-PR review fix). The per-intermediate-commit waste it was written for belongs
+  to flows that push repeatedly while drafting. Don't invent draft pushes to
+  "use" the saving, and don't treat a short draft window as a reason to skip
+  step 6.1.
 
 ## Step 6 — Ready, CI, and merge
 
@@ -244,12 +251,19 @@ PR is ready, so waiting on a draft's checks is an infinite wait, not patience.
    pass, and it looks exactly like one:** a draft's jobs all skip, `gh pr checks`
    files those under the `skipping` bucket, exits 0, and prints "All checks were
    successful". So the exit code cannot tell you whether anything ran. Assert on
-   the buckets:
+   the buckets — and scope the assertion to the **CI** workflow, because
+   `release.yml`'s push-only jobs are skipped on every healthy PR:
 
    ```sh
-   gh pr view --json isDraft,mergeable          # isDraft must be false
-   gh pr checks --json name,bucket,event        # zero buckets may be "skipping"
+   gh pr view --json isDraft,mergeable        # isDraft must be false
+   gh pr checks --json name,bucket,workflow \
+     --jq '[.[] | select(.workflow == "CI" and .bucket == "skipping")]'   # must be []
    ```
+
+   A draft run and a ready run can both attach check runs to the same head SHA, so
+   if a name appears twice, take the newest — or read the run directly with
+   `gh run list --workflow CI --commit "$(git rev-parse HEAD)"` and inspect only
+   the latest id.
 
    This is the failure mode to fear under autonomy: forget step 2, poll, read
    "All checks were successful", and report a green CI on a diff nothing ran.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -221,9 +221,11 @@ opening the PR.
   `ci.yml` and `release.yml` skips while `draft == true`, so pushing here buys you
   a workflow run in which nothing executes. Don't poll it, don't push extra
   commits to "kick" it, and don't read the absence of checks as a problem — this
-  is the design. Two macOS legs at 10× billing, a four-target release matrix and
-  macOS Electron packaging are what a draft run used to cost per intermediate
-  commit.
+  is the design. Five macOS legs at 10× billing plus a four-target release matrix
+  are what a draft run used to cost per intermediate commit.
+- **Those skipped jobs report as passing checks.** The draft PR you just opened
+  will show a green tick. It means nothing ran. See step 6.3 before you ever
+  report a CI result.
 
 ## Step 6 — Ready, CI, and merge
 
@@ -236,12 +238,23 @@ PR is ready, so waiting on a draft's checks is an infinite wait, not patience.
    — fix it locally first. If Step 0 chose *review: None*, say in the PR body that
    the only pre-merge signal is CI.
 2. `gh pr ready` — this is the step that fires `ready_for_review` and starts CI.
-3. **Wait for CI to actually go green.** Never assume checks are missing because
-   they haven't started — poll until they report. A red or pending check is not a
-   pass. If *no* checks appear a minute or two after marking ready, don't keep
-   waiting: confirm with `gh pr view --json isDraft,mergeable` that the PR really
-   is out of draft and is not `CONFLICTING` — a conflicted PR stops firing
-   `pull_request` events entirely.
+3. **Wait for CI to actually go green — and do not trust a green summary.**
+   Never assume checks are missing because they haven't started; poll until they
+   report. A red or pending check is not a pass. **A *skipped* check is also not a
+   pass, and it looks exactly like one:** a draft's jobs all skip, `gh pr checks`
+   files those under the `skipping` bucket, exits 0, and prints "All checks were
+   successful". So the exit code cannot tell you whether anything ran. Assert on
+   the buckets:
+
+   ```sh
+   gh pr view --json isDraft,mergeable          # isDraft must be false
+   gh pr checks --json name,bucket,event        # zero buckets may be "skipping"
+   ```
+
+   This is the failure mode to fear under autonomy: forget step 2, poll, read
+   "All checks were successful", and report a green CI on a diff nothing ran.
+   If *no* checks appear at all a minute or two after marking ready, the PR is
+   probably `CONFLICTING` — that stops `pull_request` events firing entirely.
 4. When a check fails, read the failing job's log and fix the real cause; don't
    retry blind (a rerun re-runs the same commit). Pushing the fix fires
    `synchronize`, and since the PR is now ready, that re-runs CI normally.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -3,7 +3,8 @@ name: ship
 description: >
   Carry a change to the veld repo from empty diff to merged PR the way this
   project expects — autonomous implementation, adversarial review rounds, draft
-  PR, wait for green CI, and (when authorized) bypass-merge. Opens with a short
+  PR, mark ready only once the local review is done (CI does not run on drafts),
+  wait for green CI, and (when authorized) bypass-merge. Opens with a short
   kickoff questionnaire that sets review depth, merge policy, and hands-on test
   checkpoints for the rest of the run. Use when the maintainer says "ship this", "build and merge X",
   "implement and open a PR", "take this to merge", or hands over a feature/fix to
@@ -58,9 +59,18 @@ in their request):
 2. **Merge policy** (AGENTS.md's default posture is **ask-first**; bypass is the
    exception and requires the maintainer's explicit upfront authorization, which
    this questionnaire captures)
-   - *Bypass-merge on green* — merge with admin bypass the moment CI is green.
-   - *Open PR, stop for human* — push the draft PR, report, do not merge.
-   - *Human PR review* — push, request review, wait for approval, then merge.
+   - *Bypass-merge on green* — mark ready, merge with admin bypass the moment CI
+     is green.
+   - *Open PR, stop for human* — push, mark ready so CI actually runs, report the
+     link and the CI result, do not merge.
+   - *Human PR review* — push, mark ready, request review, wait for approval,
+     then merge.
+
+   All three end with the PR marked ready, because **CI does not run on drafts**
+   (AGENTS.md → CI cost convention). "Stop for human" does not mean "leave it a
+   draft" — a draft PR handed over with no checks is a PR the maintainer has to
+   flip themselves to learn anything. What differs between the three is who
+   merges, not whether CI runs.
 3. **Hands-on test checkpoints** — orthogonal to the merge policy: does the
    maintainer want to drive the change themselves before it moves on? This is the
    house style for anything with a UI or a new CLI surface, because a review
@@ -207,18 +217,40 @@ opening the PR.
   Commits message.
 - Push and open a **draft** PR with a clear body: what changed, why, root cause,
   test evidence, reviewer-scope notes, and any known follow-ups.
+- **CI does not run on a draft** (AGENTS.md → CI cost convention). Every job in
+  `ci.yml` and `release.yml` skips while `draft == true`, so pushing here buys you
+  a workflow run in which nothing executes. Don't poll it, don't push extra
+  commits to "kick" it, and don't read the absence of checks as a problem — this
+  is the design. Two macOS legs at 10× billing, a four-target release matrix and
+  macOS Electron packaging are what a draft run used to cost per intermediate
+  commit.
 
-## Step 6 — CI and merge
+## Step 6 — Ready, CI, and merge
 
-- **Wait for CI to actually go green.** Never assume checks are missing because
-  they haven't started — poll until they report. A red or pending check is not a
-  pass. When a check fails, read the failing job's log and fix the real cause;
-  don't retry blind (a rerun re-runs the same commit).
-- Then apply the Step 0 merge policy:
-  - *Bypass-merge on green* → `gh pr ready` then `gh pr merge --squash --admin`,
-    confirm merged, report the merge commit.
-  - *Open PR, stop* → report the PR link and stop.
-  - *Human PR review* → request review, wait for approval, then merge.
+**Mark ready first, then wait.** In that order, always: nothing reports until the
+PR is ready, so waiting on a draft's checks is an infinite wait, not patience.
+
+1. **Gate yourself before spending.** Only run `gh pr ready` once the Step 4
+   review loop has met its exit criteria (or legitimately exited early per
+   §9/§11) **and** the pre-pass is green. A red pre-pass never gets marked ready
+   — fix it locally first. If Step 0 chose *review: None*, say in the PR body that
+   the only pre-merge signal is CI.
+2. `gh pr ready` — this is the step that fires `ready_for_review` and starts CI.
+3. **Wait for CI to actually go green.** Never assume checks are missing because
+   they haven't started — poll until they report. A red or pending check is not a
+   pass. If *no* checks appear a minute or two after marking ready, don't keep
+   waiting: confirm with `gh pr view --json isDraft,mergeable` that the PR really
+   is out of draft and is not `CONFLICTING` — a conflicted PR stops firing
+   `pull_request` events entirely.
+4. When a check fails, read the failing job's log and fix the real cause; don't
+   retry blind (a rerun re-runs the same commit). Pushing the fix fires
+   `synchronize`, and since the PR is now ready, that re-runs CI normally.
+5. Then apply the Step 0 merge policy:
+   - *Bypass-merge on green* → `gh pr merge --squash --admin`, confirm merged,
+     report the merge commit.
+   - *Open PR, stop* → report the PR link and the CI result, then stop. Leave it
+     ready, not draft.
+   - *Human PR review* → request review, wait for approval, then merge.
 
 ## When to involve the human
 

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -260,10 +260,17 @@ PR is ready, so waiting on a draft's checks is an infinite wait, not patience.
      --jq '[.[] | select(.workflow == "CI" and .bucket == "skipping")]'   # must be []
    ```
 
-   A draft run and a ready run can both attach check runs to the same head SHA, so
-   if a name appears twice, take the newest — or read the run directly with
-   `gh run list --workflow CI --commit "$(git rev-parse HEAD)"` and inspect only
-   the latest id.
+   Apply that assertion **only when no CI check is `pending`** — it is a terminal
+   test. The ready run's check replaces the draft's for a given job name (names do
+   not duplicate), but a name whose ready-run job has not started yet still shows
+   the draft's `skipping` entry; measured on #209, four CI names read `skipping`
+   while `check` was in progress because their jobs `needs:` it. Read the run
+   itself if you want an unambiguous answer at any moment:
+
+   ```sh
+   gh run list --workflow CI --commit "$(git rev-parse HEAD)" --json databaseId
+   gh run view <id> --json jobs
+   ```
 
    This is the failure mode to fear under autonomy: forget step 2, poll, read
    "All checks were successful", and report a green CI on a diff nothing ran.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,9 @@ concurrency:
 # `tests/validate-workflow-gates.py` asserts the invariant instead: every job is
 # draft-guarded, push-only, or a dependent that cannot outlive a skipped root.
 #
-# Do not add a status function (`always()`, `!cancelled()`, `!failure()`) to a job
-# that relies on the cascade, and do not OR the guard with another condition —
+# Do not add a status function — `always()`, `cancelled()`, `failure()`,
+# `success()`, in any negated spelling — to a job that relies on the cascade
+# rather than on its own guard, and do not OR the guard with another condition —
 # `true || <guard>` gates nothing, and `A || <guard> && X` binds as `A || (guard
 # && X)`. All of these are holes the gate looks for.
 #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,14 @@ env:
   RUSTFLAGS: "-D warnings"
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+# Supersede an in-flight run when a PR is pushed again. Deliberately NOT enabled
+# for pushes to main: `release.yml` tags and publishes on that event, and half a
+# release is worse than a queued one. `github.ref` is the fallback key so a main
+# run gets its own group rather than sharing the PR group.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # ── Draft PRs do not spend runner minutes ─────────────────────────────
 #
 # Every job below carries:
@@ -23,21 +31,36 @@ env:
 #   if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
 #
 # A draft PR is where an agent's intermediate commits land, and this workflow is
-# expensive: two macOS legs (billed at 10× a Linux minute), a four-target release
-# build matrix, and macOS Electron packaging. The house workflow (AGENTS.md → PR
-# Workflow) is local review first and ready-for-review second, so a draft has by
-# definition not earned a CI run yet. A push to a draft still creates a workflow
-# run, but every job in it skips — that costs queue time, not runner time.
+# expensive: a pull_request run reaches five macOS legs — `integration`,
+# `injection-test`, the mac leg of `desktop-package`, and both darwin legs of
+# `release-build` — each billed at 10× a Linux minute. The house workflow
+# (AGENTS.md → PR Workflow) is local review first and ready-for-review second, so
+# a draft has by definition not earned a CI run yet. A push to a draft still
+# creates a workflow run, but every job in it skips — that costs queue time, not
+# runner time.
 #
-# The guard is repeated per job rather than hoisted because Actions has no
-# workflow-level `if` and does not support YAML anchors. Leaning on `needs:` to
-# cascade the skip into dependent jobs would work today and silently stop working
-# the day someone drops a `needs:`, so `tests/validate-workflow-gates.py` asserts
-# the invariant instead: every job is draft-guarded, push-only, or a dependent
-# that cannot outlive a skipped root.
+# **A skipped job reports as a *successful* check run.** That is Actions'
+# behaviour, not something this workflow chose, and it is the trap here: a draft
+# PR looks green rather than looking unrun. Never conclude "CI passed" from a
+# check summary without confirming the PR is out of draft — see the CI cost
+# convention in AGENTS.md for how to check.
 #
-# Do not add `if: always()` to a job that relies on the cascade — that is exactly
-# the hole the gate looks for.
+# The guard is repeated per job rather than hoisted. Actions has no
+# workflow-level `if`, and while YAML anchors *are* supported (GA since
+# 2025-09-18), the documented pattern is to define the anchor on first use — i.e.
+# inside one job — which would make eleven other jobs' guards depend on that one
+# job's continued existence and position in the file. Fourteen greppable copies
+# beat one alias plus a hidden ordering constraint, and the typo risk an anchor
+# would remove is already caught by the gate below.
+#
+# Leaning on `needs:` to cascade the skip into dependent jobs would work today
+# and silently stop working the day someone drops a `needs:`, so
+# `tests/validate-workflow-gates.py` asserts the invariant instead: every job is
+# draft-guarded, push-only, or a dependent that cannot outlive a skipped root.
+#
+# Do not add `if: always()` to a job that relies on the cascade, and do not OR the
+# guard with another condition — `true || <guard>` gates nothing. Both are holes
+# the gate looks for.
 jobs:
   commits:
     name: Conventional Commits
@@ -101,6 +124,10 @@ jobs:
       - name: Workflows do not run on draft PRs
         run: |
           pip install pyyaml
+          # --selftest first: it asserts the gate still detects the holes it
+          # claims to. A gate that has rotted into `return []` passes the real
+          # check trivially, which reads as a clean bill of health.
+          python3 tests/validate-workflow-gates.py --selftest
           python3 tests/validate-workflow-gates.py
 
   licenses:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,11 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    # `ready_for_review` is NOT in the default type set (opened, synchronize,
+    # reopened) and every job below refuses to run while the PR is a draft, so
+    # the two halves are required together: without this line, flipping a draft
+    # to ready fires nothing and the PR sits forever with no checks.
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main]
 
@@ -11,11 +16,33 @@ env:
   RUSTFLAGS: "-D warnings"
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+# ── Draft PRs do not spend runner minutes ─────────────────────────────
+#
+# Every job below carries:
+#
+#   if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+#
+# A draft PR is where an agent's intermediate commits land, and this workflow is
+# expensive: two macOS legs (billed at 10× a Linux minute), a four-target release
+# build matrix, and macOS Electron packaging. The house workflow (AGENTS.md → PR
+# Workflow) is local review first and ready-for-review second, so a draft has by
+# definition not earned a CI run yet. A push to a draft still creates a workflow
+# run, but every job in it skips — that costs queue time, not runner time.
+#
+# The guard is repeated per job rather than hoisted because Actions has no
+# workflow-level `if` and does not support YAML anchors. Leaning on `needs:` to
+# cascade the skip into dependent jobs would work today and silently stop working
+# the day someone drops a `needs:`, so `tests/validate-workflow-gates.py` asserts
+# the invariant instead: every job is draft-guarded, push-only, or a dependent
+# that cannot outlive a skipped root.
+#
+# Do not add `if: always()` to a job that relies on the cascade — that is exactly
+# the hole the gate looks for.
 jobs:
   commits:
     name: Conventional Commits
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -47,14 +74,16 @@ jobs:
   website:
     name: Website Docker Build
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
       - name: Build website container
         run: docker build -t veld-website website/
 
   schema:
-    name: Validate JSON Schema
+    name: Validate JSON Schema & Workflow Gates
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -64,10 +93,20 @@ jobs:
         run: |
           chmod +x tests/validate-schema.sh
           ./tests/validate-schema.sh --install
+      # Homed here because this is the one job that already has a managed Python
+      # and does static, checkout-only validation. Nothing in Actions enforces
+      # that a newly added job carries the draft guard, and the symptom of a
+      # missing one is a bill rather than a failure, so it gets a drift gate —
+      # the same reason THIRD-PARTY-LICENSES.md and desktop/assets have one.
+      - name: Workflows do not run on draft PRs
+        run: |
+          pip install pyyaml
+          python3 tests/validate-workflow-gates.py
 
   licenses:
     name: Third-Party Licenses
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -96,6 +135,7 @@ jobs:
   go-test:
     name: Go Module Tests
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -108,6 +148,7 @@ jobs:
   check:
     name: Check & Lint
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -135,6 +176,7 @@ jobs:
   frontend:
     name: Frontend (TypeScript)
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     defaults:
       run:
         working-directory: crates/veld-daemon/frontend
@@ -154,6 +196,7 @@ jobs:
   ui:
     name: Management UI v2 (TypeScript)
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     defaults:
       run:
         working-directory: crates/veld-daemon/ui
@@ -175,6 +218,7 @@ jobs:
   desktop:
     name: Desktop Shell (Electron)
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     defaults:
       run:
         working-directory: desktop
@@ -246,6 +290,7 @@ jobs:
   desktop-package:
     name: Desktop Packaging (${{ matrix.name }})
     needs: desktop
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     # This job downloads and runs third-party build tooling (the Electron dist,
     # app-builder-bin), so it gets the token scope its release-workflow twin has
     # rather than the repo default.
@@ -313,6 +358,7 @@ jobs:
     name: Integration Tests (macOS)
     runs-on: macos-latest
     needs: check
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -705,6 +751,7 @@ jobs:
     name: Release Build (${{ matrix.suffix }})
     runs-on: ${{ matrix.os }}
     needs: check
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       matrix:
@@ -776,6 +823,7 @@ jobs:
     name: Injection E2E (macOS)
     runs-on: macos-latest
     needs: check
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,51 +16,73 @@ env:
   RUSTFLAGS: "-D warnings"
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
-# Supersede an in-flight run when a PR is pushed again. Deliberately NOT enabled
-# for pushes to main: `release.yml` tags and publishes on that event, and half a
-# release is worse than a queued one. `github.ref` is the fallback key so a main
-# run gets its own group rather than sharing the PR group.
+# Supersede an in-flight run when the same PR is pushed again. Two details that
+# are easy to get wrong, and one of them was:
+#
+#   * `cancel-in-progress: false` does NOT mean "a run in this group is never
+#     cancelled". Actions also cancels any *pending* run in the group when a newer
+#     one arrives, independently of this flag. So keying main pushes on
+#     `github.ref` — one shared `refs/heads/main` group — would mean three merges
+#     in quick succession silently drop the middle one's run. `github.sha` gives
+#     every main push its own group, which is what it had before this block
+#     existed: parallel, never superseded.
+#   * `github.workflow` is part of the key so CI and Release never share a group.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# ── Draft PRs do not spend runner minutes ─────────────────────────────
+# ── Draft PRs do not run CI ───────────────────────────────────────────
 #
-# Every job below carries:
+# Every job below carries its own copy of the draft guard, in one of two forms:
 #
 #   if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+#   if: github.event_name == 'pull_request' && github.event.pull_request.draft == false   # PR-only jobs
 #
-# A draft PR is where an agent's intermediate commits land, and this workflow is
-# expensive: a pull_request run reaches five macOS legs — `integration`,
-# `injection-test`, the mac leg of `desktop-package`, and both darwin legs of
-# `release-build` — each billed at 10× a Linux minute. The house workflow
-# (AGENTS.md → PR Workflow) is local review first and ready-for-review second, so
-# a draft has by definition not earned a CI run yet. A push to a draft still
-# creates a workflow run, but every job in it skips — that costs queue time, not
-# runner time.
+# A draft PR is where an agent's intermediate commits land, and a pull_request run
+# of this workflow occupies five macOS legs — `integration`, `injection-test`, the
+# mac leg of `desktop-package`, and both darwin legs of `release-build` — plus a
+# four-target release build matrix. Standard macOS runners are free on public
+# repositories, so what a draft run costs is *runner time and the account's macOS
+# concurrency allowance*: five simultaneous mac jobs is a large share of it, and a
+# draft's runs queue ahead of work that matters. (The same legs bill at 10× a
+# Linux minute wherever Actions billing does apply, which is why the shape is
+# worth keeping small even here.) The house workflow (AGENTS.md → PR Workflow) is
+# local review first and ready-for-review second, so a draft has by definition not
+# earned a run yet. A push to a draft still creates a workflow run, but every job
+# in it skips.
 #
 # **A skipped job reports as a *successful* check run.** That is Actions'
 # behaviour, not something this workflow chose, and it is the trap here: a draft
 # PR looks green rather than looking unrun. Never conclude "CI passed" from a
 # check summary without confirming the PR is out of draft — see the CI cost
-# convention in AGENTS.md for how to check.
+# convention in AGENTS.md for the two commands that tell the cases apart.
 #
 # The guard is repeated per job rather than hoisted. Actions has no
 # workflow-level `if`, and while YAML anchors *are* supported (GA since
 # 2025-09-18), the documented pattern is to define the anchor on first use — i.e.
-# inside one job — which would make eleven other jobs' guards depend on that one
-# job's continued existence and position in the file. Fourteen greppable copies
-# beat one alias plus a hidden ordering constraint, and the typo risk an anchor
-# would remove is already caught by the gate below.
+# inside one job — which would make every other job's guard depend on that one
+# job's continued existence and position in the file. A copy per job stays
+# greppable and independently deletable, and the typo drift an anchor would
+# prevent is already caught by the gate below.
 #
 # Leaning on `needs:` to cascade the skip into dependent jobs would work today
 # and silently stop working the day someone drops a `needs:`, so
 # `tests/validate-workflow-gates.py` asserts the invariant instead: every job is
 # draft-guarded, push-only, or a dependent that cannot outlive a skipped root.
 #
-# Do not add `if: always()` to a job that relies on the cascade, and do not OR the
-# guard with another condition — `true || <guard>` gates nothing. Both are holes
-# the gate looks for.
+# Do not add a status function (`always()`, `!cancelled()`, `!failure()`) to a job
+# that relies on the cascade, and do not OR the guard with another condition —
+# `true || <guard>` gates nothing, and `A || <guard> && X` binds as `A || (guard
+# && X)`. All of these are holes the gate looks for.
+#
+# KNOWN BLIND SPOT, stated rather than implied: the gate runs inside the `schema`
+# job, which is itself draft-guarded, so it cannot fire on the run where a missing
+# guard actually costs something. A new unguarded job will run on draft pushes
+# until the PR is marked ready and `schema` finally reports. `just workflow-gates`
+# locally is the real mitigation, and docs/agentic-review.md §1.1 requires it
+# whenever a change touches this directory. Making the gate an unguarded sentinel
+# job would close it for ~1 ubuntu minute per draft push; that is a policy call
+# for the maintainer, not a silent one — see the PR that introduced this.
 jobs:
   commits:
     name: Conventional Commits
@@ -123,7 +145,9 @@ jobs:
       # the same reason THIRD-PARTY-LICENSES.md and desktop/assets have one.
       - name: Workflows do not run on draft PRs
         run: |
-          pip install pyyaml
+          # Pinned to a major, same reasoning as cargo-about above: an unpinned
+          # install makes this job's behaviour depend on the day it ran.
+          pip install "pyyaml>=6,<7"
           # --selftest first: it asserts the gate still detects the holes it
           # claims to. A gate that has rotted into `return []` passes the real
           # check trivially, which reads as a clean bill of health.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,14 @@ env:
 # Only a PR's runs are cancellable. A push to main is a release: it tags,
 # publishes artifacts and pushes a container image, and cancelling that midway
 # leaves a tag with no artifacts behind it.
+#
+# Hence `github.sha`, not `github.ref`, as the non-PR key. A shared main group
+# would let a newer merge cancel an older *pending* release run — which
+# `cancel-in-progress: false` does not prevent, because that flag governs only
+# in-progress runs. Per-SHA groups keep main releases independent, as they were
+# before this block existed. See the fuller note in ci.yml.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions: {}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,13 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+# Only a PR's runs are cancellable. A push to main is a release: it tags,
+# publishes artifacts and pushes a container image, and cancelling that midway
+# leaves a tag with no artifacts behind it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # Paired with the draft guard on `plan` — see the note above `jobs:` in
+    # ci.yml. Without `ready_for_review` the version preview would never appear
+    # on a PR that started life as a draft, which is every PR this repo opens.
+    types: [opened, synchronize, reopened, ready_for_review]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -18,6 +22,10 @@ jobs:
   plan:
     name: Plan Release
     runs-on: ubuntu-latest
+    # The only job here a PR can reach — every other one is `github.event_name ==
+    # 'push'`. Draft PRs skip it: the next-version preview is worth a runner
+    # minute once the PR is real, not on every intermediate agent commit.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     permissions:
       contents: write
       issues: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,10 +200,17 @@ and several were paid for in this codebase already.
     --jq '[.[] | select(.workflow == "CI" and .bucket == "skipping")]'   # must be []
   ```
 
-  Where a name appears twice — a draft run and a ready run can both attach check
-  runs to the same head SHA — take the newest per name, or list the run directly:
-  `gh run list --workflow CI --commit "$(git rev-parse HEAD)"` and read only the
-  latest run id.
+  **This is a terminal test, not a progress test.** The ready run's check for a
+  job name replaces the draft run's, so names do not duplicate — but until the
+  ready run's job for a name has *started*, the draft's `skipping` entry is still
+  the one showing. Measured on #209: four CI names still read `skipping` while
+  `check` was in progress, because their jobs `needs:` it. So apply the assertion
+  only once no CI check is `pending`, or bypass the rollup and read the run:
+
+  ```sh
+  gh run list --workflow CI --commit "$(git rev-parse HEAD)" --json databaseId
+  gh run view <id> --json jobs      # authoritative per-job status/conclusion
+  ```
 
   The other consequence: **the local pre-pass is the only correctness signal a
   draft gets**, so never push-and-mark-ready on a red pre-pass hoping CI will

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ Follow this workflow for every feature or fix:
 3. **Review loop (autonomous, multi-angle, staged)** — Run the loop in [docs/agentic-review.md](docs/agentic-review.md) on the diff: pre-pass (clippy/fmt/tests) → context pack → staged angles as parallel background subagents with explicit per-angle model tiering → verify each critical/major yourself → fix → re-review the fix delta. Loop until the doc's exit criteria hold or a cap/hard stop fires. Do not run separate single-reviewer warm-up rounds — the multi-angle pass replaces them. Diffs under ~50 lines with no stakes flag take the doc's trivia clause (§11); the stakes override (§3.3) is never downgradable.
 4. **Push to draft PR** — Push the branch and open a draft PR on GitHub. **CI does not run while a PR is a draft** (see the CI cost convention below), so do not push intermediate commits expecting a signal from GitHub — the local pre-pass is your only signal at this stage, which is what makes it load-bearing rather than advisory.
 5. **Mark ready for review — only after the review loop is done.** `gh pr ready` is what actually spends runner minutes, so it is a deliberate step, not a formality. Do not flip a PR ready until step 3's exit criteria hold *and* the local pre-pass (clippy, fmt, tests, plus the UI checks when the diff touches them) is green. A draft that has not been locally reviewed has not earned a CI run.
-6. **Wait for CI** — All checks must be green *and none of them skipped*. A skipped job reports as a passing check, so a draft's checks look successful; `gh pr checks` will exit 0 and say "All checks were successful" on a PR where nothing ran. Confirm `isDraft: false` and zero `skipping` buckets (commands in the CI cost convention below) before believing a green summary. Never assume checks are missing just because they haven't started yet — but if none appear after marking ready, the PR is probably `CONFLICTING`, which stops `pull_request` events firing entirely.
+6. **Wait for CI** — All checks must be green, and no *CI* job may be skipped. A skipped job reports as a passing check, so a draft's checks look successful; `gh pr checks` will exit 0 and say "All checks were successful" on a PR where nothing ran. Confirm `isDraft: false` and that no check from the **CI** workflow is in the `skipping` bucket — `release.yml`'s push-only jobs are always skipped on a PR, so "nothing skipped" is the wrong test (commands in the CI cost convention below). Never assume checks are missing just because they haven't started yet — but if none appear after marking ready, the PR is probably `CONFLICTING`, which stops `pull_request` events firing entirely.
 7. **Ask before merging** — Ask the maintainer for explicit approval before merging. Only merge with admin bypass if the maintainer explicitly says so upfront at task start.
 
 **Hand the maintainer the running software before the PR.** For any change with a UI or a new CLI surface, the house style is *checkpointed autonomy*: stop after implementing so they can drive it themselves, run the review loop unattended, then stop once more after the review fixes — because fixes that touch rendering, wire shapes, or CLI output regress exactly what was hand-verified the first time. A review subagent cannot see that a graph renders wrong. `/ship` captures this in its kickoff questionnaire; the two stops are planned, not escalations.
@@ -168,25 +168,42 @@ and several were paid for in this codebase already.
   and both workflows list `ready_for_review` in `on.pull_request.types` — both
   halves are required, because with the guard and without the type a PR flipped
   from draft to ready would fire nothing at all and sit with no checks forever.
-  Pushes to a draft still create a workflow run whose jobs all skip: queue time,
-  not runner minutes. The reason is what this workflow costs — a `pull_request`
-  run reaches **five macOS legs** (`integration`, `injection-test`, the mac leg of
-  `desktop-package`, and both darwin legs of `release-build`), each billed at 10×
-  a Linux minute, on top of a four-target release build matrix — all of which an
-  agent was previously re-running on every intermediate commit of a branch nobody
-  had reviewed yet.
+  Pushes to a draft still create a workflow run, but every job in it skips. The
+  reason is what a `pull_request` run occupies: **five macOS legs**
+  (`integration`, `injection-test`, the mac leg of `desktop-package`, and both
+  darwin legs of `release-build`) plus a four-target release build matrix — all of
+  which an agent was previously re-running on every intermediate commit of a
+  branch nobody had reviewed yet. Standard macOS runners are free on public
+  repositories, so the cost being saved here is **runner time and the account's
+  macOS concurrency allowance**, not a dollar figure: five simultaneous mac jobs
+  is a large share of that allowance, and a draft's runs queue ahead of work that
+  matters. (The same legs bill at 10× a Linux minute wherever Actions billing does
+  apply — a reason to keep the shape small, not a claim about this repo's bill.)
 
   **A skipped job reports as a *passing* check, so a draft PR looks green rather
   than looking unrun.** This is the trap the convention creates, and it is
   Actions' behaviour, not ours: `gh pr checks` sorts a skipped check into the
   `skipping` bucket, exits 0, and prints "All checks were successful". Nothing
-  distinguishes that from a real pass except the bucket. So never conclude "CI
-  is green" from an exit code or a summary line — check both of these:
+  distinguishes that from a real pass except the bucket.
+
+  So never conclude "CI is green" from an exit code or a summary line. But also do
+  **not** assert that nothing is skipped: `release.yml`'s push-only jobs are
+  *always* skipped on a PR, on every green PR this repo has ever merged (five of
+  them — `Tag & Release`, `Publish Artifacts`, `Publish veld-gateway image`,
+  `Build`, `Build Desktop`). A rule that fails on every healthy PR is a rule an
+  agent learns to ignore, which costs you the detection you added it for. Scope
+  the assertion to the CI workflow's own jobs:
 
   ```sh
-  gh pr view --json isDraft,mergeable          # isDraft must be false
-  gh pr checks --json name,bucket,event        # no bucket may be "skipping"
+  gh pr view --json isDraft,mergeable        # isDraft must be false
+  gh pr checks --json name,bucket,workflow \
+    --jq '[.[] | select(.workflow == "CI" and .bucket == "skipping")]'   # must be []
   ```
+
+  Where a name appears twice — a draft run and a ready run can both attach check
+  runs to the same head SHA — take the newest per name, or list the run directly:
+  `gh run list --workflow CI --commit "$(git rev-parse HEAD)"` and read only the
+  latest run id.
 
   The other consequence: **the local pre-pass is the only correctness signal a
   draft gets**, so never push-and-mark-ready on a red pre-pass hoping CI will

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ Follow this workflow for every feature or fix:
 3. **Review loop (autonomous, multi-angle, staged)** — Run the loop in [docs/agentic-review.md](docs/agentic-review.md) on the diff: pre-pass (clippy/fmt/tests) → context pack → staged angles as parallel background subagents with explicit per-angle model tiering → verify each critical/major yourself → fix → re-review the fix delta. Loop until the doc's exit criteria hold or a cap/hard stop fires. Do not run separate single-reviewer warm-up rounds — the multi-angle pass replaces them. Diffs under ~50 lines with no stakes flag take the doc's trivia clause (§11); the stakes override (§3.3) is never downgradable.
 4. **Push to draft PR** — Push the branch and open a draft PR on GitHub. **CI does not run while a PR is a draft** (see the CI cost convention below), so do not push intermediate commits expecting a signal from GitHub — the local pre-pass is your only signal at this stage, which is what makes it load-bearing rather than advisory.
 5. **Mark ready for review — only after the review loop is done.** `gh pr ready` is what actually spends runner minutes, so it is a deliberate step, not a formality. Do not flip a PR ready until step 3's exit criteria hold *and* the local pre-pass (clippy, fmt, tests, plus the UI checks when the diff touches them) is green. A draft that has not been locally reviewed has not earned a CI run.
-6. **Wait for CI** — All checks must be green. Never assume checks are missing just because they haven't started yet. If no checks appear at all after marking ready, the PR is probably still a draft or is `CONFLICTING` — check `gh pr view --json isDraft,mergeable` before waiting any longer.
+6. **Wait for CI** — All checks must be green *and none of them skipped*. A skipped job reports as a passing check, so a draft's checks look successful; `gh pr checks` will exit 0 and say "All checks were successful" on a PR where nothing ran. Confirm `isDraft: false` and zero `skipping` buckets (commands in the CI cost convention below) before believing a green summary. Never assume checks are missing just because they haven't started yet — but if none appear after marking ready, the PR is probably `CONFLICTING`, which stops `pull_request` events firing entirely.
 7. **Ask before merging** — Ask the maintainer for explicit approval before merging. Only merge with admin bypass if the maintainer explicitly says so upfront at task start.
 
 **Hand the maintainer the running software before the PR.** For any change with a UI or a new CLI surface, the house style is *checkpointed autonomy*: stop after implementing so they can drive it themselves, run the review loop unattended, then stop once more after the review fixes — because fixes that touch rendering, wire shapes, or CLI output regress exactly what was hand-verified the first time. A review subagent cannot see that a graph renders wrong. `/ship` captures this in its kickoff questionnaire; the two stops are planned, not escalations.
@@ -169,20 +169,49 @@ and several were paid for in this codebase already.
   halves are required, because with the guard and without the type a PR flipped
   from draft to ready would fire nothing at all and sit with no checks forever.
   Pushes to a draft still create a workflow run whose jobs all skip: queue time,
-  not runner minutes. The reason is what this workflow costs — two macOS legs
-  (billed at 10× a Linux minute), a four-target release build matrix, and macOS
-  Electron packaging, all of which an agent was previously re-running on every
-  intermediate commit of a branch nobody had reviewed yet. The consequence for
-  how you work: **the local pre-pass is the only correctness signal a draft
-  gets**, so never push-and-mark-ready on a red pre-pass hoping CI will tell you
-  what broke, and never treat "I'll let CI catch it" as a substitute for running
-  clippy/fmt/tests locally. The guard is repeated per job because Actions has no
-  workflow-level `if` and no YAML anchors; a dependent job may instead inherit
-  the skip through `needs:`, but must not carry `always()`/`!cancelled()`, which
-  runs it even when its dependencies skipped.
-  `tests/validate-workflow-gates.py` (run by the `schema` job) asserts all of
-  this, because nothing in Actions does and the symptom of a missing guard is a
-  bill rather than a failing job.
+  not runner minutes. The reason is what this workflow costs — a `pull_request`
+  run reaches **five macOS legs** (`integration`, `injection-test`, the mac leg of
+  `desktop-package`, and both darwin legs of `release-build`), each billed at 10×
+  a Linux minute, on top of a four-target release build matrix — all of which an
+  agent was previously re-running on every intermediate commit of a branch nobody
+  had reviewed yet.
+
+  **A skipped job reports as a *passing* check, so a draft PR looks green rather
+  than looking unrun.** This is the trap the convention creates, and it is
+  Actions' behaviour, not ours: `gh pr checks` sorts a skipped check into the
+  `skipping` bucket, exits 0, and prints "All checks were successful". Nothing
+  distinguishes that from a real pass except the bucket. So never conclude "CI
+  is green" from an exit code or a summary line — check both of these:
+
+  ```sh
+  gh pr view --json isDraft,mergeable          # isDraft must be false
+  gh pr checks --json name,bucket,event        # no bucket may be "skipping"
+  ```
+
+  The other consequence: **the local pre-pass is the only correctness signal a
+  draft gets**, so never push-and-mark-ready on a red pre-pass hoping CI will
+  tell you what broke, and never treat "I'll let CI catch it" as a substitute for
+  running clippy/fmt/tests locally.
+
+  Mechanics worth not rediscovering: the guard is repeated per job because
+  Actions has no workflow-level `if`, and although YAML anchors *are* supported
+  (GA 2025-09-18), the documented pattern defines the anchor on first use — inside
+  one job — so every other job's guard would depend on that job's position in the
+  file. A dependent job may instead inherit the skip through `needs:`, but must
+  not carry `always()`/`!cancelled()`, which runs it even when its dependencies
+  skipped. Do not OR the guard with anything either: `true || <guard>` reads as
+  guarded and gates nothing. `github.event_name != 'pull_request'` is also the
+  *wrong* half for a `pull_request_target` workflow, where it evaluates true — use
+  the bare `github.event.pull_request.draft == false` there (on a push the left
+  side is null, and Actions coerces null and false alike to `0`, so the job still
+  runs). `tests/validate-workflow-gates.py` (run by the `schema` job, or
+  `just workflow-gates` locally) asserts all of this and self-tests that it still
+  detects each hole, because nothing in Actions does and the symptom of a missing
+  guard is a bill rather than a failing job.
+
+  Both workflows also carry `concurrency` with `cancel-in-progress` scoped to
+  `pull_request` only — a superseded PR run is waste, but a half-cancelled push
+  to `main` is a release that tagged without publishing.
 - **Any user-supplied command executed by a daemon must inherit the user's login-shell `PATH`.** The daemon (launchd), gateway (systemd), and helper run with a bare service `PATH`, so a raw `sh -c` cannot find user-installed CLIs (`op`, `vault`, `pg_isready`, version-manager shims) even though the same command works in the user's terminal. Pass it via `.env("PATH", …)`, resolved by one of the two helpers in `veld_core::user_path`. Anything inside a daemon uses `cached_user_path()` — every request handler (`spawn_veld`, the desktop directory picker and git plumbing, and `SecretSource::Command` token resolution in `veld-share/src/endpoint.rs`, which `POST /api/shares` reaches while the caller waits) and the health monitor's liveness probes; a dedicated `warm_user_path_cache` task keeps that entry warm, deliberately **not** the monitor's scan, whose own cadence stretches to 300s during a recovery restart. `resolve_user_path()` is the uncached primitive, for a one-shot context that resolves once and exits — today only a CLI run's lazy var sources. Resolution spawns a login shell: sub-second normally, up to 10s on a stalled rc file, and the slow rc files belong to exactly the users who need the resolved PATH — which is why a handler must not resolve inline. The cache is one writer (the warm task) publishing into a cell that readers only read, with a single rule doing the work: **a resolution that learned nothing never displaces one that did.** A stall, or a shell that exits zero while answering with nothing better than the process's own `PATH`, leaves the previous value alone — because that value is the bare service PATH, i.e. the bug itself. Resist adding a TTL or a which-resolution-wins rule back: the first version of this cache had both, and each grew its own bug. Never spawn a config-declared command on a daemon without this. **A login shell is not a substitute for the injection.** `$SHELL -l -c` sources `.zprofile` but not `.zshrc`, which is where version managers (nvm, fnm, rbenv) and `brew shellenv` live on most machines; on Debian `/etc/profile` overwrites `PATH` outright, so a login shell wrapped around an injected PATH *discards* it. That mistake shipped in `spawn_veld` and made every UI- or Desktop-initiated `veld start` resolve node commands against the bare launchd PATH (`sh: npx: command not found`). Spawn the binary directly with the injected PATH; don't reach for a shell to get it. Scope: the rule covers daemon/gateway/helper spawns only — commands the `veld` CLI itself spawns (orchestrator `command`/`start_server` steps, setup checks, actions) already inherit the terminal's `PATH` and are exempt. Only `PATH` is inherited, never the rest of the shell environment — and note that this genuinely differs from the CLI path, where a macOS terminal's zsh *is* a login shell, so `.zprofile` exports (`JAVA_HOME`, `LANG`, tool tokens) do reach a terminal-run `veld` and its node commands but not a daemon-spawned one. A node that needs such a variable must declare it in its `env`; "works in my terminal, fails from the UI" for a non-PATH variable is this asymmetry, not a bug.
 - **`rg` needs `-a` on `crates/veld-daemon/ui/src/App.tsx`.** That file contains a
   NUL byte (`trustedOrigins.join("\0")`), so ripgrep and grep classify the largest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ This starts a local HTTP server for the `website/` directory with an HTTPS URL l
 
 Veld ships consumer-facing skills in `skills/` for the [npx skills](https://github.com/vercel-labs/skills) ecosystem. Users install with `npx skills add prosperity-solutions/veld`. Skills are auto-discovered from `skills/*/SKILL.md`.
 
-For **contributors** working on this repo with Claude Code, `.claude/skills/ship/` provides a `/ship` workflow skill that wraps the PR Workflow below (kickoff questionnaire → autonomous implement → adversarial review rounds → draft PR → wait for green CI → bypass-merge when authorized). It's a dev tool, not a published consumer skill.
+For **contributors** working on this repo with Claude Code, `.claude/skills/ship/` provides a `/ship` workflow skill that wraps the PR Workflow below (kickoff questionnaire → autonomous implement → adversarial review rounds → draft PR → mark ready for review → wait for green CI → bypass-merge when authorized). It's a dev tool, not a published consumer skill.
 
 **Every skill under `.claude/skills/` must carry `metadata.internal: true` in its
 SKILL.md frontmatter.** The `npx skills` CLI scans `.claude/skills/` alongside
@@ -76,9 +76,10 @@ Follow this workflow for every feature or fix:
 1. **Implement** — Make the code changes.
 2. **Docs audit** — Before considering the work done, check the [documentation checklist](#documentation-checklist) below.
 3. **Review loop (autonomous, multi-angle, staged)** — Run the loop in [docs/agentic-review.md](docs/agentic-review.md) on the diff: pre-pass (clippy/fmt/tests) → context pack → staged angles as parallel background subagents with explicit per-angle model tiering → verify each critical/major yourself → fix → re-review the fix delta. Loop until the doc's exit criteria hold or a cap/hard stop fires. Do not run separate single-reviewer warm-up rounds — the multi-angle pass replaces them. Diffs under ~50 lines with no stakes flag take the doc's trivia clause (§11); the stakes override (§3.3) is never downgradable.
-4. **Push to draft PR** — Push the branch and open a draft PR on GitHub.
-5. **Wait for CI** — All checks must be green. Never assume checks are missing just because they haven't started yet.
-6. **Ask before merging** — Ask the maintainer for explicit approval before merging. Only merge with admin bypass if the maintainer explicitly says so upfront at task start.
+4. **Push to draft PR** — Push the branch and open a draft PR on GitHub. **CI does not run while a PR is a draft** (see the CI cost convention below), so do not push intermediate commits expecting a signal from GitHub — the local pre-pass is your only signal at this stage, which is what makes it load-bearing rather than advisory.
+5. **Mark ready for review — only after the review loop is done.** `gh pr ready` is what actually spends runner minutes, so it is a deliberate step, not a formality. Do not flip a PR ready until step 3's exit criteria hold *and* the local pre-pass (clippy, fmt, tests, plus the UI checks when the diff touches them) is green. A draft that has not been locally reviewed has not earned a CI run.
+6. **Wait for CI** — All checks must be green. Never assume checks are missing just because they haven't started yet. If no checks appear at all after marking ready, the PR is probably still a draft or is `CONFLICTING` — check `gh pr view --json isDraft,mergeable` before waiting any longer.
+7. **Ask before merging** — Ask the maintainer for explicit approval before merging. Only merge with admin bypass if the maintainer explicitly says so upfront at task start.
 
 **Hand the maintainer the running software before the PR.** For any change with a UI or a new CLI surface, the house style is *checkpointed autonomy*: stop after implementing so they can drive it themselves, run the review loop unattended, then stop once more after the review fixes — because fixes that touch rendering, wire shapes, or CLI output regress exactly what was hand-verified the first time. A review subagent cannot see that a graph renders wrong. `/ship` captures this in its kickoff questionnaire; the two stops are planned, not escalations.
 
@@ -161,6 +162,27 @@ and several were paid for in this codebase already.
   Design context that must outlive a working document belongs in the PR
   description, commit messages, or `docs/` — don't cite `notes/` files from
   code comments, since readers of the repo can't see them.
+- **CI runs only on a PR that is ready for review, so marking one ready is a
+  spending decision.** Every job in `ci.yml` and `release.yml` carries
+  `if: github.event_name != 'pull_request' || github.event.pull_request.draft == false`,
+  and both workflows list `ready_for_review` in `on.pull_request.types` — both
+  halves are required, because with the guard and without the type a PR flipped
+  from draft to ready would fire nothing at all and sit with no checks forever.
+  Pushes to a draft still create a workflow run whose jobs all skip: queue time,
+  not runner minutes. The reason is what this workflow costs — two macOS legs
+  (billed at 10× a Linux minute), a four-target release build matrix, and macOS
+  Electron packaging, all of which an agent was previously re-running on every
+  intermediate commit of a branch nobody had reviewed yet. The consequence for
+  how you work: **the local pre-pass is the only correctness signal a draft
+  gets**, so never push-and-mark-ready on a red pre-pass hoping CI will tell you
+  what broke, and never treat "I'll let CI catch it" as a substitute for running
+  clippy/fmt/tests locally. The guard is repeated per job because Actions has no
+  workflow-level `if` and no YAML anchors; a dependent job may instead inherit
+  the skip through `needs:`, but must not carry `always()`/`!cancelled()`, which
+  runs it even when its dependencies skipped.
+  `tests/validate-workflow-gates.py` (run by the `schema` job) asserts all of
+  this, because nothing in Actions does and the symptom of a missing guard is a
+  bill rather than a failing job.
 - **Any user-supplied command executed by a daemon must inherit the user's login-shell `PATH`.** The daemon (launchd), gateway (systemd), and helper run with a bare service `PATH`, so a raw `sh -c` cannot find user-installed CLIs (`op`, `vault`, `pg_isready`, version-manager shims) even though the same command works in the user's terminal. Pass it via `.env("PATH", …)`, resolved by one of the two helpers in `veld_core::user_path`. Anything inside a daemon uses `cached_user_path()` — every request handler (`spawn_veld`, the desktop directory picker and git plumbing, and `SecretSource::Command` token resolution in `veld-share/src/endpoint.rs`, which `POST /api/shares` reaches while the caller waits) and the health monitor's liveness probes; a dedicated `warm_user_path_cache` task keeps that entry warm, deliberately **not** the monitor's scan, whose own cadence stretches to 300s during a recovery restart. `resolve_user_path()` is the uncached primitive, for a one-shot context that resolves once and exits — today only a CLI run's lazy var sources. Resolution spawns a login shell: sub-second normally, up to 10s on a stalled rc file, and the slow rc files belong to exactly the users who need the resolved PATH — which is why a handler must not resolve inline. The cache is one writer (the warm task) publishing into a cell that readers only read, with a single rule doing the work: **a resolution that learned nothing never displaces one that did.** A stall, or a shell that exits zero while answering with nothing better than the process's own `PATH`, leaves the previous value alone — because that value is the bare service PATH, i.e. the bug itself. Resist adding a TTL or a which-resolution-wins rule back: the first version of this cache had both, and each grew its own bug. Never spawn a config-declared command on a daemon without this. **A login shell is not a substitute for the injection.** `$SHELL -l -c` sources `.zprofile` but not `.zshrc`, which is where version managers (nvm, fnm, rbenv) and `brew shellenv` live on most machines; on Debian `/etc/profile` overwrites `PATH` outright, so a login shell wrapped around an injected PATH *discards* it. That mistake shipped in `spawn_veld` and made every UI- or Desktop-initiated `veld start` resolve node commands against the bare launchd PATH (`sh: npx: command not found`). Spawn the binary directly with the injected PATH; don't reach for a shell to get it. Scope: the rule covers daemon/gateway/helper spawns only — commands the `veld` CLI itself spawns (orchestrator `command`/`start_server` steps, setup checks, actions) already inherit the terminal's `PATH` and are exempt. Only `PATH` is inherited, never the rest of the shell environment — and note that this genuinely differs from the CLI path, where a macOS terminal's zsh *is* a login shell, so `.zprofile` exports (`JAVA_HOME`, `LANG`, tool tokens) do reach a terminal-run `veld` and its node commands but not a daemon-spawned one. A node that needs such a variable must declare it in its `env`; "works in my terminal, fails from the UI" for a non-PATH variable is this asymmetry, not a bug.
 - **`rg` needs `-a` on `crates/veld-daemon/ui/src/App.tsx`.** That file contains a
   NUL byte (`trustedOrigins.join("\0")`), so ripgrep and grep classify the largest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,8 @@ just dev-restore    # runs veld update
 | `just build` | Build Rust + frontend | No |
 | `just test` | Run all tests | No |
 | `just lint` | Clippy + TypeScript type check | No |
-| `just workflow-gates` | Assert no CI job can run on a draft PR (needs PyYAML) | No |
+| `just workflow-gates` | Assert no CI job can run on a draft PR. Needs PyYAML: `python3 -m pip install --user pyyaml` | No |
+| `just commit-subjects` | Check your commit subjects against the conventional-commits pattern CI enforces | No |
 
 ## Guidelines
 
@@ -148,8 +149,8 @@ just dev-restore    # runs veld update
 - Don't break existing behavior without discussion.
 - Add tests where it makes sense, but don't over-test trivial code.
 - If CI fails after you've marked the PR ready, fix it before asking for a human review.
-- **Draft PRs don't run CI.** Every job in `ci.yml` skips while a PR is a draft, and marking it ready for review is what starts them. A run reaches five macOS jobs (billed at 10× a Linux minute) alongside a four-target release build matrix, so a branch that gets 20 intermediate pushes while it's being written used to cost 20 full runs. Keep the work in draft, run `just lint`/`just test` locally as you go, and flip to ready when it's genuinely ready.
-- **A skipped check shows up as a passing one.** So a draft PR looks green even though nothing ran — don't read that tick as a pass. `gh pr checks --json name,bucket` puts them in the `skipping` bucket; that's the only thing that distinguishes them.
+- **Draft PRs don't run CI.** Every job in `ci.yml` skips while a PR is a draft, and marking it ready for review is what starts them. A run occupies five macOS jobs alongside a four-target release build matrix, so a branch that gets 20 intermediate pushes while it's being written used to mean 20 full runs of that — runner time and macOS concurrency that queues ahead of everyone else's work. Keep the work in draft, run `just lint`/`just test` locally as you go, and flip to ready when it's genuinely ready.
+- **A skipped check shows up as a passing one.** So a draft PR looks green even though nothing ran — don't read that tick as a pass. `gh pr checks --json name,bucket,workflow` puts skipped ones in the `skipping` bucket; that's the only thing that distinguishes them. Note that the `Release` workflow's jobs are *supposed* to be skipped on a PR, so check the `CI` workflow's jobs specifically.
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,8 +147,9 @@ just dev-restore    # runs veld update
 - Keep PRs focused — one feature or fix per PR.
 - Don't break existing behavior without discussion.
 - Add tests where it makes sense, but don't over-test trivial code.
-- If CI fails, fix it before requesting review.
-- **Draft PRs don't run CI.** Every job in `ci.yml` skips while a PR is a draft, and marking it ready for review is what starts them. Two of those jobs run on macOS runners (billed at 10× a Linux minute) alongside a four-target release build matrix, so a branch that gets 20 intermediate pushes while it's being written used to cost 20 full runs. Keep the work in draft, run `just lint`/`just test` locally as you go, and flip to ready when it's genuinely ready. If your PR shows no checks at all, it's almost certainly still a draft.
+- If CI fails after you've marked the PR ready, fix it before asking for a human review.
+- **Draft PRs don't run CI.** Every job in `ci.yml` skips while a PR is a draft, and marking it ready for review is what starts them. A run reaches five macOS jobs (billed at 10× a Linux minute) alongside a four-target release build matrix, so a branch that gets 20 intermediate pushes while it's being written used to cost 20 full runs. Keep the work in draft, run `just lint`/`just test` locally as you go, and flip to ready when it's genuinely ready.
+- **A skipped check shows up as a passing one.** So a draft PR looks green even though nothing ran — don't read that tick as a pass. `gh pr checks --json name,bucket` puts them in the `skipping` bucket; that's the only thing that distinguishes them.
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,8 @@ Why? Because that's how this project was built, and it's how we believe modern s
 1. **Fork the repo** and create a branch from `main`.
 2. **Use an AI coding agent** to implement your changes.
 3. **Follow conventional commits** — we use [Conventional Commits](https://www.conventionalcommits.org/) for semantic versioning. Prefix your commit messages with `feat:`, `fix:`, `docs:`, `chore:`, etc.
-4. **Make sure CI passes** — `cargo fmt`, `cargo clippy`, and `cargo test` must all be green.
-5. **Open a PR** with a clear description of what changed and why.
+4. **Run the checks locally first** — `just lint` and `just test` (`cargo fmt`, `cargo clippy`, `cargo test`) must all be green *before* you ask CI for an opinion. This is not a formality: **CI does not run while a PR is a draft.**
+5. **Open a PR** with a clear description of what changed and why. Open it as a draft while you're still iterating — pushes to a draft are free — and mark it ready for review once your agent has finished reviewing the change and your local checks are green. That's the step that starts CI.
 
 ## Development setup
 
@@ -140,6 +140,7 @@ just dev-restore    # runs veld update
 | `just build` | Build Rust + frontend | No |
 | `just test` | Run all tests | No |
 | `just lint` | Clippy + TypeScript type check | No |
+| `just workflow-gates` | Assert no CI job can run on a draft PR (needs PyYAML) | No |
 
 ## Guidelines
 
@@ -147,6 +148,7 @@ just dev-restore    # runs veld update
 - Don't break existing behavior without discussion.
 - Add tests where it makes sense, but don't over-test trivial code.
 - If CI fails, fix it before requesting review.
+- **Draft PRs don't run CI.** Every job in `ci.yml` skips while a PR is a draft, and marking it ready for review is what starts them. Two of those jobs run on macOS runners (billed at 10× a Linux minute) alongside a four-target release build matrix, so a branch that gets 20 intermediate pushes while it's being written used to cost 20 full runs. Keep the work in draft, run `just lint`/`just test` locally as you go, and flip to ready when it's genuinely ready. If your PR shows no checks at all, it's almost certainly still a draft.
 
 ## License
 

--- a/docs/agentic-review.md
+++ b/docs/agentic-review.md
@@ -156,13 +156,20 @@ Capture output verbatim.
 
 - **Pre-pass red → fix that first**, then start. Reviewing a diff that doesn't
   compile or whose tests fail is a category error.
-- **The pre-pass is not a warm-up for CI — it is the only signal this diff gets
-  until the PR is marked ready.** CI skips every job while a PR is a draft
-  (AGENTS.md → CI cost convention), and this loop runs entirely on a draft. So
-  there is no second opinion coming: a check you skip here is a check nobody runs.
-  Run the full list, including the UI checks when the diff touches
+- **The pre-pass is not a warm-up for CI — it is the only signal this diff gets.**
+  CI skips every job while a PR is a draft (AGENTS.md → CI cost convention), and
+  this loop runs before the PR exists at all, or at most on a draft. So there is
+  no second opinion coming: a check you skip here is a check nobody runs. Run the
+  full list, including the UI checks when the diff touches
   `crates/veld-daemon/ui`, and re-run it after every fix (§8.4) rather than
   batching one run at the end.
+- **Two CI checks have no default local equivalent — add them when the diff
+  reaches them.** `just workflow-gates` when the change touches
+  `.github/workflows/` (the `schema` job's draft-PR gate), and a read of your own
+  commit subjects against the conventional-commits pattern in the `commits` job
+  (`ci.yml`, a regex over `git rev-list BASE..HEAD`). Both used to fail on the
+  first draft push; now they first run *after* the spending decision, so a
+  malformed commit subject costs a full five-macOS-leg run to discover.
 - **Everything the pre-pass reports is out of scope for every subagent.** Put
   this line in every brief: *"The typechecker, linter and tests already ran;
   their output is in the context pack. Do not re-report it. Findings that

--- a/docs/agentic-review.md
+++ b/docs/agentic-review.md
@@ -156,6 +156,13 @@ Capture output verbatim.
 
 - **Pre-pass red → fix that first**, then start. Reviewing a diff that doesn't
   compile or whose tests fail is a category error.
+- **The pre-pass is not a warm-up for CI — it is the only signal this diff gets
+  until the PR is marked ready.** CI skips every job while a PR is a draft
+  (AGENTS.md → CI cost convention), and this loop runs entirely on a draft. So
+  there is no second opinion coming: a check you skip here is a check nobody runs.
+  Run the full list, including the UI checks when the diff touches
+  `crates/veld-daemon/ui`, and re-run it after every fix (§8.4) rather than
+  batching one run at the end.
 - **Everything the pre-pass reports is out of scope for every subagent.** Put
   this line in every brief: *"The typechecker, linter and tests already ran;
   their output is in the context pack. Do not re-report it. Findings that
@@ -190,6 +197,12 @@ linters, apply fixes, re-route angles, add rounds within budget, write to
 default branch, modify CI credentials or secrets, delete tests to make them pass,
 widen scope into pre-existing bugs the diff merely exposed, reformat or "improve"
 code outside a finding's fix, change intended product behavior.
+
+**Never mark the PR ready for review** (`gh pr ready`). That is what starts CI,
+and it belongs to the caller *after* this loop exits — the whole point of the
+draft state is that an unreviewed diff costs nothing (AGENTS.md → CI cost
+convention). A loop that flips the PR ready mid-round pays for a full CI run on
+code it is about to change.
 
 **Three hard stops — halt the loop, write the report, ask:**
 

--- a/docs/agentic-review.md
+++ b/docs/agentic-review.md
@@ -163,13 +163,15 @@ Capture output verbatim.
   full list, including the UI checks when the diff touches
   `crates/veld-daemon/ui`, and re-run it after every fix (§8.4) rather than
   batching one run at the end.
-- **Two CI checks have no default local equivalent — add them when the diff
-  reaches them.** `just workflow-gates` when the change touches
-  `.github/workflows/` (the `schema` job's draft-PR gate), and a read of your own
-  commit subjects against the conventional-commits pattern in the `commits` job
-  (`ci.yml`, a regex over `git rev-list BASE..HEAD`). Both used to fail on the
-  first draft push; now they first run *after* the spending decision, so a
-  malformed commit subject costs a full five-macOS-leg run to discover.
+- **Two CI checks are now post-spend, so run them locally instead.**
+  `just workflow-gates` whenever the change touches `.github/workflows/`, and
+  `just commit-subjects` before pushing. Both used to fail on the first draft
+  push, in seconds, on a Linux runner; both are draft-guarded now and first report
+  *after* the PR is marked ready — so a malformed commit subject or an unguarded
+  new job is discovered only once the five macOS legs have already dispatched.
+  `just workflow-gates` is the sole thing standing between an unguarded job and a
+  draft that quietly runs it, because the gate's CI home (the `schema` job) is
+  draft-guarded too.
 - **Everything the pre-pass reports is out of scope for every subagent.** Put
   this line in every brief: *"The typechecker, linter and tests already ran;
   their output is in the context pack. Do not re-report it. Findings that

--- a/justfile
+++ b/justfile
@@ -312,6 +312,7 @@ lint:
 # recipe every contributor runs constantly — it must not grow a Python dep.
 # The `schema` job in ci.yml is the enforcing copy.
 workflow-gates:
+    python3 tests/validate-workflow-gates.py --selftest
     python3 tests/validate-workflow-gates.py
 
 build-frontend:

--- a/justfile
+++ b/justfile
@@ -307,6 +307,13 @@ lint:
     cd crates/veld-daemon/frontend && npx tsc --noEmit
     cd crates/veld-daemon/ui && npm run typecheck
 
+# Assert no CI job can run on a draft PR (AGENTS.md → CI cost convention).
+# Deliberately not folded into `lint`: this needs PyYAML, and `lint` is the
+# recipe every contributor runs constantly — it must not grow a Python dep.
+# The `schema` job in ci.yml is the enforcing copy.
+workflow-gates:
+    python3 tests/validate-workflow-gates.py
+
 build-frontend:
     cd crates/veld-daemon/frontend && npm run build
 

--- a/justfile
+++ b/justfile
@@ -310,10 +310,40 @@ lint:
 # Assert no CI job can run on a draft PR (AGENTS.md → CI cost convention).
 # Deliberately not folded into `lint`: this needs PyYAML, and `lint` is the
 # recipe every contributor runs constantly — it must not grow a Python dep.
-# The `schema` job in ci.yml is the enforcing copy.
+# Install it with `python3 -m pip install --user pyyaml`.
+# The `schema` job in ci.yml is the enforcing copy — and because that job is
+# itself draft-guarded, this local recipe is the ONLY thing that catches an
+# unguarded job before it has already run on a draft push. Run it whenever you
+# touch .github/workflows/.
 workflow-gates:
     python3 tests/validate-workflow-gates.py --selftest
     python3 tests/validate-workflow-gates.py
+
+# Check commit subjects against the pattern the `commits` job enforces. That job
+# is draft-guarded too, so without this a malformed subject is discovered only
+# after the PR is marked ready and the expensive legs have already dispatched.
+# The regex is duplicated from .github/workflows/ci.yml on purpose: extracting it
+# from a YAML `run:` block is more fragile than two copies of a list of
+# conventional-commit types that changes approximately never. ci.yml is the
+# enforcing copy; if they disagree, ci.yml wins.
+commit-subjects base="origin/main":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    pattern='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?: .+'
+    failed=0
+    while IFS= read -r sha; do
+        msg=$(git log --format='%s' -1 "$sha")
+        if echo "$msg" | grep -qE "$pattern"; then
+            echo "✅ $msg"
+        else
+            echo "❌ $msg"
+            failed=1
+        fi
+    done < <(git rev-list {{base}}..HEAD)
+    if [ "$failed" -eq 1 ]; then
+        echo "Expected: type(scope)?: description — see CONTRIBUTING.md" >&2
+        exit 1
+    fi
 
 build-frontend:
     cd crates/veld-daemon/frontend && npm run build

--- a/justfile
+++ b/justfile
@@ -330,8 +330,20 @@ commit-subjects base="origin/main":
     #!/usr/bin/env bash
     set -euo pipefail
     pattern='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?: .+'
+    # Command substitution, NOT `while read ... < <(git rev-list ...)`. `set -e`
+    # does not reach into a process substitution, so a stale or unfetched
+    # {{base}} made the loop read zero lines, leave failed=0, and exit 0 —
+    # reporting "clean" for a check that never ran. An assignment carries the
+    # substitution's status, so this form actually fails. (Also avoids `mapfile`,
+    # which macOS's bundled bash 3.2 does not have.)
+    shas=$(git rev-list "{{base}}..HEAD")
+    if [ -z "$shas" ]; then
+        echo "No commits in {{base}}..HEAD — nothing to check." >&2
+        exit 0
+    fi
     failed=0
-    while IFS= read -r sha; do
+    # Unquoted on purpose: SHAs are hex, so word-splitting is safe here.
+    for sha in $shas; do
         msg=$(git log --format='%s' -1 "$sha")
         if echo "$msg" | grep -qE "$pattern"; then
             echo "✅ $msg"
@@ -339,7 +351,7 @@ commit-subjects base="origin/main":
             echo "❌ $msg"
             failed=1
         fi
-    done < <(git rev-list {{base}}..HEAD)
+    done
     if [ "$failed" -eq 1 ]; then
         echo "Expected: type(scope)?: description — see CONTRIBUTING.md" >&2
         exit 1

--- a/tests/validate-workflow-gates.py
+++ b/tests/validate-workflow-gates.py
@@ -4,9 +4,12 @@
 Draft PRs are where an agentic contributor's intermediate commits land, and
 `.github/workflows/ci.yml` is expensive to run: a pull_request run reaches five
 macOS legs (`integration`, `injection-test`, the mac leg of `desktop-package`,
-and both darwin legs of `release-build`), each billed at 10x a Linux minute, on
-top of a four-target release build matrix. The house workflow (AGENTS.md -> PR
-Workflow) reviews locally first and marks the PR ready for review second, so a
+and both darwin legs of `release-build`), on top of a four-target release build
+matrix. Standard macOS runners are free on public repositories, so what a draft
+run costs is runner time and the account's macOS concurrency allowance rather
+than a dollar figure -- five simultaneous mac jobs is a large share of it, and a
+draft's runs queue ahead of work that matters. The house workflow (AGENTS.md ->
+PR Workflow) reviews locally first and marks the PR ready for review second, so a
 draft has by definition not earned a CI run yet.
 
 Nothing in Actions enforces that, and the symptom of a missing guard is a bill
@@ -49,11 +52,19 @@ BARE_GUARD = GUARD
 # needs no draft guard. release.yml's build/desktop jobs are in this class.
 PUSH_ONLY = "github.event_name == 'push'"
 
-# These make a job run even when its `needs` were skipped, which is exactly how a
-# dependent job escapes the cascade. `cancelled()` counts because the common
-# `!cancelled()` idiom has the same effect as `always()` here.
-CASCADE_BREAKERS = ("always(", "cancelled(")
+# Any status-check function on a job that has `needs:` is treated as escaping the
+# skip cascade. This is deliberately broader than the two obvious spellings:
+# allowlisting `always(`/`cancelled(` let `if: '!failure()'` and
+# `success() || failure()` through, and the gate has no business deciding which
+# status functions happen to rescue a job whose dependency was skipped. If a job
+# needs one of these AND must not run on drafts, it states the guard explicitly.
+CASCADE_BREAKERS = ("always(", "cancelled(", "failure(", "success(")
 
+# `ready_for_review` is the half that makes the guard survivable, but `synchronize`
+# is the half that keeps a *ready* PR testing its own pushes. Requiring only the
+# former let `types: [ready_for_review]` pass, which is the same bug pointing the
+# other way: a ready PR that never re-runs on a push.
+REQUIRED_TYPES = ("opened", "synchronize", "reopened", "ready_for_review")
 REQUIRED_TYPE = "ready_for_review"
 
 # `pull_request_target` carries the same `draft` field and the same activity
@@ -128,14 +139,26 @@ def check_doc(doc, name):
                 f"{name}: `on.{trigger}` has no `types`, so it uses the default "
                 f"set (opened, synchronize, reopened) and will never fire on "
                 f"{REQUIRED_TYPE} -- a PR flipped from draft to ready would get "
-                f"no checks at all. Add: types: [opened, synchronize, reopened, "
-                f"{REQUIRED_TYPE}]"
+                f"no checks at all. Add: types: {list(REQUIRED_TYPES)}"
             )
-        elif REQUIRED_TYPE not in types:
+        elif not isinstance(types, list):
+            # `types: ready_for_review` is legal YAML and yields a string, against
+            # which `in` is substring matching rather than membership -- so a
+            # scalar would have satisfied the old check while listing one type.
             problems.append(
-                f"{name}: `on.{trigger}.types` is {types} and is missing "
-                f"`{REQUIRED_TYPE}`, so marking a draft PR ready fires nothing."
+                f"{name}: `on.{trigger}.types` is the scalar {types!r}, not a "
+                f"list. Write it as a list: types: {list(REQUIRED_TYPES)}"
             )
+        else:
+            missing = [t for t in REQUIRED_TYPES if t not in types]
+            if missing:
+                problems.append(
+                    f"{name}: `on.{trigger}.types` is {types} and is missing "
+                    f"{missing}. `{REQUIRED_TYPE}` is what makes marking a draft "
+                    f"ready fire anything at all; `synchronize` is what keeps a "
+                    f"ready PR re-testing its own pushes. Use: "
+                    f"types: {list(REQUIRED_TYPES)}"
+                )
 
     # `github.event_name != 'pull_request'` is TRUE for a pull_request_target
     # event, so the usual guard leaves such a job wide open. A workflow carrying
@@ -152,8 +175,19 @@ def check_doc(doc, name):
             continue
         cond = normalize(job.get("if", ""))
 
-        if cond in (ANY_EVENT_GUARD, PR_ONLY_GUARD, BARE_GUARD):
-            if cond == ANY_EVENT_GUARD and has_target:
+        # An extra clause may be ANDed ONTO a guard: `<guard> && X` is strictly
+        # more restrictive than `<guard>`, so it cannot start running on drafts.
+        #
+        # It may not be ANDed onto the bare `||` form, though, because `&&` binds
+        # tighter than `||` in Actions expressions: `A || B && X` parses as
+        # `A || (B && X)`, NOT `(A || B) && X` -- so the `A` branch escapes the
+        # extra condition entirely. Parenthesise it and it is fine.
+        andable = [PR_ONLY_GUARD, BARE_GUARD, "(" + ANY_EVENT_GUARD + ")"]
+        if any(cond == f or cond.startswith(f + " &&") for f in andable):
+            continue
+
+        if cond == ANY_EVENT_GUARD:
+            if has_target:
                 problems.append(
                     f"{name}: job `{job_name}` guards on "
                     f"`github.event_name != 'pull_request'`, which is TRUE for a "
@@ -164,6 +198,19 @@ def check_doc(doc, name):
             continue
 
         if cond == PUSH_ONLY or cond.startswith(PUSH_ONLY + " &&"):
+            # `github.event_name == 'push' && X || github.event_name ==
+            # 'pull_request'` starts with the push-only prefix and runs on every
+            # draft PR, because `&&` binds tighter than `||`. A push-only
+            # condition that contains `||` is not push-only.
+            if "||" not in cond:
+                continue
+            problems.append(
+                f"{name}: job `{job_name}` looks push-only but its condition "
+                f"contains `||`, and `&&` binds tighter than `||` -- so "
+                f"`{PUSH_ONLY} && X || <anything>` runs on draft PRs. Add the "
+                f"explicit guard, or parenthesise the push-only half.\n"
+                f"    (got: {cond})"
+            )
             continue
 
         if GUARD in cond:
@@ -171,10 +218,13 @@ def check_doc(doc, name):
                 f"{name}: job `{job_name}` mentions the draft guard but its "
                 f"condition as a whole is not an accepted form, so the guard may "
                 f"not gate anything -- `true || {GUARD}` is the shape this "
-                f"catches. Use exactly one of:\n"
+                f"catches. Extra conditions are fine, but they must be ANDed onto "
+                f"one of these (and the `||` form must be parenthesised first, "
+                f"because `&&` binds tighter than `||`):\n"
                 f"      if: {ANY_EVENT_GUARD}\n"
-                f"      if: {PR_ONLY_GUARD}\n"
-                f"      if: {BARE_GUARD}\n"
+                f"      if: ({ANY_EVENT_GUARD}) && <rest>\n"
+                f"      if: {PR_ONLY_GUARD} && <rest>\n"
+                f"      if: {BARE_GUARD} && <rest>\n"
                 f"    (got: {cond})"
             )
             continue
@@ -300,6 +350,93 @@ SELFTEST = [
               || github.event.pull_request.draft == false }}
             runs-on: ubuntu-latest
             steps: [{run: echo}]
+        """,
+    ),
+    (
+        "push-only prefix widened with || runs on draft PRs",
+        False,
+        """
+        on:
+          push: {branches: [main]}
+          pull_request: {types: [opened, synchronize, reopened, ready_for_review]}
+        jobs:
+          leaky:
+            if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
+            runs-on: macos-latest
+            steps: [{run: echo}]
+        """,
+    ),
+    (
+        "the || form ANDed without parens leaves a branch unguarded",
+        False,
+        """
+        on: {pull_request: {types: [opened, synchronize, reopened, ready_for_review]}}
+        jobs:
+          precedence:
+            if: github.event_name != 'pull_request' || github.event.pull_request.draft == false && github.ref != 'refs/heads/wip'
+            runs-on: macos-latest
+            steps: [{run: echo}]
+        """,
+    ),
+    (
+        "extra clause ANDed onto the bare guard is fine",
+        True,
+        """
+        on: {pull_request: {types: [opened, synchronize, reopened, ready_for_review]}}
+        jobs:
+          narrower:
+            if: github.event.pull_request.draft == false && github.event.pull_request.base.ref == 'main'
+            runs-on: ubuntu-latest
+            steps: [{run: echo}]
+        """,
+    ),
+    (
+        "the || form parenthesised then ANDed is fine",
+        True,
+        """
+        on: {pull_request: {types: [opened, synchronize, reopened, ready_for_review]}}
+        jobs:
+          narrower:
+            if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && github.ref != 'refs/heads/wip'
+            runs-on: ubuntu-latest
+            steps: [{run: echo}]
+        """,
+    ),
+    (
+        "types listing only ready_for_review stops a ready PR re-testing pushes",
+        False,
+        """
+        on: {pull_request: {types: [ready_for_review]}}
+        jobs:
+          ok:
+            if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+            runs-on: ubuntu-latest
+            steps: [{run: echo}]
+        """,
+    ),
+    (
+        "types as a YAML scalar is not membership",
+        False,
+        """
+        on: {pull_request: {types: ready_for_review}}
+        jobs:
+          ok:
+            if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+            runs-on: ubuntu-latest
+            steps: [{run: echo}]
+        """,
+    ),
+    (
+        "a dependent rescued by !failure() escapes the cascade",
+        False,
+        """
+        on: {pull_request: {types: [opened, synchronize, reopened, ready_for_review]}}
+        jobs:
+          root:
+            if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+            runs-on: ubuntu-latest
+            steps: [{run: echo}]
+          dep: {needs: root, if: '!failure()', runs-on: macos-latest, steps: [{run: echo}]}
         """,
     ),
     (

--- a/tests/validate-workflow-gates.py
+++ b/tests/validate-workflow-gates.py
@@ -175,19 +175,43 @@ def check_doc(doc, name):
             continue
         cond = normalize(job.get("if", ""))
 
-        # An extra clause may be ANDed ONTO a guard: `<guard> && X` is strictly
-        # more restrictive than `<guard>`, so it cannot start running on drafts.
+        # Every accepted shape lives in ONE table, checked by ONE loop. It was
+        # briefly two code paths -- a match against the ANDable forms, then a
+        # separate `cond == ANY_EVENT_GUARD` branch carrying the
+        # pull_request_target check -- and adding the parenthesised form to the
+        # first path silently routed around the second, so
+        # `(A || draft == false)` under pull_request_target passed. The
+        # duplicated path was the defect; don't reintroduce it.
         #
-        # It may not be ANDed onto the bare `||` form, though, because `&&` binds
-        # tighter than `||` in Actions expressions: `A || B && X` parses as
-        # `A || (B && X)`, NOT `(A || B) && X` -- so the `A` branch escapes the
-        # extra condition entirely. Parenthesise it and it is fine.
-        andable = [PR_ONLY_GUARD, BARE_GUARD, "(" + ANY_EVENT_GUARD + ")"]
-        if any(cond == f or cond.startswith(f + " &&") for f in andable):
-            continue
-
-        if cond == ANY_EVENT_GUARD:
-            if has_target:
+        # `andable`: an extra clause may be ANDed ONTO a guard, because
+        # `<guard> && X` is strictly more restrictive than `<guard>` and so cannot
+        # start running on drafts. The unparenthesised `||` form is the exception:
+        # `&&` binds tighter than `||` in Actions expressions, so `A || B && X`
+        # parses as `A || (B && X)`, NOT `(A || B) && X`, and the `A` branch
+        # escapes the extra condition entirely.
+        #
+        # `event_name_half`: relies on `github.event_name != 'pull_request'`, which
+        # is TRUE during a pull_request_target event and therefore guards nothing
+        # in a workflow carrying that trigger.
+        #
+        #                    form                          andable  event_name_half
+        accepted = (
+            (ANY_EVENT_GUARD,                              False,   True),
+            ("(" + ANY_EVENT_GUARD + ")",                   True,    True),
+            (PR_ONLY_GUARD,                                 True,    False),
+            (BARE_GUARD,                                    True,    False),
+        )
+        matched = next(
+            (
+                (form, event_name_half)
+                for form, andable, event_name_half in accepted
+                if cond == form or (andable and cond.startswith(form + " &&"))
+            ),
+            None,
+        )
+        if matched is not None:
+            _, event_name_half = matched
+            if event_name_half and has_target:
                 problems.append(
                     f"{name}: job `{job_name}` guards on "
                     f"`github.event_name != 'pull_request'`, which is TRUE for a "
@@ -316,6 +340,43 @@ SELFTEST = [
             if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
             runs-on: ubuntu-latest
             steps: [{run: echo}]
+        """,
+    ),
+    (
+        "pull_request_target: the PARENTHESISED event_name form is still not guarded",
+        False,
+        """
+        on: {pull_request_target: {types: [opened, synchronize, reopened, ready_for_review]}}
+        jobs:
+          labeler:
+            if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+            runs-on: ubuntu-latest
+            steps: [{run: echo}]
+        """,
+    ),
+    (
+        "pull_request_target: parenthesised event_name form with an ANDed clause",
+        False,
+        """
+        on: {pull_request_target: {types: [opened, synchronize, reopened, ready_for_review]}}
+        jobs:
+          labeler:
+            if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && github.ref != 'refs/heads/wip'
+            runs-on: ubuntu-latest
+            steps: [{run: echo}]
+        """,
+    ),
+    (
+        "a dependent rescued by success() escapes the cascade",
+        False,
+        """
+        on: {pull_request: {types: [opened, synchronize, reopened, ready_for_review]}}
+        jobs:
+          root:
+            if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+            runs-on: ubuntu-latest
+            steps: [{run: echo}]
+          dep: {needs: root, if: success() || failure(), runs-on: macos-latest, steps: [{run: echo}]}
         """,
     ),
     (

--- a/tests/validate-workflow-gates.py
+++ b/tests/validate-workflow-gates.py
@@ -2,18 +2,24 @@
 """Assert that no GitHub Actions job can run on a draft pull request.
 
 Draft PRs are where an agentic contributor's intermediate commits land, and
-`.github/workflows/ci.yml` is expensive to run: two macOS legs (billed at 10x a
-Linux minute), a four-target release build matrix, and macOS Electron packaging.
-The house workflow (AGENTS.md -> PR Workflow) reviews locally first and marks the
-PR ready for review second, so a draft has by definition not earned a CI run yet.
+`.github/workflows/ci.yml` is expensive to run: a pull_request run reaches five
+macOS legs (`integration`, `injection-test`, the mac leg of `desktop-package`,
+and both darwin legs of `release-build`), each billed at 10x a Linux minute, on
+top of a four-target release build matrix. The house workflow (AGENTS.md -> PR
+Workflow) reviews locally first and marks the PR ready for review second, so a
+draft has by definition not earned a CI run yet.
 
 Nothing in Actions enforces that, and the symptom of a missing guard is a bill
 rather than a failed job -- so this is the drift gate, in the same spirit as the
 THIRD-PARTY-LICENSES.md and desktop/assets checks.
 
-Usage: python3 tests/validate-workflow-gates.py [workflow.yml ...]
+Usage:
+    python3 tests/validate-workflow-gates.py [workflow.yml ...]
+    python3 tests/validate-workflow-gates.py --selftest
 
-With no arguments it checks every workflow under .github/workflows.
+With no arguments it checks every workflow under .github/workflows. `--selftest`
+runs the gate against inline fixtures, which is what keeps the gate itself from
+silently degrading into a function that returns "fine" for everything.
 Requires PyYAML.
 """
 
@@ -24,9 +30,20 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
-# The canonical guard. Matched as a substring so a job may combine it with its
-# own conditions (`commits` in ci.yml is also restricted to PR events).
-DRAFT_GUARD = "github.event.pull_request.draft == false"
+GUARD = "github.event.pull_request.draft == false"
+
+# The whole condition must equal one of these (after normalization), NOT merely
+# contain the guard. A substring test looks equivalent and is not: `true ||
+# <guard>` contains the guard and gates nothing at all, because `||`
+# short-circuits on the first truthy operand. That hole was found by a review
+# angle and reproduced before this became an exact match.
+ANY_EVENT_GUARD = "github.event_name != 'pull_request' || " + GUARD
+PR_ONLY_GUARD = "github.event_name == 'pull_request' && " + GUARD
+# Valid under every trigger: on a push there is no `pull_request` in the payload,
+# so the left side is null, and Actions coerces both null and false to 0 when the
+# operand types differ -- making `null == false` true and the job run.
+# (docs.github.com/actions/reference/workflows-and-actions/expressions)
+BARE_GUARD = GUARD
 
 # A job that only ever runs on a push to main cannot run on a PR at all, so it
 # needs no draft guard. release.yml's build/desktop jobs are in this class.
@@ -39,24 +56,26 @@ CASCADE_BREAKERS = ("always(", "cancelled(")
 
 REQUIRED_TYPE = "ready_for_review"
 
+# `pull_request_target` carries the same `draft` field and the same activity
+# types, so it is just as capable of spending runner minutes on a draft. It is
+# listed because omitting it was a real hole: `pr_trigger` matched only the
+# literal key `pull_request`, so a future pull_request_target workflow would have
+# returned "no findings" while running on every draft push.
+PR_TRIGGERS = ("pull_request", "pull_request_target")
 
-def pr_trigger(on):
-    """Return the `pull_request` trigger config, or None if there isn't one.
 
-    PyYAML parses the unquoted key `on:` as the boolean True (YAML 1.1), so the
-    top-level mapping is keyed by True rather than "on" -- hence both lookups at
-    the call site. A shorthand trigger list (`on: [push, pull_request]`) has no
-    `types` to inspect and is reported as a bare dict.
+def normalize(cond):
+    """Collapse an `if:` expression to a canonical single-line string.
+
+    Handles the two spellings that mean the same thing to Actions: an optional
+    `${{ ... }}` wrapper, and a YAML block scalar (`>-`) that arrives with
+    embedded newlines. Anything this does not recognise simply fails the exact
+    match below, which is the safe direction for a cost gate.
     """
-    if isinstance(on, list):
-        return {} if "pull_request" in on else None
-    if isinstance(on, str):
-        return {} if on == "pull_request" else None
-    if isinstance(on, dict):
-        if "pull_request" not in on:
-            return None
-        return on["pull_request"] or {}
-    return None
+    cond = " ".join(str(cond).split())
+    if cond.startswith("${{") and cond.endswith("}}"):
+        cond = " ".join(cond[3:-2].split())
+    return cond
 
 
 def label(path):
@@ -72,49 +91,94 @@ def label(path):
         return path
 
 
-def check(path):
-    """Return a list of human-readable problems for one workflow file."""
-    doc = yaml.safe_load(path.read_text())
-    if not isinstance(doc, dict):
-        return [f"{label(path)}: not a YAML mapping"]
+def pr_triggers(on):
+    """Return {trigger_name: config} for every PR-ish trigger the workflow has.
 
-    # `on` may have been parsed as the boolean key True; see pr_trigger().
-    on = doc.get("on", doc.get(True))
-    trigger = pr_trigger(on)
-    if trigger is None:
-        return []  # No pull_request trigger, nothing a draft PR can start.
+    PyYAML parses the unquoted key `on:` as the boolean True (YAML 1.1), so the
+    top-level mapping is keyed by True rather than "on" -- hence both lookups at
+    the call site. A shorthand trigger list (`on: [push, pull_request]`) has no
+    `types` to inspect, and is reported as an empty config so the missing-types
+    check still fires.
+    """
+    if isinstance(on, str):
+        on = [on]
+    if isinstance(on, list):
+        return {t: {} for t in PR_TRIGGERS if t in on}
+    if isinstance(on, dict):
+        return {t: (on[t] or {}) for t in PR_TRIGGERS if t in on}
+    return {}
+
+
+def check_doc(doc, name):
+    """Return a list of human-readable problems for one parsed workflow."""
+    if not isinstance(doc, dict):
+        return [f"{name}: not a YAML mapping"]
+
+    # `on` may have been parsed as the boolean key True; see pr_triggers().
+    triggers = pr_triggers(doc.get("on", doc.get(True)))
+    if not triggers:
+        return []  # Nothing a draft PR can start.
 
     problems = []
-    rel = label(path)
 
-    types = trigger.get("types")
-    if types is None:
-        problems.append(
-            f"{rel}: `on.pull_request` has no `types`, so it uses the default set "
-            f"(opened, synchronize, reopened) and will never fire on "
-            f"{REQUIRED_TYPE} -- a PR flipped from draft to ready would get no "
-            f"checks at all. Add: types: [opened, synchronize, reopened, "
-            f"{REQUIRED_TYPE}]"
-        )
-    elif REQUIRED_TYPE not in types:
-        problems.append(
-            f"{rel}: `on.pull_request.types` is {types} and is missing "
-            f"`{REQUIRED_TYPE}`, so marking a draft PR ready fires nothing."
-        )
+    for trigger, cfg in triggers.items():
+        types = cfg.get("types")
+        if types is None:
+            problems.append(
+                f"{name}: `on.{trigger}` has no `types`, so it uses the default "
+                f"set (opened, synchronize, reopened) and will never fire on "
+                f"{REQUIRED_TYPE} -- a PR flipped from draft to ready would get "
+                f"no checks at all. Add: types: [opened, synchronize, reopened, "
+                f"{REQUIRED_TYPE}]"
+            )
+        elif REQUIRED_TYPE not in types:
+            problems.append(
+                f"{name}: `on.{trigger}.types` is {types} and is missing "
+                f"`{REQUIRED_TYPE}`, so marking a draft PR ready fires nothing."
+            )
+
+    # `github.event_name != 'pull_request'` is TRUE for a pull_request_target
+    # event, so the usual guard leaves such a job wide open. A workflow carrying
+    # that trigger must use the bare or event-specific form instead.
+    has_target = "pull_request_target" in triggers
 
     jobs = doc.get("jobs") or {}
     if not jobs:
-        problems.append(f"{rel}: no `jobs` block found -- did the parse succeed?")
+        problems.append(f"{name}: no `jobs` block found -- did the parse succeed?")
 
-    for name, job in jobs.items():
+    for job_name, job in jobs.items():
         if not isinstance(job, dict):
-            problems.append(f"{rel}: job `{name}` is not a mapping")
+            problems.append(f"{name}: job `{job_name}` is not a mapping")
             continue
-        # `if` is another YAML 1.1 casualty in principle, but unlike `on` it is
-        # not a boolean word, so it survives as the string "if".
-        cond = str(job.get("if", ""))
-        if DRAFT_GUARD in cond or PUSH_ONLY in cond:
+        cond = normalize(job.get("if", ""))
+
+        if cond in (ANY_EVENT_GUARD, PR_ONLY_GUARD, BARE_GUARD):
+            if cond == ANY_EVENT_GUARD and has_target:
+                problems.append(
+                    f"{name}: job `{job_name}` guards on "
+                    f"`github.event_name != 'pull_request'`, which is TRUE for a "
+                    f"`pull_request_target` event -- so this job still runs on "
+                    f"draft PRs. In a workflow with that trigger use the bare "
+                    f"form: if: {BARE_GUARD}"
+                )
             continue
+
+        if cond == PUSH_ONLY or cond.startswith(PUSH_ONLY + " &&"):
+            continue
+
+        if GUARD in cond:
+            problems.append(
+                f"{name}: job `{job_name}` mentions the draft guard but its "
+                f"condition as a whole is not an accepted form, so the guard may "
+                f"not gate anything -- `true || {GUARD}` is the shape this "
+                f"catches. Use exactly one of:\n"
+                f"      if: {ANY_EVENT_GUARD}\n"
+                f"      if: {PR_ONLY_GUARD}\n"
+                f"      if: {BARE_GUARD}\n"
+                f"    (got: {cond})"
+            )
+            continue
+
         # A dependent job inherits the skip: when every job it `needs` is
         # skipped, it is skipped too -- unless its own condition overrides that.
         if job.get("needs"):
@@ -122,22 +186,168 @@ def check(path):
             if breaker is None:
                 continue
             problems.append(
-                f"{rel}: job `{name}` relies on `needs` to inherit the draft "
+                f"{name}: job `{job_name}` relies on `needs` to inherit the draft "
                 f"skip, but its `if` contains `{breaker}`, which runs it even "
                 f"when its dependencies were skipped. Add the explicit guard: "
-                f"if: github.event_name != 'pull_request' || {DRAFT_GUARD}"
+                f"if: {ANY_EVENT_GUARD}"
             )
             continue
+
         problems.append(
-            f"{rel}: job `{name}` can run on a draft PR -- it has no `needs` to "
-            f"inherit a skip from and no draft guard. Add: "
-            f"if: github.event_name != 'pull_request' || {DRAFT_GUARD}"
+            f"{name}: job `{job_name}` can run on a draft PR -- it has no `needs` "
+            f"to inherit a skip from and no draft guard. Add: "
+            f"if: {ANY_EVENT_GUARD}"
         )
 
     return problems
 
 
+def check(path):
+    return check_doc(yaml.safe_load(path.read_text()), str(label(path)))
+
+
+# ── Self-test ─────────────────────────────────────────────────────────
+# A gate whose own correctness was confirmed once, by hand, in a temp directory
+# is a gate that can rot into `return []` without anyone noticing. Each fixture
+# below is a hole this script has actually been asked to catch.
+SELFTEST = [
+    (
+        "unguarded root job",
+        False,
+        """
+        on: {pull_request: {types: [opened, synchronize, reopened, ready_for_review]}}
+        jobs: {expensive: {runs-on: macos-latest, steps: [{run: echo}]}}
+        """,
+    ),
+    (
+        "missing ready_for_review type",
+        False,
+        """
+        on: {pull_request: {branches: [main]}}
+        jobs:
+          ok:
+            if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+            runs-on: ubuntu-latest
+            steps: [{run: echo}]
+        """,
+    ),
+    (
+        "dependent job breaks the cascade with always()",
+        False,
+        """
+        on: {pull_request: {types: [opened, synchronize, reopened, ready_for_review]}}
+        jobs:
+          root:
+            if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+            runs-on: ubuntu-latest
+            steps: [{run: echo}]
+          dep: {needs: root, if: always(), runs-on: macos-latest, steps: [{run: echo}]}
+        """,
+    ),
+    (
+        "guard neutralised by a tautology",
+        False,
+        """
+        on: {pull_request: {types: [opened, synchronize, reopened, ready_for_review]}}
+        jobs:
+          sneaky:
+            if: true || github.event.pull_request.draft == false
+            runs-on: macos-latest
+            steps: [{run: echo}]
+        """,
+    ),
+    (
+        "pull_request_target with the event_name form is not guarded",
+        False,
+        """
+        on: {pull_request_target: {types: [opened, synchronize, reopened, ready_for_review]}}
+        jobs:
+          labeler:
+            if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+            runs-on: ubuntu-latest
+            steps: [{run: echo}]
+        """,
+    ),
+    (
+        "pull_request_target with the bare guard is fine",
+        True,
+        """
+        on: {pull_request_target: {types: [opened, synchronize, reopened, ready_for_review]}}
+        jobs:
+          labeler:
+            if: github.event.pull_request.draft == false
+            runs-on: ubuntu-latest
+            steps: [{run: echo}]
+        """,
+    ),
+    (
+        "no pull_request trigger at all",
+        True,
+        """
+        on: {push: {branches: [main]}}
+        jobs: {anything: {runs-on: macos-latest, steps: [{run: echo}]}}
+        """,
+    ),
+    (
+        "canonical guard wrapped in ${{ }} and split over lines",
+        True,
+        """
+        on: {pull_request: {types: [opened, synchronize, reopened, ready_for_review]}}
+        jobs:
+          ok:
+            if: >-
+              ${{ github.event_name != 'pull_request'
+              || github.event.pull_request.draft == false }}
+            runs-on: ubuntu-latest
+            steps: [{run: echo}]
+        """,
+    ),
+    (
+        "push-only job plus a plain dependent",
+        True,
+        """
+        on:
+          push: {branches: [main]}
+          pull_request: {types: [opened, synchronize, reopened, ready_for_review]}
+        jobs:
+          plan:
+            if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+            runs-on: ubuntu-latest
+            steps: [{run: echo}]
+          build:
+            needs: plan
+            if: github.event_name == 'push' && needs.plan.outputs.go == 'true'
+            runs-on: macos-latest
+            steps: [{run: echo}]
+          publish: {needs: build, runs-on: ubuntu-latest, steps: [{run: echo}]}
+        """,
+    ),
+]
+
+
+def selftest():
+    failures = []
+    for name, should_pass, text in SELFTEST:
+        problems = check_doc(yaml.safe_load(text), f"<selftest: {name}>")
+        passed = not problems
+        if passed != should_pass:
+            want = "pass" if should_pass else "be rejected"
+            failures.append(f"  fixture {name!r} should {want}, got {problems or 'no problems'}")
+        print(f"  {'ok' if passed == should_pass else 'FAIL'}  {name}")
+
+    if failures:
+        print("\n::error::the draft-PR gate no longer detects what it claims to:")
+        for f in failures:
+            print(f)
+        return 1
+    print(f"Self-test passed ({len(SELFTEST)} fixtures).")
+    return 0
+
+
 def main(argv):
+    if "--selftest" in argv:
+        return selftest()
+
     if argv:
         paths = [Path(a).resolve() for a in argv]
     else:

--- a/tests/validate-workflow-gates.py
+++ b/tests/validate-workflow-gates.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Assert that no GitHub Actions job can run on a draft pull request.
+
+Draft PRs are where an agentic contributor's intermediate commits land, and
+`.github/workflows/ci.yml` is expensive to run: two macOS legs (billed at 10x a
+Linux minute), a four-target release build matrix, and macOS Electron packaging.
+The house workflow (AGENTS.md -> PR Workflow) reviews locally first and marks the
+PR ready for review second, so a draft has by definition not earned a CI run yet.
+
+Nothing in Actions enforces that, and the symptom of a missing guard is a bill
+rather than a failed job -- so this is the drift gate, in the same spirit as the
+THIRD-PARTY-LICENSES.md and desktop/assets checks.
+
+Usage: python3 tests/validate-workflow-gates.py [workflow.yml ...]
+
+With no arguments it checks every workflow under .github/workflows.
+Requires PyYAML.
+"""
+
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# The canonical guard. Matched as a substring so a job may combine it with its
+# own conditions (`commits` in ci.yml is also restricted to PR events).
+DRAFT_GUARD = "github.event.pull_request.draft == false"
+
+# A job that only ever runs on a push to main cannot run on a PR at all, so it
+# needs no draft guard. release.yml's build/desktop jobs are in this class.
+PUSH_ONLY = "github.event_name == 'push'"
+
+# These make a job run even when its `needs` were skipped, which is exactly how a
+# dependent job escapes the cascade. `cancelled()` counts because the common
+# `!cancelled()` idiom has the same effect as `always()` here.
+CASCADE_BREAKERS = ("always(", "cancelled(")
+
+REQUIRED_TYPE = "ready_for_review"
+
+
+def pr_trigger(on):
+    """Return the `pull_request` trigger config, or None if there isn't one.
+
+    PyYAML parses the unquoted key `on:` as the boolean True (YAML 1.1), so the
+    top-level mapping is keyed by True rather than "on" -- hence both lookups at
+    the call site. A shorthand trigger list (`on: [push, pull_request]`) has no
+    `types` to inspect and is reported as a bare dict.
+    """
+    if isinstance(on, list):
+        return {} if "pull_request" in on else None
+    if isinstance(on, str):
+        return {} if on == "pull_request" else None
+    if isinstance(on, dict):
+        if "pull_request" not in on:
+            return None
+        return on["pull_request"] or {}
+    return None
+
+
+def label(path):
+    """Repo-relative path for messages, falling back to the absolute one.
+
+    An explicitly passed file can live outside the repo (a fixture in a temp dir),
+    and `relative_to` raises rather than degrading -- which turned a would-be
+    finding into a traceback the first time this was exercised.
+    """
+    try:
+        return path.relative_to(REPO_ROOT)
+    except ValueError:
+        return path
+
+
+def check(path):
+    """Return a list of human-readable problems for one workflow file."""
+    doc = yaml.safe_load(path.read_text())
+    if not isinstance(doc, dict):
+        return [f"{label(path)}: not a YAML mapping"]
+
+    # `on` may have been parsed as the boolean key True; see pr_trigger().
+    on = doc.get("on", doc.get(True))
+    trigger = pr_trigger(on)
+    if trigger is None:
+        return []  # No pull_request trigger, nothing a draft PR can start.
+
+    problems = []
+    rel = label(path)
+
+    types = trigger.get("types")
+    if types is None:
+        problems.append(
+            f"{rel}: `on.pull_request` has no `types`, so it uses the default set "
+            f"(opened, synchronize, reopened) and will never fire on "
+            f"{REQUIRED_TYPE} -- a PR flipped from draft to ready would get no "
+            f"checks at all. Add: types: [opened, synchronize, reopened, "
+            f"{REQUIRED_TYPE}]"
+        )
+    elif REQUIRED_TYPE not in types:
+        problems.append(
+            f"{rel}: `on.pull_request.types` is {types} and is missing "
+            f"`{REQUIRED_TYPE}`, so marking a draft PR ready fires nothing."
+        )
+
+    jobs = doc.get("jobs") or {}
+    if not jobs:
+        problems.append(f"{rel}: no `jobs` block found -- did the parse succeed?")
+
+    for name, job in jobs.items():
+        if not isinstance(job, dict):
+            problems.append(f"{rel}: job `{name}` is not a mapping")
+            continue
+        # `if` is another YAML 1.1 casualty in principle, but unlike `on` it is
+        # not a boolean word, so it survives as the string "if".
+        cond = str(job.get("if", ""))
+        if DRAFT_GUARD in cond or PUSH_ONLY in cond:
+            continue
+        # A dependent job inherits the skip: when every job it `needs` is
+        # skipped, it is skipped too -- unless its own condition overrides that.
+        if job.get("needs"):
+            breaker = next((b for b in CASCADE_BREAKERS if b in cond), None)
+            if breaker is None:
+                continue
+            problems.append(
+                f"{rel}: job `{name}` relies on `needs` to inherit the draft "
+                f"skip, but its `if` contains `{breaker}`, which runs it even "
+                f"when its dependencies were skipped. Add the explicit guard: "
+                f"if: github.event_name != 'pull_request' || {DRAFT_GUARD}"
+            )
+            continue
+        problems.append(
+            f"{rel}: job `{name}` can run on a draft PR -- it has no `needs` to "
+            f"inherit a skip from and no draft guard. Add: "
+            f"if: github.event_name != 'pull_request' || {DRAFT_GUARD}"
+        )
+
+    return problems
+
+
+def main(argv):
+    if argv:
+        paths = [Path(a).resolve() for a in argv]
+    else:
+        paths = sorted((REPO_ROOT / ".github" / "workflows").glob("*.y*ml"))
+
+    if not paths:
+        print("No workflow files found.", file=sys.stderr)
+        return 1
+
+    problems = []
+    for path in paths:
+        problems.extend(check(path))
+
+    if problems:
+        for p in problems:
+            print(f"::error::{p}")
+        # Deliberately stdout, not stderr: the two streams interleave
+        # unpredictably in an Actions log, and a trailer that lands above the
+        # findings it explains is worse than no trailer.
+        print(
+            "\nDraft PRs must not spend runner minutes. See the note above "
+            "`jobs:` in .github/workflows/ci.yml."
+        )
+        return 1
+
+    print(f"Draft-PR gate verified across {len(paths)} workflow file(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## What changed

CI no longer runs on draft PRs, and the agent harness now treats "mark ready for review" as a deliberate spending decision that happens **after** the local review loop.

**The CI half**

- Every job in `ci.yml` (13) and `release.yml`'s only PR-reachable job (`plan`) carries a draft guard, and both workflows add `ready_for_review` to `on.pull_request.types`. Both halves are required: with the guard and without the type, flipping a draft to ready would fire nothing and the PR would sit with no checks forever.
- `concurrency` added to both workflows, with `cancel-in-progress` scoped to `pull_request` only.
- `tests/validate-workflow-gates.py` — new drift gate asserting the invariant, with a `--selftest` of 19 fixtures. Runs in the `schema` job and via `just workflow-gates`.
- `just commit-subjects` — local equivalent of the `commits` job's conventional-commits check.

**The harness half**

- `AGENTS.md` — new CI cost convention; "mark ready for review" is now an explicit numbered step between the review loop and the CI wait.
- `docs/agentic-review.md` — the review loop is forbidden from running `gh pr ready`, and the pre-pass is documented as the only signal a draft gets.
- `.claude/skills/ship/SKILL.md` — **Step 6 was reordered.** It previously said "wait for CI green → then `gh pr ready`", which under this change waits forever.
- `CONTRIBUTING.md`, `justfile` — contributor-facing equivalents.

## Why this shape

A `pull_request` run occupies **five macOS legs** (`integration`, `injection-test`, the mac leg of `desktop-package`, and both darwin legs of `release-build`) plus a four-target release build matrix. An agent iterating on a draft re-ran all of it per push.

**Correction made during review:** standard macOS runners are free on public repositories, and this repo is public — so an earlier draft of these docs claiming "billed at 10× a Linux minute" was wrong in four places. What a draft run actually costs is **runner time and the account's macOS concurrency allowance**, which is what the original request said. The 10× multiplier is retained in comments only as a reason to keep the run's shape small, not as a claim about this repo's bill. If we *are* seeing macOS charges, the framing should go back — say so and I'll change it.

## Why not the obvious alternative

**YAML anchors.** The guard is repeated per job. Anchors are GA in Actions (since 2025-09-18), and an earlier version of this PR justified the repetition by claiming they weren't supported — that was false and the review caught it. The decision survived the correction on different grounds: GitHub's documented pattern is to define the anchor *on first use*, i.e. inside one job, which would make every other job's guard depend on that one job's continued existence and position in the file. A copy per job stays greppable and independently deletable, and the typo drift an anchor would prevent is already caught by the gate.

**A single gate job everything `needs:`.** Rejected: it costs a runner job per run and adds ~20s of serialization to every job, and it has the same drift exposure (a new job can forget `needs:` just as easily as `if:`). The gate script closes that properly instead.

## Root causes found in review, worth naming

- **The documented green criterion was unsatisfiable.** Four docs said "no bucket may be `skipping`". Verified against merged, fully-green #206: 17 CI checks pass and **5 Release checks skip**, on every healthy PR. A rule that fails on every green PR is a rule an agent learns to ignore. Now scoped to `workflow == "CI"`.
- **A skipped job reports as a *passing* check.** A draft PR looks green rather than unrun; `gh pr checks` exits 0 and prints "All checks were successful". The original diagnostic ("if no checks appear at all") could never fire. Every doc that tells an agent to wait for CI now says so and gives the `bucket`-based check.
- **`concurrency` regression, introduced and then fixed within this PR.** `cancel-in-progress: false` does not stop Actions cancelling a *pending* run in the same group. Keying non-PR runs on `github.ref` would have let three quick merges to main silently drop the middle one's release. Re-keyed on `github.sha`.

## Decision for the maintainer (not taken silently)

**The gate cannot run where it matters, and the same is true of the commit check.** `tests/validate-workflow-gates.py` lives in the `schema` job and the conventional-commits regex in `commits` — both now draft-guarded. So if someone adds an unguarded job, it runs on draft pushes until the PR is marked ready; and a malformed commit subject is discovered only after the expensive legs have dispatched.

Mitigated locally (`just workflow-gates`, `just commit-subjects`, both required by `docs/agentic-review.md` §1.1) and **stated as a known blind spot in `ci.yml`** rather than implied.

Closing it properly means one small **unguarded sentinel job** running just those two checks — ~1 ubuntu minute per draft push. That is better engineering, but it contradicts the literal request ("only ever execute the CI checks if a PR is actually ready for review"), so it is deliberately not in this PR. Happy to add it here or as a follow-up.

## Test evidence

- `just workflow-gates` → 19/19 self-test fixtures pass, both real workflows pass. Each fixture is a hole the gate has actually been asked to catch: unguarded root job, missing `ready_for_review`, `needs` + `always()`/`!failure()`/`success()`, `true || <guard>` tautology, `pull_request_target` with the wrong guard half (bare **and** parenthesised **and** parenthesised-plus-ANDed), push-only prefix widened with `||`, the `||` form ANDed without parens, `types: [ready_for_review]` alone, scalar `types:`.
- `just commit-subjects` → all 4 subjects pass; verified it now exits **128** on a stale base (it previously exited 0, reporting clean for a check that never ran) and exits 0 with a stderr note on an empty range.
- `actionlint` (via `docker run rhysd/actionlint`) → zero expression/syntax findings on every new `if:`, `types:` and `concurrency:` key. Only pre-existing shellcheck nits in `run:` blocks this PR does not touch.
- `python3 -m py_compile`, `just --list` → clean.
- `cargo clippy`/`fmt`/`test` deliberately **not** run: the diff touches zero Rust and zero TypeScript (`git diff --name-only` is 5 markdown files, 2 workflows, the justfile, and one new Python script).
- The draft-vs-ready behaviour was verified on this PR itself before marking it ready — see the comment below.

## Reviewer scope notes

- Three review rounds, 6 subagent spawns (one lost to an API 529), 26 findings — all verified before fixing. **Both round-3 criticals were in round-2's own fixes**, and F23 was specifically a duplicated code path routing around a check; it was fixed by collapsing the two paths into one table, not by adding a second guard.
- Round 3's fixes were **not** re-reviewed by a subagent — the spawn cap was reached. I verified each myself with a direct reproduction (both are quoted in `142b914`'s message). Treat that round with proportionally less confidence.
- No stakes-elevated path is touched: no privileged helper, secrets/relay tokens, gateway auth, proxy headers, daemon API, or SQLite migration.
- Docs checklist deliberately not triggered: this adds no config field, CLI flag, subcommand, or user-visible veld behaviour, so `README.md`, `docs/configuration.md`, `skills/`, both schemas, `docs/migrating-to-v3.md`, `website/index.html` and `llms-full.txt` are untouched. The website describes what veld does, not how this repo bills its runners.

## Follow-ups

- The unguarded sentinel job decision above.
- `justfile`'s conventional-commits regex is a second copy of `ci.yml`'s. Deliberate — extracting it from a YAML `run:` block is more fragile than two copies of a list that changes approximately never — and `ci.yml` is stated as the enforcing copy. Worth revisiting only if they ever disagree.

## Measured impact (not estimated)

Numbers from this repo, 2026-08-01 → 2026-08-05 (5 days):

| Metric | Value |
|---|---|
| Total Actions minutes consumed | 1,487 |
| Total job runs | 494 |
| Workflow runs | 56 (40 `pull_request`, 16 `push`) |
| CI runs on `pull_request` | 20, across 10 branches — **average 2 per branch** |
| CI runs beyond the first per branch | 10 |
| CI wall-clock per run | median 11 min, max 12 min |
| **Billable ms reported by the run-timing API** | **0, for every run, UBUNTU and MACOS alike** |

Two honest conclusions from this:

1. **Nothing here is billed.** `/actions/runs/<id>/timing` reports `billable: {UBUNTU: {total_ms: 0}, MACOS: {total_ms: 0}}` on every run sampled. The 1,487 minutes in Actions Usage Metrics are *consumption*, not *charges* — standard runners are free on public repos. The cost this PR reduces is runner time, macOS concurrency, and queue latency, not money. (It becomes money if the repo goes private or any job moves to a larger runner.)

2. **The saving is real but modest, and smaller than "enormous".** PRs in this repo average **2** CI runs, not 20 — so draft-gating removes on the order of a third of PR runs, not most of them. For `/ship`'s own flow it is close to break-even, exactly as the review's F14 finding argued: the review completes before the PR is opened, so there is barely a draft window to save.

**The bigger lever is what a run *contains*, not when it fires.** Every PR run executes ~10 jobs including a four-target release build matrix, Electron packaging on Linux *and* macOS, and two macOS end-to-end suites — 494 job runs in five days. Path-filtering those, or moving `release-build`/`desktop-package` to release time only, would cut far more than draft-gating does. Deliberately out of scope here: `ci.yml` has no path filters anywhere today and adding the first one is a policy decision, not a detail. Recommended as the follow-up worth doing.
