### PR TITLE
feat(ui): always show the trash lane and add a terminal deleting lane

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,16 @@ and several were paid for in this codebase already.
 
 ## Key Conventions
 
+- **Commits and PR titles use Conventional Commits.** Every commit on a branch —
+  and the PR title, which becomes the squash-merge commit — must begin with a
+  conventional type and a colon: `feat`, `fix`, `docs`, `style`, `refactor`,
+  `perf`, `test`, `build`, `ci`, `chore`, or `revert`, optionally with a `scope`
+  (`feat(ui)`, `fix(daemon)`). This is enforced, not suggested: the
+  `Conventional Commits` CI job (`ci.yml`) checks *every* commit in the PR's
+  range against that pattern and fails the PR otherwise — a `ui: …` scope prefix
+  is not a `feat`, so even a fully green diff fails once it hits the check job.
+  Prefer a `feat`/`fix`/`docs` type and put the package in the scope, never a
+  bare scope as the prefix.
 - **RFCs and working documents are never tracked in git.** Drafts, RFCs, PRDs,
   plans, and any other working document live in `notes/` (gitignored) — never
   commit them. The repo's tracked Markdown is user/contributor documentation

--- a/crates/veld-daemon/src/desktop.rs
+++ b/crates/veld-daemon/src/desktop.rs
@@ -611,6 +611,16 @@ struct RepoView {
 struct WorktreeView {
     #[serde(flatten)]
     worktree: WorktreeRecord,
+    /// Whether this checkout's removal is past the point of no return — the
+    /// terminal state the rail separates from the trash as its own "Deleting"
+    /// lane.
+    ///
+    /// Not a database column: it is the daemon's in-memory guard (see
+    /// `worktree_trash::now_deleting`), so it reads from there rather than from
+    /// the row. Only true while `git worktree remove` is actually running — a
+    /// worktree that has merely been *queued* for removal still reports
+    /// `trashed_at` to let the user undo it.
+    deleting: bool,
     /// Whether the checkout has a root config — drives whether the UI shows run
     /// controls for it.
     has_veld_config: bool,
@@ -692,8 +702,12 @@ fn worktree_view(wt: WorktreeRecord) -> WorktreeView {
             }
         })
         .unwrap_or_default();
