### PR TITLE
fix(desktop): centre the macOS window buttons and free the bar in full screen

### DIFF
--- a/crates/veld-daemon/ui/src/main.tsx
+++ b/crates/veld-daemon/ui/src/main.tsx
@@ -10,6 +10,12 @@ import "./styles.css";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
+import { watchFullScreen } from "./shell";
+
+// Before the first render: the top bar's traffic-light inset is a CSS rule keyed
+// off `<body data-fullscreen>`, and a page that boots in full screen would
+// otherwise paint one frame with a 90px gutter for buttons macOS is not drawing.
+watchFullScreen();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/crates/veld-daemon/ui/src/shell.ts
+++ b/crates/veld-daemon/ui/src/shell.ts
@@ -166,6 +166,11 @@ export interface DesktopWindowApi {
     reason?: string | null;
     accepted?: string[];
   }>;
+  /** Native full screen when the page started. Optional: an older shell has no
+   *  such field, and `undefined` reads as the windowed state it always had. */
+  fullScreen?: boolean;
+  /** …and every change to it. Optional for the same reason. */
+  onFullScreen?(fn: (p: { fullScreen: boolean }) => void): () => void;
   snapshot(payload: TabTransfer): Promise<boolean>;
   setTitle(title: string): Promise<boolean>;
   close(): Promise<boolean>;
