### PR TITLE
fix(desktop): expire handoff reports so an old failure is not announced

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4462,7 +4462,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "veld"
-version = "16.6.1"
+version = "16.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4482,7 +4482,7 @@ dependencies = [
 
 [[package]]
 name = "veld-core"
-version = "16.6.1"
+version = "16.7.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -4506,7 +4506,7 @@ dependencies = [
 
 [[package]]
 name = "veld-daemon"
-version = "16.6.1"
+version = "16.7.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4535,7 +4535,7 @@ dependencies = [
 
 [[package]]
 name = "veld-gateway"
-version = "16.6.1"
+version = "16.7.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4566,7 +4566,7 @@ dependencies = [
 
 [[package]]
 name = "veld-helper"
-version = "16.6.1"
+version = "16.7.0"
 dependencies = [
  "anyhow",
  "nix 0.29.0",
@@ -4582,7 +4582,7 @@ dependencies = [
 
 [[package]]
 name = "veld-share"
-version = "16.6.1"
+version = "16.7.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/desktop/src/updatePolicy.js
+++ b/desktop/src/updatePolicy.js
@@ -161,6 +161,43 @@ function versionSkew({ appVersion, daemonVersion, isPackaged }) {
   };
 }
 
+/**
+ * How long a handoff report stays meaningful.
+ *
+ * The whole exchange is seconds long: the CLI writes the outcome and the app is
+ * already relaunching. Fifteen minutes is far longer than that and still short
+ * enough that nothing ancient survives.
+ */
+const REPORT_MAX_AGE_MS = 15 * 60 * 1000;
+
+/**
+ * Whether a `desktop-update.json` describes the handoff this launch just came
+ * back from, rather than one from some earlier day.
+ *
+ * There was no such check, and the failure it allows is not hypothetical: a
+ * report left behind by a failed update sat in `~/.veld` for a day, and the next
+ * time the app started — a *different* install, of a newer version — it read the
+ * file and announced that "Veld Desktop 99.0.0 was not installed". Everything
+ * downstream of it was working correctly; the report simply had no expiry.
+ *
+ * Missing or unparseable timestamps count as stale. A report that cannot say
+ * when it was written cannot claim to be about this launch, and staying quiet is
+ * the cheaper mistake — the alternative is telling someone an update failed when
+ * nothing of the sort just happened.
+ *
+ * Clock skew is tolerated in both directions by the same margin: a timestamp
+ * slightly in the future is a machine whose clock moved, not a lie.
+ *
+ * @param {{finishedAt?: string | null, now?: number, maxAgeMs?: number}} ctx
+ * @returns {boolean}
+ */
+function reportIsFresh({ finishedAt, now = Date.now(), maxAgeMs = REPORT_MAX_AGE_MS }) {
+  if (typeof finishedAt !== "string" || !finishedAt) return false;
+  const written = Date.parse(finishedAt);
+  if (Number.isNaN(written)) return false;
+  return Math.abs(now - written) <= maxAgeMs;
+}
+
 /** The page a user lands on to pick the right artifact for their machine. */
 function releasePageUrl(version) {
   const tag = version ? `tag/v${String(version).replace(/^v/, "")}` : "latest";
@@ -221,11 +258,13 @@ function looksLikeVeldCli(output) {
 
 module.exports = {
   GITHUB_REPO,
+  REPORT_MAX_AGE_MS,
   cliCandidatePaths,
   compareVersions,
   downloadOnlyReason,
   looksLikeVeldCli,
   releasePageUrl,
+  reportIsFresh,
   updateMode,
   versionSkew,
 };

--- a/desktop/src/updatePolicy.test.js
+++ b/desktop/src/updatePolicy.test.js
@@ -2,11 +2,13 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const {
+  REPORT_MAX_AGE_MS,
   cliCandidatePaths,
   compareVersions,
   downloadOnlyReason,
   looksLikeVeldCli,
   releasePageUrl,
+  reportIsFresh,
   updateMode,
   versionSkew,
 } = require("./updatePolicy");
@@ -195,4 +197,46 @@ test("looksLikeVeldCli accepts the CLI's own --version and nothing looser", () =
   for (const junk of [null, undefined, {}, 12, ["veld 1.0.0"]]) {
     assert.equal(looksLikeVeldCli(junk), false, `${JSON.stringify(junk)} is not veld`);
   }
+});
+
+test("a handoff report expires, so yesterday's failure is not announced today", () => {
+  const now = Date.parse("2026-08-07T05:00:00Z");
+
+  // The report the app just came back from.
+  assert.equal(
+    reportIsFresh({ finishedAt: "2026-08-07T04:59:55Z", now }),
+    true,
+    "a report written five seconds ago is this launch's",
+  );
+
+  // The bug this exists for, with the real values off the machine it happened
+  // on: a failed 99.0.0 handoff left a report in ~/.veld, and the next launch —
+  // a different install, a day later, running 16.7.0 — announced it.
+  assert.equal(
+    reportIsFresh({ finishedAt: "2026-08-06T14:45:59.044305+00:00", now }),
+    false,
+    "a report from the previous day must never be announced",
+  );
+
+  // Boundaries.
+  assert.equal(reportIsFresh({ finishedAt: "2026-08-07T04:46:00Z", now }), true);
+  assert.equal(reportIsFresh({ finishedAt: "2026-08-07T04:44:00Z", now }), false);
+
+  // Clock skew is tolerated the same amount in both directions: a stamp slightly
+  // in the future is a machine whose clock moved, not a lie.
+  assert.equal(reportIsFresh({ finishedAt: "2026-08-07T05:05:00Z", now }), true);
+  assert.equal(reportIsFresh({ finishedAt: "2026-09-01T00:00:00Z", now }), false);
+
+  // A report that cannot say when it was written cannot claim to be about this
+  // launch. Staying quiet is the cheaper mistake.
+  for (const junk of [undefined, null, "", "not a date", 12, {}, []]) {
+    assert.equal(
+      reportIsFresh({ finishedAt: junk, now }),
+      false,
+      `finished_at ${JSON.stringify(junk)} must not count as fresh`,
+    );
+  }
+
+  assert.equal(typeof REPORT_MAX_AGE_MS, "number");
+  assert.ok(REPORT_MAX_AGE_MS > 0);
 });

--- a/desktop/src/updater.js
+++ b/desktop/src/updater.js
@@ -33,6 +33,7 @@ const {
   downloadOnlyReason,
   looksLikeVeldCli,
   releasePageUrl,
+  reportIsFresh,
   updateMode,
   versionSkew,
 } = require("./updatePolicy");
@@ -541,6 +542,10 @@ async function reportPreviousCliUpdate() {
   // A success needs no dialog: the user asked for an update and is looking at
   // it. `app.getVersion()` is the receipt.
   if (!report || report.ok !== false) return;
+  // …and neither does a report about some earlier day's handoff. One left behind
+  // by a failed update was read a day later by a different, newer install, which
+  // duly announced that a version it had never tried to install had failed.
+  if (!reportIsFresh({ finishedAt: report.finished_at })) return;
 
   const buttons = report.log ? ["Show Log", "Close"] : ["Close"];
   const { response } = await dialog.showMessageBox({


### PR DESCRIPTION
## The bug

`~/.veld/desktop-update.json` — the note the CLI leaves so the app can report how
a handoff went — had **no expiry**. The app announced whatever it found there on
its next launch, whenever that was.

Observed on the maintainer's machine right after #232 shipped: a deliberately
failing `99.0.0` handoff (a test, run the previous afternoon) left a report
behind. The next day a *different* install, running 16.7.0, started up, read the
file, and popped a dialog saying **"Veld Desktop 99.0.0 was not installed"** — for
an update that machine had never attempted.

Nothing downstream was broken. The report was found, parsed, rendered and deleted
exactly as designed, with the right log link. The file just had no notion of
being out of date.

## The fix

`reportIsFresh` requires `finished_at` to be within fifteen minutes of now.

The exchange a report describes lasts *seconds* — the CLI writes the outcome
while the app is already relaunching — so the window is generous by two orders of
magnitude and still leaves nothing ancient alive. And a report can only exist if
the CLI ran to completion, which means the installer's EXIT trap has already
reopened the app; there is no path where a genuine report waits hours for someone
to notice it.

Two deliberate calls:

- **A missing or unparseable timestamp counts as stale.** A report that cannot
  say when it was written cannot claim to be about this launch, and silence is
  the cheaper mistake than telling someone an update failed when none was
  running.
- **Clock skew is tolerated equally in both directions.** A stamp slightly in the
  future is a machine whose clock moved, not a lie.

The report is still deleted *before* either guard runs, so a stale one is
consumed rather than left to fire again on the launch after.

## Testing

`reportIsFresh` is pure and lives in `updatePolicy.js` with the rest of the
testable logic. Covered: the five-seconds-ago case, **the real timestamp from the
machine this happened on**, both boundaries, both skew directions, and the
junk-input set (`undefined`, `null`, `""`, non-dates, numbers, objects, arrays).

Pre-pass green: clippy, fmt, cargo test, 100 desktop tests, biome, shellcheck +
the install-contract gate.

## Scope

~10 lines of logic; the rest is tests and the reasoning. No change to when a
report is *written*, to the handoff itself, or to any install path.