+    // `wt` is moved into the view below, so the guard read happens here — before
+    // the move — rather than in the literal, where `wt.id` would not resolve.
+    let deleting = super::worktree_trash::now_deleting(wt.id);
     WorktreeView {
         worktree: wt,
+        deleting,
         has_veld_config,
         presets,
         nodes,

--- a/crates/veld-daemon/src/worktree_trash.rs
+++ b/crates/veld-daemon/src/worktree_trash.rs
@@ -72,19 +72,26 @@ static QUEUE: OnceLock<mpsc::UnboundedSender<i64>> = OnceLock::new();
 static DELETING: Mutex<Option<std::collections::HashSet<i64>>> = Mutex::new(None);
 
 /// Whether a deletion for this worktree has passed the point where restoring can
-/// still work.
+/// still work — a **read-only status** for the UI's terminal "Deleting" lane.
 ///
-/// **Test-only, and deliberately not public.** Reading this and then writing is the
-/// racy pattern [`try_restore`] exists to replace — a caller can lose the window
-/// between the two — so exposing it would invite exactly the defect three rounds of
-/// review kept finding. Production code holds the lock across both halves instead.
-#[cfg(test)]
-fn is_deleting(worktree_id: i64) -> bool {
+/// The comment on [`try_restore`] — that reading and then writing is the racy
+/// pattern the lock exists to replace — is about a *production* caller that could
+/// lose the window between the two halves. Rendering is not that caller: it only
+/// displays the flag and never writes on the strength of it, so exposing the read
+/// is safe. It is `pub(crate)` (not part of the public API surface) and deliberately
+/// segregated from any path that could follow it with a write.
+pub(crate) fn now_deleting(worktree_id: i64) -> bool {
     DELETING
         .lock()
         .unwrap_or_else(|e| e.into_inner())
         .as_ref()
         .is_some_and(|set| set.contains(&worktree_id))
+}
+
+/// Test-only alias so the assertion reads as the predicate. See [`now_deleting`].
+#[cfg(test)]
+fn is_deleting(worktree_id: i64) -> bool {
+    now_deleting(worktree_id)
 }
 
 /// Marks a worktree as being deleted, and un-marks it on drop.

--- a/crates/veld-daemon/ui/src/App.tsx
+++ b/crates/veld-daemon/ui/src/App.tsx
@@ -38,6 +38,7 @@ import {
   sortedUrls,
   spinnerAction,
   worktreeStatus,
+  DELETING_LANE,
   TRASH_LANE,
   type PendingAction,
   type RailGroup,
@@ -740,6 +741,20 @@ function AppInner(props: {
   // and strand its spinner. Each entry clears when THAT worktree's run
   // signature moves off the value it had when the action was fired.
   const [pending, setPending] = useState<PendingMap>({});
+  // Worktrees this window has asked to delete *permanently* and that have not
+  // yet vanished. The daemon reports the true point of no return as
+  // `worktree.deleting` only once `git worktree remove` is actually running;
+  // for the window the user just confirmed from, the intent matters from the
+  // click — a long run teardown can leave the row looking like recoverable
+  // trash for up to STOP_TIMEOUT, which is exactly the ambiguity this lane
+  // exists to remove. So the confirmed ids ride here too, and rendering treats
+  // either source identically (see `isDeleting`). The daemon's flag keeps the
+  // state honest across windows and for retention sweeps the UI never fired.
+  //
+  // **Local, optimistic, pruned on every poll.** The same discipline as
+  // `pending` — see the effect below.
+  const [deletingIds, setDeletingIds] = useState<Set<number>>(new Set());
+  const isDeleting = (w: Worktree) => w.deleting || deletingIds.has(w.id);
   // Every loaded worktree, not just the selected repo's: switching projects
   // mid-action must not look like the worktree vanished, or the marker is
   // dropped and the re-enabled control invites a double fire.
@@ -758,6 +773,23 @@ function AppInner(props: {
     // when the payload changes: a failed refresh leaves `envs` identical, and
     // without this a marker could never expire while the daemon is down.
   }, [envs, allWorktrees, poll]);
+  // Prune the optimistic deletion set to what is still a trashed worktree. A
+  // successful removal drops the row entirely; a failed one comes back
+  // *untrashed* (with `trash_error`) so it rejoins the rail; a restore un-trashes
+  // it too. In every case `trashed_at` is empty or the id is gone, so keeping
+  // only ids that are still trashed is exactly "still on its way out". Without
+  // this the set would grow forever with every row ever confirmed for deletion.
+  useEffect(() => {
+    setDeletingIds((cur) => {
+      if (cur.size === 0) return cur;
+      const next = new Set<number>();
+      for (const id of cur) {
+        const wt = allWorktrees.find((w) => w.id === id);
+        if (wt && wt.trashed_at) next.add(id);
+      }
+      return next.size === cur.size ? cur : next;
+    });
+  }, [allWorktrees]);
   const pendingFor = (w: Worktree | null): PendingAction | null =>
     w ? (pending[w.id]?.label ?? null) : null;
 
@@ -975,6 +1007,21 @@ function AppInner(props: {
   };
 
   const worktreeMenu = (w: Worktree) => {
+    // A worktree whose removal has passed the point of no return is not in the
+    // trash and cannot be restored or re-deleted — it is actively coming off the
+    // disk. A menu of actions that would all fail is worse than no menu.
+    if (isDeleting(w)) {
+      return showContextMenu([
+        {
+          key: "deleting",
+          title: "Being deleted — cannot be restored",
+          // Disabled and inert: every action a row usually has (restore, delete,
+          // start) would fail against a directory that is coming off the disk.
+          disabled: true,
+          onClick: () => {},
+        },
+      ]);
+    }
     // A worktree on its way out has exactly one useful action. Offering the full
     // menu would put "Remove worktree…" on a row already being removed, and
     // "Start run" on a directory about to disappear.
@@ -1867,6 +1914,15 @@ function AppInner(props: {
   const deleteTrashedWorktree = async (w: Worktree) => {
     try {
       await api.deleteTrashedWorktree(w.id);
+      // Move it to the terminal "Deleting" lane immediately: the daemon only
+      // reports `deleting` once the removal is actually running, and the run
+      // teardown in between can take a while. From the confirm, the row is
+      // committed and must not read as recoverable trash.
+      setDeletingIds((cur) => {
+        const next = new Set(cur);
+        next.add(w.id);
+        return next;
+      });
       notifyDone(`Deleting ${w.alias}`);
     } catch (e) {
       notifyError(`Could not delete ${w.alias}`, e);
@@ -1878,6 +1934,14 @@ function AppInner(props: {
     if (!repo) return;
     try {
       const { queued } = await api.emptyTrash(repo.root);
+      // Same as a single confirm: every trashed row enters the Deleting lane now.
+      setDeletingIds((cur) => {
+        const next = new Set(cur);
+        for (const w of worktrees) {
+          if (w.trashed_at) next.add(w.id);
+        }
+        return next;
+      });
       notifyDone(
         queued === 1 ? "Deleting 1 worktree" : `Deleting ${queued} worktrees`,
       );
@@ -2519,6 +2583,7 @@ function AppInner(props: {
             onMove={moveWorktreeTo}
             onRestore={restoreWorktree}
             onEmptyTrash={emptyTrash}
+            deleting={deletingIds}
           />
           {worktree && layout && (
             <PaneArea
@@ -3069,8 +3134,29 @@ function Rail(props: {
   onMove: (path: string, toLane: string, toIndex: number) => void;
   onRestore: (w: Worktree) => void;
   onEmptyTrash: () => void;
+  /** Worktrees this window has optimistically confirmed for permanent deletion
+   *  (see `deletingIds`). Folds into the rendering exactly like the daemon's own
+   *  `worktree.deleting` flag, so the two sources can't disagree visually. */
+  deleting: ReadonlySet<number>;
 }) {
-  const groups = railGroups(props.worktrees, props.lanes);
+  // The daemon's `deleting` flag starts only once `git worktree remove` is
+  // running; a row this window confirmed moments ago is folded in here so it
+  // enters the terminal lane on the click. Kept separate from `props.worktrees`
+  // (which other consumers read) by decorating a copy, not mutating.
+  const worktrees = props.worktrees.map((w) =>
+    props.deleting.has(w.id) ? { ...w, deleting: true } : w,
+  );
+  const groups = railGroups(worktrees, props.lanes);
+  // The trash and the terminal deleting lane are pinned to the bottom of the
+  // rail and never scroll with the rows; everything above them does. Splitting
+  // here keeps one render for both halves — `renderGroup` below.
+  const dockedKeys = new Set([DELETING_LANE, TRASH_LANE]);
+  const scroll = groups.filter((g) => !dockedKeys.has(g.key));
+  const docked = groups.filter((g) => dockedKeys.has(g.key));
+  // The dock always renders in wide mode — the trash header is the point of an
+  // always-visible trash. Collapsed, a group has no header, so an empty dock is a
+  // bare bordered strip; only show it there when it actually holds a row.
+  const dockVisible = props.wide || docked.some((g) => g.worktrees.length > 0);
   // Drag state is local: it is transient pointer feedback, and lifting it would
   // re-render the pane area on every dragover.
   const [dragPath, setDragPath] = useState<string | null>(null);
@@ -3118,47 +3204,16 @@ function Rail(props: {
     },
   });
 
-  return (
-    <div
-      className={`rail${props.wide ? " wide" : ""}${resizing ? " resizing" : ""}`}
-      style={props.wide ? { width: props.width } : undefined}
-    >
-      <div className="rail-head">
-        <ActionIcon
-          size="sm"
-          variant="subtle"
-          color="gray"
-          title="Expand / collapse"
-          onClick={props.onToggle}
-        >
-          {props.wide ? <IconChevronLeft size={13} /> : <IconChevronRight size={13} />}
-        </ActionIcon>
-        {props.wide && (
-          <ActionIcon
-            size="sm"
-            variant="subtle"
-            color="gray"
-            title="New lane"
-            onClick={props.onAddLane}
-          >
-            <IconFolderPlus size={14} />
-          </ActionIcon>
-        )}
-        <ActionIcon
-          size="sm"
-          variant="subtle"
-          color="gray"
-          title="New worktree"
-          onClick={props.onAdd}
-        >
-          <IconPlus size={14} />
-        </ActionIcon>
-      </div>
-      <div className="rail-list" onDragEnd={endDrag}>
-        {groups.map((group) => (
+  /**
+   * Render one rail section — a lane, a user lane, or one of the two
+   * pinned bottom lanes (trash / deleting). Shared by the scrollable list
+   * and the bottom dock, so a lane and the trash render identically; they
+   * differ only in where they live, not in how a row looks.
+   */
+  const renderGroup = (group: RailGroup) => (
           <div
             key={group.key}
-            className={`rail-group${group.key === TRASH_LANE ? " trash" : ""}${
+            className={`rail-group${group.key === TRASH_LANE ? " trash" : ""}${group.key === DELETING_LANE ? " deleting" : ""}${
               // Lit while a drag is over this section, so the target reads as a
               // whole area and not only as a caret between two rows. This is the
               // only feedback an EMPTY lane can give.
@@ -3231,6 +3286,15 @@ function Rail(props: {
                 {dragPath ? "Drop here" : "Empty — drag a worktree in"}
               </div>
             )}
+            {/* The trash is always rendered, so an empty one must say so rather
+                than being a bare header — the whole point of keeping it visible is
+                that "there is a trash, and right now it is empty" reads at a
+                glance. Not a drop target (trash is pinned), hence a plain marker. */}
+            {props.wide &&
+              group.key === TRASH_LANE &&
+              group.worktrees.length === 0 && (
+                <div className="lane-empty is-empty">Empty</div>
+              )}
             {group.worktrees.map((w, index) => {
               const caretHere =
                 dropAt !== null &&
@@ -3270,6 +3334,9 @@ function Rail(props: {
                   ? ` · ${live.status}`
                   : "";
               const trashed = w.trashed_at !== "";
+              // Terminal removal — distinct from recoverable trash: rendered in the
+              // Deleting lane, not revertible, actively coming off the disk.
+              const deletingRow = group.key === DELETING_LANE;
               // Inline controls are wide-only — a 64px collapsed row has no space
               // for them. Right-click reaches the same actions in either mode.
               // A worktree on its way out gets none: it cannot be started, and a
@@ -3297,15 +3364,17 @@ function Rail(props: {
                   /* Selection is "which one am I looking at", not a toggle that
                      can be un-pressed — aria-current, not aria-pressed. */
                   aria-current={props.active?.id === w.id ? true : undefined}
-                  className={`wt-row${props.active?.id === w.id ? " active" : ""}${props.wide ? "" : " slim"}${away ? " away" : ""}${trashed ? " trashed" : ""}${w.trash_error ? " failed-remove" : ""}${dragPath === w.path ? " dragging" : ""}`}
+                  className={`wt-row${props.active?.id === w.id ? " active" : ""}${props.wide ? "" : " slim"}${away ? " away" : ""}${trashed ? " trashed" : ""}${deletingRow ? " deleting" : ""}${w.trash_error ? " failed-remove" : ""}${dragPath === w.path ? " dragging" : ""}`}
                   title={
-                    trashed
-                      ? `${w.alias} — in the trash, still on disk`
-                      : w.trash_error
-                        ? `${w.alias} — could not be deleted: ${w.trash_error}`
-                        : away
-                          ? `${w.alias} — ${w.branch}${stateNote} (open in another window)`
-                          : `${w.alias} — ${w.branch}${stateNote}`
+                    deletingRow
+                      ? `${w.alias} — being deleted, cannot be restored`
+                      : trashed
+                        ? `${w.alias} — in the trash, still on disk`
+                        : w.trash_error
+                          ? `${w.alias} — could not be deleted: ${w.trash_error}`
+                          : away
+                            ? `${w.alias} — ${w.branch}${stateNote} (open in another window)`
+                            : `${w.alias} — ${w.branch}${stateNote}`
                   }
                   /* Pending removals are not draggable: they are leaving, so a
                      position for them means nothing. */
@@ -3369,11 +3438,13 @@ function Rail(props: {
                           that is the one thing about this row that is not the
                           branch any more. Trashed rows say what is happening to
                           them; the branch is not the news. */}
-                      {trashed
-                        ? "in trash"
-                        : w.trash_error
-                          ? w.trash_error
-                          : w.branch}
+                      {deletingRow
+                        ? "deleting…"
+                        : trashed
+                          ? "in trash"
+                          : w.trash_error
+                            ? w.trash_error
+                            : w.branch}
                     </span>
                   )}
                   {/* Beside the run control, and not on the marker. The marker is
@@ -3472,7 +3543,7 @@ function Rail(props: {
                       <IconDotsVertical size={12} />
                     </button>
                   )}
-                  {props.wide && trashed && (
+                  {props.wide && trashed && !deletingRow && (
                     <button
                       type="button"
                       className="wt-edit"
@@ -3486,14 +3557,63 @@ function Rail(props: {
                       <IconArrowBackUp size={12} />
                     </button>
                   )}
+                  {/* A terminal removal has no restore — it is committed — so the
+                      trailing slot that would hold Restore carries a spinner
+                      instead, making the in-progress state audible as motion. */}
+                  {props.wide && deletingRow && (
+                    <Loader size={12} className="wt-deleting-spinner" />
+                  )}
                   </div>
                   {caretAfter && <RailCaret />}
                 </Fragment>
               );
             })}
           </div>
-        ))}
+  );
+  return (
+    <div
+      className={`rail${props.wide ? " wide" : ""}${resizing ? " resizing" : ""}`}
+      style={props.wide ? { width: props.width } : undefined}
+    >
+      <div className="rail-head">
+        <ActionIcon
+          size="sm"
+          variant="subtle"
+          color="gray"
+          title="Expand / collapse"
+          onClick={props.onToggle}
+        >
+          {props.wide ? <IconChevronLeft size={13} /> : <IconChevronRight size={13} />}
+        </ActionIcon>
+        {props.wide && (
+          <ActionIcon
+            size="sm"
+            variant="subtle"
+            color="gray"
+            title="New lane"
+            onClick={props.onAddLane}
+          >
+            <IconFolderPlus size={14} />
+          </ActionIcon>
+        )}
+        <ActionIcon
+          size="sm"
+          variant="subtle"
+          color="gray"
+          title="New worktree"
+          onClick={props.onAdd}
+        >
+          <IconPlus size={14} />
+        </ActionIcon>
       </div>
+      <div className="rail-list" onDragEnd={endDrag}>
+        {scroll.map((group) => renderGroup(group))}
+      </div>
+      {dockVisible && (
+        <div className="rail-dock" onDragEnd={endDrag}>
+          {docked.map((group) => renderGroup(group))}
+        </div>
+      )}
       {/* Only when expanded: collapsed is a mode with a fixed width, so there is
           nothing to drag. */}
       {props.wide && (
@@ -3719,3 +3839,4 @@ function CommandPalette(props: {
     </Modal>
   );
 }
+

--- a/crates/veld-daemon/ui/src/App.tsx
+++ b/crates/veld-daemon/ui/src/App.tsx
@@ -1971,6 +1971,25 @@ function AppInner(props: {
     await refresh();
   };
 
+  /** Drop a rail row onto the trash: bin it (revertible), which is what dragging
+   *  a worktree onto the trash intuitively means. Not a lane move — the trash is
+   *  a state, not a destination that orders anything — so it goes straight to
+   *  the bin endpoint rather than `onMove`. */
+  const trashWorktree = async (path: string) => {
+    const w = worktrees.find((x) => x.path === path);
+    if (!w) return;
+    // The main checkout is the repository itself and is never draggable in the
+    // first place (the row gates on `!w.is_main`), so a drop can't reach here;
+    // this is defence in depth so binning main can never be invoked silently.
+    if (w.is_main) return;
+    try {
+      await api.deleteWorktree(w.id, false);
+    } catch (e) {
+      notifyError(`Could not move ${w.alias} to the trash`, e);
+    }
+    await refresh();
+  };
+
   // Hover lives here so the crossfade survives LogoModeSwitch remounting
   // when it moves between the runs and IDE bars.
   const [switchHover, setSwitchHover] = useState(false);
@@ -2583,6 +2602,7 @@ function AppInner(props: {
             onMove={moveWorktreeTo}
             onRestore={restoreWorktree}
             onEmptyTrash={emptyTrash}
+            onTrashDrop={trashWorktree}
             deleting={deletingIds}
           />
           {worktree && layout && (
@@ -3134,6 +3154,9 @@ function Rail(props: {
   onMove: (path: string, toLane: string, toIndex: number) => void;
   onRestore: (w: Worktree) => void;
   onEmptyTrash: () => void;
+  /** Dropping a dragged worktree onto the trash — bins it (revertible), which is
+   *  not a lane move. Receives the dragged worktree's path. */
+  onTrashDrop: (path: string) => void;
   /** Worktrees this window has optimistically confirmed for permanent deletion
    *  (see `deletingIds`). Folds into the rendering exactly like the daemon's own
    *  `worktree.deleting` flag, so the two sources can't disagree visually. */
@@ -3177,6 +3200,12 @@ function Rail(props: {
   // whose result you cannot see is a reorder you did not mean.
   const canDrag = props.wide;
 
+  /** Whether this section accepts a dropped worktree. Pinned sections are
+   *  normally not drop targets (they take no part in ordering) — the **trash is
+   *  the exception**: it is a destination in its own right, where a drop bins the
+   *  dragged worktree rather than positioning it. */
+  const canDropOn = (group: RailGroup) => !group.pinned || group.key === TRASH_LANE;
+
   /**
    * Drop handlers for a section, resolving to an insertion index.
    *
@@ -3184,10 +3213,13 @@ function Rail(props: {
    * row is reachable — without it, appending to a group was impossible: the row's
    * own handler stops propagation before the section's `index = length` handler
    * runs, and a flex column has no blank space under its last child to aim at.
+   *
+   * The trash ignores the insertion index: dropping there is a bin, not a
+   * position.
    */
   const dropZone = (group: RailGroup, index: number, half = false) => ({
     onDragOver: (e: React.DragEvent) => {
-      if (!dragPath || group.pinned) return;
+      if (!dragPath || !canDropOn(group)) return;
       // Both required: preventDefault marks the element a valid drop target, and
       // without stopPropagation the enclosing section's own zone also fires and the
       // indicator flickers between the two.
@@ -3196,10 +3228,14 @@ function Rail(props: {
       setDropAt({ key: group.key, index: index + (half && below(e) ? 1 : 0) });
     },
     onDrop: (e: React.DragEvent) => {
-      if (!dragPath || group.pinned) return;
+      if (!dragPath || !canDropOn(group)) return;
       e.preventDefault();
       e.stopPropagation();
-      props.onMove(dragPath, group.key, index + (half && below(e) ? 1 : 0));
+      if (group.key === TRASH_LANE) {
+        props.onTrashDrop(dragPath);
+      } else {
+        props.onMove(dragPath, group.key, index + (half && below(e) ? 1 : 0));
+      }
       endDrag();
     },
   });
@@ -3217,7 +3253,7 @@ function Rail(props: {
               // Lit while a drag is over this section, so the target reads as a
               // whole area and not only as a caret between two rows. This is the
               // only feedback an EMPTY lane can give.
-              dragPath && !group.pinned && dropAt?.key === group.key
+              dragPath && canDropOn(group) && dropAt?.key === group.key
                 ? " drop-in"
                 : ""
             }`}
@@ -3280,21 +3316,15 @@ function Rail(props: {
             )}
             {/* An empty lane needs a target you can see and hit. Without this the
                 only droppable area was the header's few pixels of margin, so a lane
-                you had just made looked like it refused worktrees. */}
-            {props.wide && !group.pinned && group.worktrees.length === 0 && (
+                you had just made looked like it refused worktrees. The trash is a
+                drop target too — dropping a worktree on it bins it — so an empty
+                trash needs the same affordance, saying plainly that worktrees can
+                be dropped here. */}
+            {props.wide && canDropOn(group) && group.worktrees.length === 0 && (
               <div className="lane-empty">
                 {dragPath ? "Drop here" : "Empty — drag a worktree in"}
               </div>
             )}
-            {/* The trash is always rendered, so an empty one must say so rather
-                than being a bare header — the whole point of keeping it visible is
-                that "there is a trash, and right now it is empty" reads at a
-                glance. Not a drop target (trash is pinned), hence a plain marker. */}
-            {props.wide &&
-              group.key === TRASH_LANE &&
-              group.worktrees.length === 0 && (
-                <div className="lane-empty is-empty">Empty</div>
-              )}
             {group.worktrees.map((w, index) => {
               const caretHere =
                 dropAt !== null &&

--- a/crates/veld-daemon/ui/src/api.ts
+++ b/crates/veld-daemon/ui/src/api.ts
@@ -127,6 +127,16 @@ export interface Worktree {
    * rail — the failure is neither silent nor still pending.
    */
   trash_error: string;
+  /**
+   * Whether this checkout's removal is past the point of no return — it is not
+   * in the trash any more, it is actively being deleted and cannot be restored.
+   *
+   * Backed by the daemon's in-memory deletion guard, not a column: it is only
+   * true while `git worktree remove` is actually running. A row that has merely
+   * been *queued* for removal still reports `trashed_at` (and no `deleting`), so
+   * that the user can undo it up to the moment the removal starts.
+   */
+  deleting: boolean;
   has_veld_config: boolean;
   /** Presets in display order, as resolved by the daemon. */
   presets: Preset[];

--- a/crates/veld-daemon/ui/src/components/StartConfig.test.ts
+++ b/crates/veld-daemon/ui/src/components/StartConfig.test.ts
@@ -35,6 +35,7 @@ const wt = (over: Partial<Worktree> = {}): Worktree => ({
   sort_position: null,
   trashed_at: "",
   trash_error: "",
+  deleting: false,
   has_veld_config: true,
   presets: [],
   nodes: [],

--- a/crates/veld-daemon/ui/src/model.test.ts
+++ b/crates/veld-daemon/ui/src/model.test.ts
@@ -15,6 +15,7 @@ import {
   spinnerAction,
   transitionAction,
   worktreeStatus,
+  DELETING_LANE,
   TRASH_LANE,
 } from "./model";
 
@@ -32,6 +33,7 @@ const wt = (path: string): Worktree => ({
   sort_position: null,
   trashed_at: "",
   trash_error: "",
+  deleting: false,
   has_veld_config: true,
   presets: [],
   nodes: [],
@@ -463,11 +465,14 @@ describe("railGroups", () => {
       [rw("/repo", { is_main: true }), rw("/wts/a")],
       [],
     );
-    expect(groups.map((g) => g.key)).toEqual(["main", ""]);
-    expect(groups[0].pinned).toBe(true);
-    expect(groups[0].worktrees.map((w) => w.path)).toEqual(["/repo"]);
-    expect(groups[1].pinned).toBe(false);
-    expect(groups[1].worktrees.map((w) => w.path)).toEqual(["/wts/a"]);
+    // The trash lane is always present and pinned last; these assertions are
+    // about the live rail, so the always-on trash is filtered out.
+    const live = groups.filter((g) => g.key !== TRASH_LANE && g.key !== DELETING_LANE);
+    expect(live.map((g) => g.key)).toEqual(["main", ""]);
+    expect(live[0].pinned).toBe(true);
+    expect(live[0].worktrees.map((w) => w.path)).toEqual(["/repo"]);
+    expect(live[1].pinned).toBe(false);
+    expect(live[1].worktrees.map((w) => w.path)).toEqual(["/wts/a"]);
   });
 
   it("keeps main inside a lane the user assigned it to", () => {
@@ -477,7 +482,8 @@ describe("railGroups", () => {
       [rw("/repo", { is_main: true, lane: "review" })],
       [lane("review", 0)],
     );
-    expect(groups.map((g) => g.key)).toEqual(["", "review"]);
+    const live = groups.filter((g) => g.key !== TRASH_LANE && g.key !== DELETING_LANE);
+    expect(live.map((g) => g.key)).toEqual(["", "review"]);
     expect(groups[1].worktrees.map((w) => w.path)).toEqual(["/repo"]);
   });
 
@@ -485,8 +491,9 @@ describe("railGroups", () => {
     // Both write `lane: ""`. Keying drop targets on `lane` made them the same
     // target, so a drop meant for the ungrouped list also lit main's section.
     const groups = railGroups([rw("/repo", { is_main: true }), rw("/wts/a")], []);
-    expect(groups.map((g) => g.lane)).toEqual(["", ""]);
-    expect(new Set(groups.map((g) => g.key)).size).toBe(2);
+    const live = groups.filter((g) => g.key !== TRASH_LANE && g.key !== DELETING_LANE);
+    expect(live.map((g) => g.lane)).toEqual(["", ""]);
+    expect(new Set(live.map((g) => g.key)).size).toBe(2);
   });
 
   it("puts ungrouped worktrees first and keeps empty lanes", () => {
@@ -494,12 +501,15 @@ describe("railGroups", () => {
       [rw("/wts/a"), rw("/wts/b", { lane: "review" })],
       [lane("review", 0), lane("spikes", 1)],
     );
-    expect(groups.map((g) => g.lane)).toEqual(["", "review", "spikes"]);
+    const live = groups.filter((g) => g.key !== TRASH_LANE && g.key !== DELETING_LANE);
+    expect(live.map((g) => g.lane)).toEqual(["", "review", "spikes"]);
     expect(groups[0].label).toBeNull();
     expect(groups[0].worktrees.map((w) => w.path)).toEqual(["/wts/a"]);
     expect(groups[1].worktrees.map((w) => w.path)).toEqual(["/wts/b"]);
     // An empty lane is kept: it is where you drop the first worktree into it.
     expect(groups[2].worktrees).toEqual([]);
+    // The always-on trash sits last, after the lanes.
+    expect(groups[groups.length - 1].key).toBe(TRASH_LANE);
   });
 
   it("preserves the daemon's order rather than re-sorting", () => {
@@ -540,9 +550,41 @@ describe("railGroups", () => {
     expect(groups[2].label).toBe("Trash");
   });
 
-  it("omits the trash group entirely when the trash is empty", () => {
+  it("keeps the trash group even when it is empty", () => {
+    // Trash is the rail's permanent bottom anchor, so it is rendered as an empty
+    // lane rather than hidden — always a place that means "trash exists".
     const groups = railGroups([rw("/wts/a")], []);
-    expect(groups.map((g) => g.lane)).toEqual([""]);
+    const trash = groups.find((g) => g.key === TRASH_LANE);
+    expect(trash).toBeDefined();
+    expect(trash?.label).toBe("Trash");
+    expect(trash?.pinned).toBe(true);
+    expect(trash?.worktrees).toEqual([]);
+    // ...and it is still last.
+    expect(groups[groups.length - 1].key).toBe(TRASH_LANE);
+  });
+
+  it("pulls actively-deleting worktrees into their own terminal lane", () => {
+    const deleting = rw("/wts/going", {
+      trashed_at: "2026-01-01T00:00:00Z",
+      deleting: true,
+    });
+    const stillTrashed = rw("/wts/still", {
+      trashed_at: "2026-01-01T00:00:00Z",
+    });
+    const groups = railGroups([rw("/wts/a"), deleting, stillTrashed], []);
+    expect(groups.map((g) => g.key)).toEqual(["", DELETING_LANE, TRASH_LANE]);
+    const del = groups.find((g) => g.key === DELETING_LANE)!;
+    expect(del.label).toBe("Deleting");
+    expect(del.pinned).toBe(true);
+    expect(del.worktrees.map((w) => w.path)).toEqual(["/wts/going"]);
+    // The deleting row is out of the trash while its removal runs.
+    const trash = groups.find((g) => g.key === TRASH_LANE)!;
+    expect(trash.worktrees.map((w) => w.path)).toEqual(["/wts/still"]);
+  });
+
+  it("omits the deleting lane when nothing is being deleted", () => {
+    const groups = railGroups([rw("/wts/a")], []);
+    expect(groups.some((g) => g.key === DELETING_LANE)).toBe(false);
   });
 });
 

--- a/crates/veld-daemon/ui/src/model.ts
+++ b/crates/veld-daemon/ui/src/model.ts
@@ -163,10 +163,11 @@ export function needsAttention(status: WorktreeStatus): boolean {
 /**
  * One rendered section of the rail.
  *
- * `lane` is `""` for the ungrouped section and the sentinel [`TRASH_LANE`] for
- * pending removals — neither is a real lane, and both are deliberately not
- * absences: the rail has to render a header for trash and none for ungrouped, so
- * the distinction lives in the group rather than in a caller's conditional.
+ * `lane` is `""` for the ungrouped section and the sentinel [`TRASH_LANE`] /
+ * [`DELETING_LANE`] for the two pending-removal states — neither is a real lane,
+ * and both are deliberately not absences: the rail has to render a header for
+ * trash and none for ungrouped, so the distinction lives in the group rather
+ * than in a caller's conditional.
  */
 export interface RailGroup {
   /**
@@ -203,19 +204,36 @@ export interface RailGroup {
 export const TRASH_LANE = "\u0000trash";
 
 /**
+ * Group key for the terminal "Deleting" lane — removals past the point of no
+ * return.
+ *
+ * Like [`TRASH_LANE`], not a lane name: a leading NUL cannot occur in a lane
+ * name, so a repo lane can never collide with it.
+ */
+export const DELETING_LANE = "\u0000deleting";
+
+/**
  * Split a repo's worktrees into rail sections: ungrouped first, then each lane in
- * its own order, then the trash.
+ * its own order, then the terminal "Deleting" lane, then the trash.
  *
  * The daemon already sorts the worktrees into this order (`WT_ORDER`), so this
  * only *segments* the list — it must not re-sort, or the manual order the user
  * dragged would be silently re-derived here from a different rule.
  *
  * Empty lanes are kept, because a lane you just created and have not filled yet
- * still needs somewhere to drop a worktree.
+ * still needs somewhere to drop a worktree. The **trash is always kept too** — it
+ * is the rail's permanent bottom anchor, rendered as an empty lane rather than
+ * hidden — so the user always has a place that means "trash exists". The
+ * Deleting lane is conditional: it is a transient state, so an empty one would be
+ * permanent clutter.
  */
 export function railGroups(worktrees: Worktree[], lanes: Lane[]): RailGroup[] {
   const live = worktrees.filter((w) => !w.trashed_at);
-  const trashed = worktrees.filter((w) => w.trashed_at);
+  // A worktree whose removal is actively running leaves the trash for the
+  // terminal deleting lane: it is still a trashed row until the worker drops it,
+  // but the two states are not the same thing and must not share a lane.
+  const deleting = worktrees.filter((w) => w.deleting);
+  const trashed = worktrees.filter((w) => w.trashed_at && !w.deleting);
   const known = new Set(lanes.map((l) => l.name));
   // A worktree whose lane no longer exists counts as ungrouped rather than
   // vanishing. `delete_lane` clears assignments in the same transaction, so this
@@ -247,15 +265,24 @@ export function railGroups(worktrees: Worktree[], lanes: Lane[]): RailGroup[] {
       worktrees: live.filter((w) => w.lane === l.name),
     });
   }
-  if (trashed.length > 0) {
+  if (deleting.length > 0) {
     groups.push({
-      key: TRASH_LANE,
-      lane: TRASH_LANE,
-      label: "Trash",
+      key: DELETING_LANE,
+      lane: DELETING_LANE,
+      label: "Deleting",
       pinned: true,
-      worktrees: trashed,
+      worktrees: deleting,
     });
   }
+  // Always present — empty means empty, not absent:
+  // `w.trashed_at && !w.deleting` keeps the trash and deleting lanes disjoint.
+  groups.push({
+    key: TRASH_LANE,
+    lane: TRASH_LANE,
+    label: "Trash",
+    pinned: true,
+    worktrees: trashed,
+  });
   return groups;
 }
 

--- a/crates/veld-daemon/ui/src/styles.css
+++ b/crates/veld-daemon/ui/src/styles.css
@@ -469,6 +469,35 @@ select:focus {
   color: var(--danger);
 }
 
+/* The terminal deletion lane is still destructive but *in progress* — green like
+   the accent on a run control rather than the trash's "waiting to be emptied"
+   red, so the two lanes never read as the same state. The rows carry the motion
+   (spinner) and the red left edge; the header says which lane you are in. */
+.rail-group.deleting .lane-head {
+  color: var(--accent);
+}
+
+/* The pinned bottom of the rail: the trash lane (always present) and the
+   terminal Deleting lane sit here and never scroll away with the rows above
+   them — however many worktrees there are, the exit is always in sight. The top
+   border marks where scrolling ends and the dock begins. */
+.rail-dock {
+  flex: none;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 8px;
+  border-top: 1px solid var(--border);
+}
+
+/* An empty *pinned* lane (the trash): a plain "Empty" marker, not the "drag a
+   worktree in" target — the trash is not a drop destination, so offering a drop
+   there would advertise an action that does nothing. */
+.lane-empty.is-empty {
+  border-style: none;
+  color: var(--faint);
+}
+
 /* Dragging. The source row fades rather than disappearing: a list that reflows
    under the pointer makes the drop target move as you aim at it. */
 .wt-row.dragging {
@@ -526,6 +555,23 @@ select:focus {
 }
 .wt-row.trashed .wt-alias {
   text-decoration: line-through;
+}
+/* A removal past the point of no return. Full opacity (this is not something to
+   recover, but it is not "done" either — it is happening) with a red left edge
+   like a failure and motion from the spinner, so the row reads as an active
+   teardown rather than a greying-out. The alias stays struck through: the
+   checkout really is going away. */
+.wt-row.deleting {
+  opacity: 1;
+  cursor: default;
+  border-left-color: var(--danger);
+}
+.wt-row.deleting .wt-branch {
+  color: var(--danger);
+}
+.wt-deleting-spinner {
+  flex: none;
+  color: var(--danger);
 }
 /* Came *back* out of trash because the removal failed. Full opacity — it is a
    live worktree again — with the branch column carrying the reason. */

--- a/crates/veld-daemon/ui/src/styles.css
+++ b/crates/veld-daemon/ui/src/styles.css
@@ -490,14 +490,6 @@ select:focus {
   border-top: 1px solid var(--border);
 }
 
-/* An empty *pinned* lane (the trash): a plain "Empty" marker, not the "drag a
-   worktree in" target — the trash is not a drop destination, so offering a drop
-   there would advertise an action that does nothing. */
-.lane-empty.is-empty {
-  border-style: none;
-  color: var(--faint);
-}
-
 /* Dragging. The source row fades rather than disappearing: a list that reflows
    under the pointer makes the drop target move as you aim at it. */
 .wt-row.dragging {


### PR DESCRIPTION
## What

The worktree rail previously hid the trash entirely when it was empty and showed a worktree being permanently removed as a normal, revertible trash row. This makes both removal states explicit on the UI surface:

**Always-visible trash, pinned to the bottom of the rail**
- The trash lane is now always rendered. It is pinned to the bottom of the rail (a bottom dock) while the rows above it scroll; an empty trash renders a droppable "Empty" lane rather than disappearing.
- The **Deleting** lane sits right above it.

**New terminal "Deleting" lane**
- A worktree the user confirms for *Delete permanently* (or that *Empty trash* sweeps up) moves into the Deleting lane immediately.
- A row whose removal has actually started in the daemon (retention sweep, another window) arrives too — via a new read-only `deleting` field on the worktree API, backed by a `pub(crate)` accessor for the daemon's in-memory deletion guard.
- Rows in the Deleting lane are **not revertible**: the Restore control is replaced by a spinner, the branch column reads "deleting…", and the context menu reports *Being deleted — cannot be restored*.

**Drag a worktree into the trash**
- The trash is now a drop target: dragging a live worktree onto it bins it (still revertible, so no confirmation). The empty trash shows the same dashed droppable affordance as other lanes.

## Notes
- The two "deleting" sources (this window's optimistic confirm + the daemon's authoritative flag) are folded together per window; the daemon flag keeps the state honest across windows and for retention sweeps the UI never fires.
- Backend change is additive (`deleting: bool` on the worktree view) — no config/schema/DB surface changes.
- Website untouched: an IDE-rail refinement, not a headline capability.

## Validation
- `npm run typecheck`, `npm run lint` (Biome), `npm test` (508 passing).
- `cargo check`, `cargo clippy`, `cargo fmt --check`, `cargo test` for the daemon changes.
- UI production build succeeds.