@@ -178,6 +183,27 @@ export interface DesktopWindowApi {
 
 export const desktopWindow: DesktopWindowApi | null =
   (window as { veldDesktop?: { window?: DesktopWindowApi } }).veldDesktop?.window ?? null;
+
+/**
+ * Mirror the window's native full-screen state onto `<body data-fullscreen>`.
+ *
+ * On the body rather than in React state because the thing that reads it is one
+ * CSS rule (`.topbar.electron`'s traffic-light inset) and there are two top bars
+ * in two modes, neither of which owns the window. `data-fullscreen` sits beside
+ * `data-theme`, which is set the same way for the same reason.
+ *
+ * Called once at boot from `main.tsx`, and nothing unsubscribes: the state is
+ * the window's, so the subscription is meant to live as long as the page. The
+ * unsubscribe is returned anyway rather than swallowed — a caller that ever does
+ * need to detach should not have to change this function to do it.
+ */
+export function watchFullScreen(): () => void {
+  const apply = (fullScreen: boolean) => {
+    document.body.dataset.fullscreen = String(fullScreen);
+  };
+  apply(desktopWindow?.fullScreen === true);
+  return desktopWindow?.onFullScreen?.((p) => apply(p?.fullScreen === true)) ?? (() => {});
+}
 
 /** App-level surfaces the Electron main process drives. */
 export interface DesktopAppApi {

--- a/crates/veld-daemon/ui/src/styles.css
+++ b/crates/veld-daemon/ui/src/styles.css
@@ -242,18 +242,29 @@ select:focus {
  * `TOPBAR_HEIGHT` in `desktop/src/main.js` mirrors this height and centers the
  * traffic lights against it — change one and change the other, or the OS-drawn
  * buttons sit off the bar's own controls. The inset is what clears those
- * buttons: `windows.js` puts the leftmost at x=13, and three 12px lights on
- * macOS's 20px pitch end at 65px, so 78 leaves them on the right the same 13px
- * they get on their left. That is the lights' own metric, not the bar's — the
- * bar uses 10px of padding and 9px between controls, so retuning those is not a
- * reason to move this. */
+ * buttons: `windows.js` puts the leftmost at x=13, and three 14px lights on
+ * macOS 26's 23px pitch end at 73px (see `TRAFFIC_LIGHT_SIZE` for where those
+ * two numbers were measured). 90 leaves 17px after them — more than the 13px
+ * they get on their left and clearly more than the 9px between the bar's own
+ * controls, so the OS buttons read as their own group rather than as the first
+ * item of ours. That is the lights' metric, not the bar's: retuning the bar's
+ * padding or gap is not a reason to move this. */
 .topbar.electron {
   height: 40px;
-  padding-left: 78px; /* traffic-light inset */
+  padding-left: 90px; /* traffic-light inset */
   -webkit-app-region: drag;
 }
 .topbar.electron > * {
   -webkit-app-region: no-drag;
+}
+/* Full screen: macOS takes the traffic lights out of the content area entirely
+   (they live in the menu-bar overlay that drops down), so the inset above is
+   90px of dead space at the left of the densest row in the app. The flag is set
+   on <body> by `watchFullScreen` in shell.ts — main-process state, since a page
+   cannot see native full screen: `:fullscreen` is about the *element* API, and
+   `display-mode: fullscreen` never matches an Electron window. */
+body[data-fullscreen="true"] .topbar.electron {
+  padding-left: 10px;
 }
 
 /* One control height for the whole bar.

--- a/desktop/ARCHITECTURE.md
+++ b/desktop/ARCHITECTURE.md
@@ -126,7 +126,12 @@ requests at runtime — branding rule.
   is on screen (runs mode does its own). Push/SSE is a later increment.
 - Detects the Electron shell via a `?shell=electron` query param to render the
   native-title-bar layout (drag region, traffic-light inset padding) instead of
-  the browser-build header row.
+  the browser-build header row. In native full screen macOS moves the traffic
+  lights out of the content area, so the shell mirrors that state onto
+  `<body data-fullscreen>` (preload `window.fullScreen` + `onFullScreen`,
+  applied by `watchFullScreen` in `shell.ts`) and the bar drops the inset. No
+  CSS can detect it: `:fullscreen` is the element API and
+  `display-mode: fullscreen` never matches an Electron window.
 - The v1 dashboard at `/` is untouched until the runs-mode rebuild reaches
   parity and takes it over.
 

--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -72,9 +72,19 @@ const REPOS_URL = `${BASE_URL}/api/repos`;
  * light. Together they place the buttons, which the OS draws — no CSS can move
  * them, so without this they sit at `hiddenInset`'s default and read as
  * misaligned against the bar's own controls. Keep in sync with that stylesheet.
+ *
+ * **14, not the 12 every older recipe on the internet says.** macOS 26 (Tahoe)
+ * grew the window buttons: measured off a 2× screenshot of this app's own bar,
+ * the circles are 14pt across on a 23pt pitch, where Big Sur through Sequoia
+ * drew 12pt on 20pt. `trafficLightPosition` maps straight onto the circle's
+ * top-left corner (both axes — verified against `x: 13` in the same shot), so
+ * the size is the *only* thing the centring depends on, and a stale 12 put the
+ * lights 1.5px below the bar's own controls. On a pre-Tahoe system the same
+ * number costs 1px in the other direction, which is the cheaper error to carry
+ * than a version check over a value Electron does not expose.
  */
 const TOPBAR_HEIGHT = 40;
-const TRAFFIC_LIGHT_SIZE = 12;
+const TRAFFIC_LIGHT_SIZE = 14;
 
 /** @type {Tray | null} */
 let tray = null;

--- a/desktop/src/preload.js
+++ b/desktop/src/preload.js
@@ -49,6 +49,25 @@ function windowSeed() {
   }
 }
 
+/**
+ * Whether this window is in native full screen as the page starts.
+ *
+ * Synchronous for the same reason `windowSeed` is, though the stake is cosmetic
+ * rather than structural: the top bar holds a 90px inset for the traffic lights,
+ * full screen removes them, and a state that lands one tick late shows an empty
+ * gutter on every reload taken in full screen. Changes arrive on
+ * `veld:window:fullscreen`.
+ */
+function windowFullScreen() {
+  try {
+    return ipcRenderer.sendSync("veld:window:fullscreen") === true;
+  } catch {
+    // An older shell without the channel: not full screen, which is the state
+    // every window had before this existed.
+    return false;
+  }
+}
+
 /** Subscribe to a main→renderer channel, returning an unsubscribe. */
 function on(channel, fn) {
   const listener = (_event, payload) => fn(payload);
@@ -83,6 +102,11 @@ contextBridge.exposeInMainWorld("veldDesktop", {
      *  then may the page restore that slot's durable layout — see `readLayouts`. */
     restored: fromArgv("--veld-window-restored=") === "1",
     seed: windowSeed(),
+    /** Native full screen at page start, and every change after it. The top bar
+     *  gives back its traffic-light inset in full screen — macOS moves those
+     *  buttons out of the content area, and no CSS in the page can see that. */
+    fullScreen: windowFullScreen(),
+    onFullScreen: (fn) => on("veld:window:fullscreen", fn),
     /** Open another full window. With no payload it inherits the app-wide last
      *  selection (what ⌘N does); with one it opens on that worktree. */
     newWindow: (payload) => ipcRenderer.invoke("veld:window:new", payload ?? {}),

--- a/desktop/src/windows.js
+++ b/desktop/src/windows.js
@@ -857,6 +857,19 @@ function openWindow(options = {}) {
   win.on("move", persistWindows);
   win.on("resize", persistWindows);
 
+  // Full screen is main-process knowledge: macOS moves the traffic lights out of
+  // the content area, and the page's top bar has to give back the inset it holds
+  // for them. Nothing in the DOM can see this — `:fullscreen` is the element API
+  // and `display-mode: fullscreen` does not match an Electron window — so the
+  // shell is the only thing that can tell it. The page reads the state it booted
+  // into over `veld:window:fullscreen` (below) and hears about changes here.
+  const sendFullScreen = (fullScreen) => {
+    if (win.isDestroyed()) return;
+    win.webContents.send("veld:window:fullscreen", { fullScreen });
+  };
+  win.on("enter-full-screen", () => sendFullScreen(true));
+  win.on("leave-full-screen", () => sendFullScreen(false));
+
   win.on("close", () => {
     // **Nothing may be given to this window from here on.** `handBack` below drains
     // its queue, while the record stays alive and matchable until `closed` — so a
@@ -1190,6 +1203,24 @@ function registerWindowIpc(ipcMain) {
   ipcMain.on("veld:window:seed", (event) => {
     const win = BrowserWindow.fromWebContents(event.sender);
     event.returnValue = recordFor(win)?.seed ?? null;
+  });
+
+  /**
+   * Whether this window is in native full screen *right now*.
+   *
+   * Synchronous, and read from the preload, for the same reason the seed is: it
+   * has to be true in the renderer's first paint. The top bar reserves 90px for
+   * the traffic lights, full screen takes those lights away, and an answer
+   * arriving a tick later means every reload in full screen — and every full
+   * screen the app is *relaunched* into — flashes an empty gutter before the bar
+   * snaps left.
+   *
+   * Resolved from `event.sender` alone, like the seed: `event.senderFrame` is not
+   * reliably populated at preload time, and only the main frame gets a preload.
+   */
+  ipcMain.on("veld:window:fullscreen", (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    event.returnValue = win && !win.isDestroyed() ? win.isFullScreen() : false;
   });
 
   /**

--- a/tests/validate-topbar-height.sh
+++ b/tests/validate-topbar-height.sh
@@ -8,9 +8,9 @@
 # traffic lights on top of it. No CSS can move those buttons: their position is
 # set once at window creation from `TOPBAR_HEIGHT` in desktop/src/main.js, which
 # desktop/src/windows.js turns into `trafficLightPosition.y` — the value that
-# centres a 12px light against the bar. So the same number lives in a stylesheet
-# and in a main-process constant, in two languages, with nothing tying them
-# together.
+# centres a light of `TRAFFIC_LIGHT_SIZE` against the bar. So the same number
+# lives in a stylesheet and in a main-process constant, in two languages, with
+# nothing tying them together.
 #
 # Drift here is invisible to every other check in the repo: `TOPBAR_HEIGHT` has
 # exactly one consumer, so tsc, biome, clippy and the node suites all stay green
@@ -20,9 +20,9 @@
 #
 # Deliberately narrow: it checks the one pair that produces a visible defect.
 # The traffic-light inset (`padding-left` on `.topbar.electron`) is arithmetic
-# over `x: 13`, `TRAFFIC_LIGHT_SIZE` and macOS's own 20px button pitch — that
-# last number is the OS's and exists nowhere in this repo, so a gate over it
-# would be asserting a constant against itself.
+# over `x: 13`, `TRAFFIC_LIGHT_SIZE` and macOS's own button pitch (23px on
+# macOS 26) — that last number is the OS's and exists nowhere in this repo, so a
+# gate over it would be asserting a constant against itself.
 
 set -euo pipefail
 


### PR DESCRIPTION
## What changed

The traffic lights sat visibly low against the top bar's own controls, nearly touched the mode switcher, and full screen left a 90px gutter where macOS was drawing nothing.

| | before | after |
|---|---|---|
| light centre vs control centre | 21 vs 19.5 (**1.5px low**) | 20 vs 19.5 |
| gap: last light → first control | 5px | 17px |
| full screen | 78px inset for absent buttons | bar starts at the bar's own 10px |

## Root cause

**macOS 26 (Tahoe) grew the window buttons.** `TRAFFIC_LIGHT_SIZE` said 12 — correct from Big Sur through Sequoia, and what every recipe on the internet still says — so `y = (40 - 12) / 2 = 14` centred a circle that is no longer 12px.

Measured off a 2× screenshot of this app's own bar, with the scale confirmed independently against two known CSS values (`--topbar-control-h: 26px` → 52 image px, the 40px bar → 80 image px, both exactly 2.0):

| metric | code assumed | actual |
|---|---|---|
| circle diameter | 12px | **14px** |
| button pitch | 20px | **23px** |
| rightmost light ends at | 65px | **73px** |

The same shot confirmed that `trafficLightPosition` maps straight onto the circle's **top-left corner on both axes** — `x: 13` produced a left edge at exactly 13 — so the diameter was the only wrong input, and no hidden frame offset is involved.

## The three fixes

1. **`TRAFFIC_LIGHT_SIZE` 12 → 14.** `y` becomes 13, putting the centre at 20 against controls that centre at 19.5. Half a pixel is the best an integer `gfx::Point` can do.
2. **Inset 78 → 90px.** 17px after the lights end: more than the 13px they get on their left, and clearly more than the 9px between the bar's own controls, so the OS buttons read as their own group rather than as the first item of ours.
3. **Full screen drops the inset.** macOS moves the lights into the menu-bar overlay, so the shell mirrors `enter-`/`leave-full-screen` onto `<body data-fullscreen>` and `.topbar.electron` falls back to the bar's normal 10px padding.

### Why full screen needs the main process at all

No CSS in the page can see native full screen: `:fullscreen` is about the *element* fullscreen API, and `display-mode: fullscreen` never matches an Electron window. So the state has to come over the bridge.

It is read **synchronously at preload** (`ipcRenderer.sendSync`), the same shape as the window seed and for a weaker but real reason: a reload taken in full screen — or the app relaunching into one — would otherwise paint one frame with a 90px gutter before snapping left.

The flag lands on `<body>` rather than in React state because its one reader is a single CSS rule, and there are two top bars in two modes, neither of which owns the window. It sits beside `data-theme`, which is set the same way for the same reason.

## Pre-Tahoe systems

14 is hardcoded. On macOS ≤ 15 it costs 1px in the other direction and 12px of extra inset. Deliberate: Electron exposes no button metric, so the alternative is a version check that has to be kept correct across future OS releases to buy back a pixel. Written down in `TRAFFIC_LIGHT_SIZE`'s comment.

## Test evidence

`just lint`, `just test` and `just build-ui` all exit 0 — including `tests/validate-topbar-height.sh`, whose comments are corrected here (they hardcoded the 12px/20px numbers in prose; the gate itself only ties `TOPBAR_HEIGHT` to the CSS height and is unaffected).

**Hand-verified by the maintainer** in a running Electron build before review: alignment in both IDE and Runs modes, the new gap, entering and leaving full screen, and a ⌘R reload taken while full screen.

## Review

Maintainer chose a minimal self-review for a change this size (24 lines of behaviour, no stakes path per `docs/agentic-review.md` §3.3). Checked inline: destroyed-window guards on both the send and the sync handler; the preload's `try`/`catch` older-shell fallback matching `windowSeed`'s; CSS specificity (`body[data-fullscreen="true"] .topbar.electron` is (0,3,1) against (0,2,0), so it wins); the browser build, where `desktopWindow` is null and the rule can never match a bar that has no `.electron` class; and no interaction with window persistence, which already reads `getNormalBounds()` precisely so a full-screen window is not remembered at full-screen size.

## Docs

`desktop/ARCHITECTURE.md` records the full-screen mirroring and why CSS cannot do it. No user-visible CLI or config surface, so the rest of the checklist does not apply. No website change — neither `index.html` nor `llms-full.txt` describes the `/ide` bar's geometry.