### PR TITLE
fix: order runs by time across projects and stabilise the logs toolbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4462,7 +4462,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "veld"
-version = "16.3.0"
+version = "16.4.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4482,7 +4482,7 @@ dependencies = [
 
 [[package]]
 name = "veld-core"
-version = "16.3.0"
+version = "16.4.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -4506,7 +4506,7 @@ dependencies = [
 
 [[package]]
 name = "veld-daemon"
-version = "16.3.0"
+version = "16.4.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4535,7 +4535,7 @@ dependencies = [
 
 [[package]]
 name = "veld-gateway"
-version = "16.3.0"
+version = "16.4.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4566,7 +4566,7 @@ dependencies = [
 
 [[package]]
 name = "veld-helper"
-version = "16.3.0"
+version = "16.4.0"
 dependencies = [
  "anyhow",
  "nix 0.29.0",
@@ -4582,7 +4582,7 @@ dependencies = [
 
 [[package]]
 name = "veld-share"
-version = "16.3.0"
+version = "16.4.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/crates/veld-daemon/assets/management-ui.html
+++ b/crates/veld-daemon/assets/management-ui.html
@@ -160,7 +160,7 @@ header{position:relative}
 .svc-empty{color:var(--dim);font-size:12px;padding:8px 0}
 
 /* log tab */
-.log-bar{display:flex;align-items:center;gap:8px;padding:0 0 8px;font-size:11px;color:var(--text2)}
+.log-bar{display:flex;flex-wrap:wrap;align-items:center;gap:8px;padding:0 0 8px;font-size:11px;color:var(--text2)}
 .log-bar select{background:var(--surface2);border:1px solid var(--border);color:var(--text);font-size:11px;padding:2px 8px;border-radius:4px;font-family:inherit}
 .log-bar select:focus{outline:none;border-color:var(--accent)}
 .log-search{background:var(--surface2);border:1px solid var(--border);color:var(--text);font-size:11px;padding:3px 8px;border-radius:4px;font-family:inherit;width:160px;transition:border-color .15s}
@@ -268,6 +268,22 @@ const runState={},nodeColors={};
 let colorIdx=0;
 function nc(n){if(!(n in nodeColors))nodeColors[n]='node-c'+(colorIdx++%8);return nodeColors[n];}
 function rk(projectRoot,run){return projectRoot+'::'+run;}
+/* Order the flat run card list by recency: live runs newest-started first,
+   ended runs last-stopped first, across every project — the same rule the
+   new IDE and the React runs view use. Deterministic to the last tie so a
+   6s/focus poll never reshuffles the list (the registry is a HashMap, and
+   two worktrees of one repo share the project name).
+   `desc` sorts newest first via cmpStr(b,a). */
+function cmpStr(a,b){return a<b?-1:a>b?1:0;}
+function compareRuns(a,b){
+  if(a.live!==b.live)return a.live?-1:1;                    // active group first
+  var ka=a.live?a.created_at:(a.ended_at||''),
+      kb=b.live?b.created_at:(b.ended_at||'');
+  var byTime=cmpStr(kb,ka); if(byTime)return byTime;        // latest first
+  var byStart=cmpStr(b.created_at,a.created_at); if(byStart)return byStart;
+  var byName=cmpStr(a.name,b.name); if(byName)return byName;
+  return cmpStr(a.run_id,b.run_id);
+}
 // The project half of a run address (`RunScope` in management.rs): a run
 // name alone resolves ambiguously when two projects run the same name.
 function scopeOf(card){return 'project_root='+encodeURIComponent(card.dataset.path);}
@@ -357,16 +373,16 @@ function render(data){
   for(const k of Object.keys(runState)){const s=runState[k];if(s.panelEl&&s.panelEl.parentNode)s.panelEl.parentNode.removeChild(s.panelEl);}
   let h='';
   const shownKeys=new Set();
+  // Flat card list across every project, ordered by recency (see compareRuns).
+  const cards=[];
   for(const proj of data.projects){
-    const runs=proj.runs.slice()
-      .filter(r=>view==='active'?r.live:!r.live)
-      .sort((a,b)=>{
-        if(a.status==='running'&&b.status!=='running')return -1;
-        if(b.status==='running'&&a.status!=='running')return 1;
-        return a.name.localeCompare(b.name);
-      });
-    for(const run of runs){
-      shownKeys.add(rk(proj.project_root,run.name));
+    for(const run of proj.runs){
+      if(view==='active'?run.live:!run.live)cards.push({proj:proj,run:run});
+    }
+  }
+  cards.sort((x,y)=>compareRuns(x.run,y.run));
+  for(const {proj,run} of cards){
+    shownKeys.add(rk(proj.project_root,run.name));
       const key=rk(proj.project_root,run.name);
       const st=runState[key]||{tab:'services'};
 
@@ -514,7 +530,6 @@ function render(data){
       h+='<div class="tab-panel'+(st.tab==='logs'?' active':'')+'" data-panel="logs" data-loghost="'+esc(key)+'"></div>';
       h+='</div>';
     }
-  }
   content.innerHTML=h;
   // Run history per card, for the logs run picker (kept out of the DOM
   // string — the picker lives in the persistent log panel element).

--- a/crates/veld-daemon/src/management.rs
+++ b/crates/veld-daemon/src/management.rs
@@ -129,6 +129,10 @@ struct RunInfo {
     outcome: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     ended_at: Option<String>,
+    /// When this environment's latest run started (`created_at`), RFC 3339.
+    /// The client sorts the Active tab by start time, so it is part of the
+    /// wire payload (not just an ordering key).
+    created_at: String,
     urls: HashMap<String, String>,
     nodes: Vec<NodeInfo>,
     /// What the latest run was started from — a preset name plus the expansion
@@ -328,6 +332,9 @@ async fn list_environments() -> Result<Json<EnvironmentList>, StatusCode> {
                             .unwrap_or_else(|| r.run_id.to_string()[..8].to_owned()),
                         outcome: latest.filter(|l| !l.is_live()).map(|l| l.outcome_label()),
                         ended_at: latest.and_then(|l| l.ended_at).map(|t| t.to_rfc3339()),
+                        created_at: latest
+                            .map(|l| l.created_at.to_rfc3339())
+                            .unwrap_or_default(),
                         urls: if live { r.urls.clone() } else { HashMap::new() },
                         nodes,
                         started_from: latest
@@ -337,7 +344,43 @@ async fn list_environments() -> Result<Json<EnvironmentList>, StatusCode> {
                     }
                 })
                 .collect();
-            runs.sort_by(|a, b| a.name.cmp(&b.name));
+            // Active (live) runs first, newest-started at the top; then ended
+            // runs, last-stopped at the top. The UI relies on this order for
+            // its Active|History tabs and the IDE run selector — a lexical
+            // name sort made the newest run hard to find while debugging a
+            // crash, which is what this order exists to fix.
+            runs.sort_by(|a, b| {
+                // Active first.
+                let by_live = b.live.cmp(&a.live);
+                if by_live != std::cmp::Ordering::Equal {
+                    return by_live;
+                }
+                // Primary time — start for live runs, stop for ended.
+                // RFC 3339 UTC strings compare chronologically.
+                let a_primary = if a.live {
+                    a.created_at.as_str()
+                } else {
+                    a.ended_at.as_deref().unwrap_or("")
+                };
+                let b_primary = if b.live {
+                    b.created_at.as_str()
+                } else {
+                    b.ended_at.as_deref().unwrap_or("")
+                };
+                let by_primary = b_primary.cmp(a_primary);
+                if by_primary != std::cmp::Ordering::Equal {
+                    return by_primary;
+                }
+                // Deterministic tiebreakers so a poll refresh never reshuffles
+                // runs that share a timestamp (ended_at can be absent): the
+                // registry is a HashMap, so an `Equal` comparator would pin
+                // the order to whatever (unstable) iteration order the fresh
+                // registry happened to produce. `run_id` is unique → total.
+                b.created_at
+                    .cmp(&a.created_at)
+                    .then_with(|| a.name.cmp(&b.name))
+                    .then_with(|| a.run_id.cmp(&b.run_id))
+            });
 
             ProjectInfo {
                 name: entry.project_name.clone(),
@@ -347,7 +390,15 @@ async fn list_environments() -> Result<Json<EnvironmentList>, StatusCode> {
         })
         .collect();
 
-    projects.sort_by(|a, b| a.name.cmp(&b.name));
+    // Projects by name, with `project_root` as a deterministic tiebreak: two
+    // worktrees of one repo share the project *name* (`veld`), so a name-only
+    // sort ties and falls back to the registry HashMap's iteration order,
+    // which changes between polls and reshuffles their runs.
+    projects.sort_by(|a, b| {
+        a.name
+            .cmp(&b.name)
+            .then_with(|| a.project_root.cmp(&b.project_root))
+    });
 
     Ok(Json(EnvironmentList { projects }))
 }
@@ -945,7 +996,10 @@ async fn get_logs(
     };
 
     // Internal (veld daemon) log — not per-node, shown as _veld:internal.
-    if include_internal {
+    // Suppressed under a specific `node` filter: this is the run's liveness
+    // stream (probes, recoveries; rows have `node = NULL`), not the node you
+    // asked for, and it drowned per-node output while debugging a crash.
+    if include_internal && q.node.is_none() {
         let lines = tail(None, None, LogStream::Internal);
         if !lines.is_empty() {
             nodes.push(NodeLogs {

--- a/crates/veld-daemon/ui/src/App.tsx
+++ b/crates/veld-daemon/ui/src/App.tsx
@@ -43,6 +43,7 @@ import {
   runsForWorktree,
   selectorRuns,
   siblingRuns,
+  sortRunsForDisplay,
   sortedUrls,
   spinnerAction,
   startRunName,
@@ -3360,7 +3361,15 @@ function RunSelect(props: {
   // would be a persisted answer to a question that has a right one.
   const [showEnded, setShowEnded] = useState(false);
   const { runs, hidden } = selectorRuns(props.runs, selected?.name, showEnded);
-  const position = selected ? runs.findIndex((r) => r.name === selected.name) + 1 : 0;
+  // Listed newest-first within each group (live by start, ended by stop) so
+  // "the run I last touched" leads the picker instead of sitting by name.
+  const orderedRuns = sortRunsForDisplay(runs);
+  // Position counted over the *sorted* list so the counter matches the order
+  // the menu actually shows (an unordered findIndex would label "1/3" a run
+  // rendered third).
+  const position = selected
+    ? orderedRuns.findIndex((r) => r.name === selected.name) + 1
+    : 0;
   // Counted over what is *listed*, so the counter and the dropdown cannot
   // disagree — "1/4" above a two-row list is worse than no counter.
   const siblingAlert = runs.length > 1 && needsAttention(props.siblingStatus);
@@ -3441,7 +3450,7 @@ function RunSelect(props: {
             no environment named {missing} here — showing {selected?.name ?? "nothing"}
           </Menu.Label>
         )}
-        {runs.map((r) => {
+        {orderedRuns.map((r) => {
           const from = startOriginLabel(r.started_from, props.presets);
           return (
             <Menu.Item

--- a/crates/veld-daemon/ui/src/api.ts
+++ b/crates/veld-daemon/ui/src/api.ts
@@ -63,6 +63,8 @@ export interface RunInfo {
   run_id: string;
   short_id: string;
   outcome?: string | null;
+  /** When this environment's latest run started (RFC 3339). */
+  created_at: string;
   ended_at?: string | null;
   urls: Record<string, string>;
   nodes: NodeInfo[];

--- a/crates/veld-daemon/ui/src/model.test.ts
+++ b/crates/veld-daemon/ui/src/model.test.ts
@@ -21,6 +21,7 @@ import {
   runsForWorktree,
   selectorRuns,
   siblingRuns,
+  sortRunsForDisplay,
   sortedUrls,
   spinnerAction,
   startRunName,
@@ -56,12 +57,17 @@ const run = (
   name: string,
   status: RunInfo["status"],
   live = status !== "stopped" && status !== "failed",
+  created_at = "2026-01-01T00:00:00Z",
+  ended_at: string | null =
+    status === "stopped" || status === "failed" ? "2026-01-01T01:00:00Z" : null,
 ): RunInfo => ({
   name,
   status,
   live,
   run_id: `${name}-run-id`,
   short_id: name,
+  created_at,
+  ended_at,
   urls: {},
   nodes: [],
 });
@@ -348,6 +354,51 @@ describe("selectorRuns", () => {
     expect(selectorRuns([], undefined)).toEqual({ runs: [], hidden: 0 });
     const live = [run("api", "starting")];
     expect(selectorRuns(live, "api").hidden).toBe(0);
+  });
+});
+
+describe("sortRunsForDisplay", () => {
+  it("puts live runs newest-started first", () => {
+    const runs = sortRunsForDisplay([
+      run("a", "running", true, "2026-01-01T00:02:00Z"),
+      run("c", "running", true, "2026-01-01T00:03:00Z"),
+      run("b", "running", true, "2026-01-01T00:01:00Z"),
+    ]);
+    expect(runs.map((r) => r.name)).toEqual(["c", "a", "b"]);
+  });
+
+  it("puts ended runs last-stopped first", () => {
+    const runs = sortRunsForDisplay([
+      run("a", "stopped", false, "2026-01-01T00:00:00Z", "2026-01-01T00:05:00Z"),
+      run("b", "failed", false, "2026-01-01T00:00:00Z", "2026-01-01T00:06:00Z"),
+      run("c", "stopped", false, "2026-01-01T00:00:00Z", "2026-01-01T00:04:00Z"),
+    ]);
+    expect(runs.map((r) => r.name)).toEqual(["b", "a", "c"]);
+  });
+
+  it("keeps the live group ahead of ended runs whatever the times", () => {
+    const runs = sortRunsForDisplay([
+      // Ended long ago but after the live run started.
+      run("old", "stopped", false, "2026-01-01T00:00:00Z", "2026-01-01T00:07:00Z"),
+      run("live", "running", true, "2026-01-01T00:08:00Z"),
+    ]);
+    expect(runs.map((r) => r.name)).toEqual(["live", "old"]);
+  });
+
+  it("is deterministic on full ties (name, then run_id)", () => {
+    // Same start and end on both — the comparator must still pick a fixed order
+    // so a poll refresh never reshuffles the list.
+    const a = run("z", "stopped", false, "2026-01-01T00:00:00Z", "2026-01-01T00:01:00Z");
+    const b = run("a", "stopped", false, "2026-01-01T00:00:00Z", "2026-01-01T00:01:00Z");
+    expect(sortRunsForDisplay([a, b]).map((r) => r.name)).toEqual(["a", "z"]);
+    expect(sortRunsForDisplay([b, a]).map((r) => r.name)).toEqual(["a", "z"]);
+  });
+
+  it("does not mutate its input", () => {
+    const input: RunInfo[] = [run("b", "stopped"), run("a", "running")];
+    const before = input.map((r) => r.name);
+    sortRunsForDisplay(input);
+    expect(input.map((r) => r.name)).toEqual(before);
   });
 });
 

--- a/crates/veld-daemon/ui/src/model.ts
+++ b/crates/veld-daemon/ui/src/model.ts
@@ -156,6 +156,40 @@ export function selectorRuns(
   return { runs: shown, hidden: runs.length - shown.length };
 }
 
+/** Locale-independent string compare (RFC 3339 UTC timestamps sort correctly). */
+const cmpStr = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0);
+
+/**
+ * Compare two runs for display order: **active first, then by time** — a live
+ * run by its start (`created_at`), an ended run by its stop (`ended_at`),
+ * both newest-first. This is the single ordering every runs surface uses so
+ * "find the run I last touched" works whether it is still running (Active /
+ * IDE selector) or has crashed (History): the latest-started run is at the
+ * top of the live group, the last-stopped at the top of the ended group,
+ * regardless of project or environment name.
+ *
+ * Determinstic to the last tie: `created_at` desc, then name, then the unique
+ * `run_id`. A non-total comparator would pin equal rows to the daemon's
+ * unstable HashMap order and reshuffle the list on every poll refresh.
+ */
+export function compareRunsForDisplay(a: RunInfo, b: RunInfo): number {
+  if (a.live !== b.live) return a.live ? -1 : 1; // active group first
+  const ka = a.live ? a.created_at : a.ended_at ?? "";
+  const kb = b.live ? b.created_at : b.ended_at ?? "";
+  const byTime = cmpStr(kb, ka); // latest first
+  if (byTime !== 0) return byTime;
+  const byStart = cmpStr(b.created_at, a.created_at); // latest-started first
+  if (byStart !== 0) return byStart;
+  const byName = cmpStr(a.name, b.name);
+  if (byName !== 0) return byName;
+  return cmpStr(a.run_id, b.run_id);
+}
+
+/** Sort a run list for display with [`compareRunsForDisplay`] (returns a copy). */
+export function sortRunsForDisplay(runs: RunInfo[]): RunInfo[] {
+  return [...runs].sort(compareRunsForDisplay);
+}
+
 /**
  * The environment name a fresh start should use, given what is already live.
  *

--- a/crates/veld-daemon/ui/src/runs/RunsMode.tsx
+++ b/crates/veld-daemon/ui/src/runs/RunsMode.tsx
@@ -18,6 +18,7 @@ import { JoinRequestRow, runOfShare } from "../shared/Sharing";
 import { countHidden, hiddenByHorizon, pruneRunHistory } from "../shared/runHistory";
 import { notifyError } from "../shared/notify";
 import { confirmedUnattached, unattachedShareIds } from "../shared/util";
+import { compareRunsForDisplay } from "../model";
 import { topbarClass } from "../shell";
 import type { ReactNode } from "react";
 
@@ -134,14 +135,15 @@ export function RunsMode(props: { modeSwitch: ReactNode; themeButton: ReactNode;
   const endedCount =
     allRuns.length - liveCount - hiddenCount;
 
+  // Split by tab, drop horizon-hidden rows, then order the whole flattened
+  // list (across every project) by the shared timestamp rule: the Active tab
+  // shows live runs newest-started first, the History tab ended runs
+  // last-stopped first. Doing it here — where the tab is known — is what lets
+  // a `main` project sit beside a crashed one by recency, not by name.
   const shown = allRuns
     .filter(({ r }) => (view === "active" ? r.live : !r.live))
     .filter(({ r }) => !hiddenByHorizon(r, props.historyDays, now))
-    .sort(
-      (a, b) =>
-        Number(b.r.status === "running") - Number(a.r.status === "running") ||
-        a.r.name.localeCompare(b.r.name),
-    );
+    .sort((a, b) => compareRunsForDisplay(a.r, b.r));
 
   const meta = offline
     ? "disconnected"

--- a/crates/veld-daemon/ui/src/shared/LogsPanel.tsx
+++ b/crates/veld-daemon/ui/src/shared/LogsPanel.tsx
@@ -124,11 +124,13 @@ export function LogsPanel(props: {
   const { rows, matchCount } = useMemo(() => {
     const entries: Entry[] = [];
     for (const n of data?.nodes ?? []) {
-      // `_veld:*` sections (internal, setup/teardown steps) belong to the run,
-      // not to a node, so a node filter does not apply to them — same rule the
-      // daemon and `veld logs` follow for run-level streams. Filtering them out
-      // left the Setup view blank whenever a node was picked.
+      // `_veld:internal` is the run's liveness stream (probes, recoveries —
+      // daemon noise, not any node's output), so a node pick hides it — same
+      // rule the daemon and `veld logs` follow. `_veld:setup`/`teardown` are
+      // a node's real step output and stay under the old rule: kept even with
+      // a node picked (filtering them out blanked the Setup view).
       const runLevel = n.node === "_veld";
+      if (runLevel && n.variant === "internal" && nodeFilter) continue;
       if (nodeFilter && !runLevel && `${n.node}:${n.variant}` !== nodeFilter) continue;
       for (const raw of n.lines) {
         // The CLI colours its own output and dev servers colour far more, so a
@@ -210,95 +212,112 @@ export function LogsPanel(props: {
       className={props.fill ? "logs-fill" : "logs-card"}
       style={props.visible ? undefined : { display: "none" }}
     >
-      <Group gap="xs" px={10} py={6} wrap="wrap">
-        {/* Which environment these lines belong to — pane mode only, since a
-            card already has the name in its header.
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 6,
+          padding: "6px 10px",
+        }}
+      >
+        {/* Row 1 — which run, node and stream. Stable: never moves when a
+            search starts. */}
+        <Group gap="xs" wrap="wrap" align="center">
+          {/* Which environment these lines belong to — pane mode only, since a
+              card already has the name in its header.
 
-            `NodesView` carries this and `LogsView` did not, which was survivable
-            while a worktree had one environment and is not now: the control beside
-            it is a *history* picker ("Latest run", "All runs") for the environment
-            already bound, so a reader with two live runs would take that dropdown
-            for the answer to "which run is this?" and be wrong. The title below
-            says `Run history` for the same reason. */}
-        {props.fill && (
-          <Text size="xs" ff="monospace" fw={700} title="The environment these logs belong to">
-            {props.run.name}
-          </Text>
-        )}
-        <NativeSelect
-          size="xs"
-          title="Run history"
-          value={runFilter}
-          onChange={(e) => {
-            setRunFilter(e.currentTarget.value);
-            setAutoScroll(true);
-            setData(null);
-          }}
-          data={[
-            { value: "", label: "Latest run" },
-            ...props.history.map((h) => ({
-              value: h.run_id,
-              label: `${h.outcome || h.status} · ${fmtWhen(h.created_at)}`,
-            })),
-            { value: "all", label: "All runs" },
-          ]}
-        />
-        <NativeSelect
-          size="xs"
-          title="Node"
-          value={nodeFilter}
-          onChange={(e) => setNodeFilter(e.currentTarget.value)}
-          data={[
-            { value: "", label: "All nodes" },
-            ...[...knownNodes.current.keys()].sort().map((k) => ({ value: k, label: k })),
-          ]}
-        />
-        <SegmentedControl
-          size="xs"
-          value={sourceFilter}
-          onChange={(v) => {
-            setSourceFilter(v);
-            setData(null);
-          }}
-          data={[
-            { value: "all", label: "All" },
-            { value: "server", label: "Server" },
-            { value: "client", label: "Client" },
-            { value: "setup", label: "Setup" },
-            { value: "internal", label: "Internal" },
-          ]}
-        />
-        <TextInput
-          size="xs"
-          placeholder="Search…"
-          value={search}
-          onChange={(e) => setSearch(e.currentTarget.value)}
-          style={{ width: 150 }}
-        />
-        {term && (
-          <>
-            <Text size="xs" c="dimmed">
-              {matchCount} matches
+              `NodesView` carries this and `LogsView` did not, which was survivable
+              while a worktree had one environment and is not now: the control beside
+              it is a *history* picker ("Latest run", "All runs") for the environment
+              already bound, so a reader with two live runs would take that dropdown
+              for the answer to "which run is this?" and be wrong. The title below
+              says `Run history` for the same reason. */}
+          {props.fill && (
+            <Text size="xs" ff="monospace" fw={700} title="The environment these logs belong to">
+              {props.run.name}
             </Text>
-            <NumberInput
-              size="xs"
-              title="Context lines"
-              value={ctxLines}
-              onChange={(v) => setCtxLines(Math.max(0, Math.min(50, Number(v) || 0)))}
-              min={0}
-              max={50}
-              style={{ width: 70 }}
-            />
-          </>
-        )}
-        <Button
-          size="compact-xs"
-          variant={autoScroll ? "light" : "default"}
-          onClick={() => setAutoScroll((v) => !v)}
-        >
-          Auto-scroll {autoScroll ? "ON" : "OFF"}
-        </Button>
-      </Group>
+          )}
+          <NativeSelect
+            size="xs"
+            title="Run history"
+            value={runFilter}
+            onChange={(e) => {
+              setRunFilter(e.currentTarget.value);
+              setAutoScroll(true);
+              setData(null);
+            }}
+            data={[
+              { value: "", label: "Latest run" },
+              ...props.history.map((h) => ({
+                value: h.run_id,
+                label: `${h.outcome || h.status} · ${fmtWhen(h.created_at)}`,
+              })),
+              { value: "all", label: "All runs" },
+            ]}
+          />
+          <NativeSelect
+            size="xs"
+            title="Node"
+            value={nodeFilter}
+            onChange={(e) => setNodeFilter(e.currentTarget.value)}
+            data={[
+              { value: "", label: "All nodes" },
+              ...[...knownNodes.current.keys()].sort().map((k) => ({ value: k, label: k })),
+            ]}
+          />
+          <SegmentedControl
+            size="xs"
+            value={sourceFilter}
+            onChange={(v) => {
+              setSourceFilter(v);
+              setData(null);
+            }}
+            data={[
+              { value: "all", label: "All" },
+              { value: "server", label: "Server" },
+              { value: "client", label: "Client" },
+              { value: "setup", label: "Setup" },
+              { value: "internal", label: "Internal" },
+            ]}
+          />
+        </Group>
+        {/* Row 2 — search and its affordances. Kept on their own row/group so
+            the auto-scroll toggle and the context control never relocate or wrap
+            onto orphaned lines when a search term appears: that reflow was making
+            them hard to reach mid-debug. */}
+        <Group gap="xs" wrap="wrap" align="center">
+          <TextInput
+            size="xs"
+            placeholder="Search…"
+            value={search}
+            onChange={(e) => setSearch(e.currentTarget.value)}
+            style={{ width: 180 }}
+          />
+          {term && (
+            <>
+              <Text size="xs" c="dimmed">
+                {matchCount} matches
+              </Text>
+              <NumberInput
+                size="xs"
+                title="Context lines"
+                value={ctxLines}
+                onChange={(v) => setCtxLines(Math.max(0, Math.min(50, Number(v) || 0)))}
+                min={0}
+                max={50}
+                style={{ width: 70 }}
+              />
+            </>
+          )}
+          <Button
+            size="compact-xs"
+            variant={autoScroll ? "light" : "default"}
+            onClick={() => setAutoScroll((v) => !v)}
+          >
+            Auto-scroll {autoScroll ? "ON" : "OFF"}
+          </Button>
+        </Group>
+      </div>
       <div
         className={`log-area${props.fill ? " fill" : ""}`}
         ref={areaRef}

--- a/crates/veld-daemon/ui/src/shared/runHistory.test.ts
+++ b/crates/veld-daemon/ui/src/shared/runHistory.test.ts
@@ -22,6 +22,7 @@ function run(over: Partial<RunInfo> = {}): RunInfo {
     short_id: "r1",
     urls: {},
     nodes: [],
+    created_at: "2026-08-05T00:00:00Z",
     ...over,
   };
 }

--- a/crates/veld-daemon/ui/src/shared/sharing.test.ts
+++ b/crates/veld-daemon/ui/src/shared/sharing.test.ts
@@ -67,6 +67,7 @@ const run = (over: Partial<RunInfo> = {}): RunInfo => ({
   run_id: "run-a",
   short_id: "run-a",
   urls: {},
+  created_at: "2026-07-30T10:00:00Z",
   nodes: [
     {
       name: "web",

--- a/crates/veld/src/commands/logs.rs
+++ b/crates/veld/src/commands/logs.rs
@@ -56,6 +56,24 @@ impl SourceFilter {
     }
 }
 
+/// The stored streams `--source` selects, minus the run-level **internal**
+/// stream when a specific `--node` filter is active.
+///
+/// Internal rows (liveness probes, recoveries) carry `node = NULL` — they are
+/// daemon noise, not the node the user asked for, and under `--node` they
+/// drowned the filtered node's output while debugging a crash. Setup/debug
+/// stay under `--source all`: setup is a node's real step output and debug is
+/// an opt-in trace, so neither is hidden by a node pick. Callers use this for
+/// both the follow-mode poll set and the snapshot filter list so the two
+/// never disagree about whether internal leaks in.
+fn selected_streams(source: SourceFilter, node: Option<&str>) -> Vec<&'static str> {
+    source
+        .streams()
+        .into_iter()
+        .filter(|s| !(node.is_some() && *s == LogStream::Internal.as_str()))
+        .collect()
+}
+
 pub struct LogsOptions {
     pub name: Option<String>,
     pub node: Option<String>,
@@ -174,11 +192,12 @@ pub async fn run(opts: LogsOptions) -> i32 {
     // streams (internal/debug/setup) never do — internal/debug rows have
     // `node = NULL`, so a node filter would silently drop them live even
     // though the snapshot shows them. The stream sets are disjoint, so no
-    // row is polled twice.
-    let (per_node_streams, run_level_streams): (Vec<&'static str>, Vec<&'static str>) = source
-        .streams()
-        .into_iter()
-        .partition(|s| stream_is_per_node(s));
+    // row is polled twice. `selected_streams` already drops internal under a
+    // `--node` filter, so follow and snapshot agree by construction.
+    let (per_node_streams, run_level_streams): (Vec<&'static str>, Vec<&'static str>) =
+        selected_streams(source, node.as_deref())
+            .into_iter()
+            .partition(|s| stream_is_per_node(s));
     let mut follow_filters: Vec<LogFilter> = Vec::new();
     if !per_node_streams.is_empty() {
         follow_filters.push(LogFilter {
@@ -201,7 +220,7 @@ pub async fn run(opts: LogsOptions) -> i32 {
     // `--lines N` means N lines per source (per node+stream), not N total —
     // otherwise one chatty node pushes every other node out of the window.
     let mut source_filters: Vec<LogFilter> = Vec::new();
-    for stream in source.streams() {
+    for stream in selected_streams(source, node.as_deref()) {
         if stream_is_per_node(stream) {
             // Per-node streams: one source per (node, variant).
             let mut targets: Vec<(&str, &str)> = run_state
@@ -221,7 +240,9 @@ pub async fn run(opts: LogsOptions) -> i32 {
             }
         } else {
             // Run-level streams (internal/debug; setup rows carry a node but
-            // the node: None filter matches them too).
+            // the node: None filter matches them too). `selected_streams` has
+            // already dropped internal under a node filter, mirroring follow
+            // mode.
             source_filters.push(LogFilter {
                 node: None,
                 variant: None,
@@ -481,4 +502,55 @@ fn parse_duration(s: &str) -> Option<u64> {
         _ => return s.parse().ok(),
     };
     num.parse::<u64>().ok().map(|n| n * multiplier)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(streams: Vec<&'static str>) -> Vec<String> {
+        streams.into_iter().map(|s| s.to_owned()).collect()
+    }
+
+    #[test]
+    fn all_sources_without_node_filter_keep_internal() {
+        let streams = selected_streams(SourceFilter::All, None);
+        assert!(streams.contains(&LogStream::Internal.as_str()));
+        assert!(streams.contains(&LogStream::Setup.as_str()));
+        assert!(streams.contains(&LogStream::Server.as_str()));
+    }
+
+    #[test]
+    fn a_node_filter_drops_internal_but_keeps_setup_and_debug() {
+        let streams = names(selected_streams(SourceFilter::All, Some("web")));
+        assert!(!streams.contains(&LogStream::Internal.as_str().to_owned()));
+        // Real project-step output and opt-in trace survive a node pick.
+        assert!(streams.contains(&LogStream::Setup.as_str().to_owned()));
+        assert!(streams.contains(&LogStream::Debug.as_str().to_owned()));
+        assert!(streams.contains(&LogStream::Server.as_str().to_owned()));
+        assert!(streams.contains(&LogStream::Client.as_str().to_owned()));
+    }
+
+    #[test]
+    fn explicit_internal_source_is_empty_under_a_node_filter() {
+        // `--node X --source internal` has nothing to show: internal is hidden
+        // the moment a node is picked, consistently with `--source all`.
+        assert_eq!(
+            names(selected_streams(SourceFilter::Internal, Some("web"))),
+            Vec::<String>::new()
+        );
+        assert_eq!(
+            names(selected_streams(SourceFilter::Internal, None)),
+            vec![LogStream::Internal.as_str().to_owned()]
+        );
+    }
+
+    #[test]
+    fn server_source_never_includes_internal() {
+        assert!(
+            selected_streams(SourceFilter::Server, None)
+                .iter()
+                .all(|s| *s != LogStream::Internal.as_str())
+        );
+    }
 }


### PR DESCRIPTION
## What & why

Both the runs dashboard views and the new IDE run selector were ordered by
name, which buried the most recently touched run while debugging a crash. This
makes every runs surface order by recency.

### Run ordering — legacy `/` page, React runs view, and the new IDE selector (Active + History)
- One shared timestamp rule everywhere: **live runs newest-started first,
  ended runs last-stopped first**, across every project.
- Sorting for the React/iDE surfaces lives in the frontend (`sortRunsForDisplay`)
  because Active sorts by **start** (`created_at`) while History sorts by
  **stop** (`ended_at`) — only the view knows which. `created_at` is now
  serialized on `RunInfo` for that.
- Two non-total sorts (the per-project run sort and the projects sort — two
  worktrees of one repo share the project name `veld`) made the list reshuffle
  between polls because the registry is a HashMap. Both are now deterministic
  to the last tie (`run_id` / `project_root`), in the backend and in the legacy
  page's comparator, so a 3s/6s refresh never moves a card that didn't change.

### Logs toolbox layout — legacy `.log-bar` and the React `LogsPanel`
Search, match count, context and auto-scroll overflowed instead of wrapping,
pushing auto-scroll/context off or clipping them when a search term added the
context control. The React toolbar is split into two stable rows and the legacy
`.log-bar` now wraps, so search + auto-scroll flow onto the next row without
relocating.

### Logs filter — `_veld:internal` under a node filter
`_veld:internal` (liveness probes, recoveries; `node = NULL`) leaked into
`--node`-filtered output in the CLI, the daemon API, and the UI. A specific
node pick now suppresses the internal stream everywhere; `_veld:setup`/`teardown`
and explicit `--source internal` still work. Centralised in `selected_streams()`
(CLI) with unit tests; mirrored in the daemon and `LogsPanel`.

## Root cause
Name-sorting plus two non-total sorts over a HashMap-backed registry — the
order looked random and changed on every poll, and the newest run was
unfindable for crash debugging.

## Test evidence
- `cargo clippy --workspace --all-targets`, `cargo fmt --check` clean.
- `cargo test --workspace` green (incl. new `selected_streams` unit tests).
- `crates/veld-daemon/ui`: typecheck + 562 tests green; `vite build` OK.
- Legacy page inline JS syntax-checked (`node --check`).

## Reviewer scope notes
- The `/#` stale dashboard page and the React/iDE bundles are separate stacks,
  so the same ordering rule is implemented in three places (backend default,
  React `model.ts`, legacy `management-ui.html`) — deliberately, no shared code.
- Docs/website deliberately unchanged: internal ordering; `--source internal`
  remains the documented way to read the internal stream.

## Follow-ups (out of scope)
- None.
