### PR TITLE
fix(core): interpolate probes and unify the veld-owned environment across node surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,8 @@ Add or strip HTTP headers as requests and responses pass through the reverse pro
 
 Declare `env` at the project, node, or variant level. Variables cascade: variant > node > project (per-key merge, most specific wins). Values support `${...}` variable substitution.
 
+Veld also injects a `VELD_*` environment on **every** surface of a node — the node's process, its readiness and liveness probes, its `on_stop` hook, and `veld action`: `VELD_RUN`, `VELD_RUN_ID`, `VELD_ROOT`, `VELD_PROJECT`, `VELD_NODE`, `VELD_VARIANT`, plus `VELD_PORT`/`VELD_URL`/`VELD_PORT_<NAME>`/`VELD_URL_<NAME>`/`VELD_HOST_<NAME>` on a `long_running` node that has ports. A `command` probe also gets the node's declared `env` and outputs as `$KEY`, and so does an `action` on the node. Probe fields (`path`, `argv`/`shell`) are interpolated like the node's own `argv`/`env`. See [Environment variables](docs/configuration.md#env) in the config reference.
+
 ```json
 {
   "env": { "FEATURE_FLAG": "1" },

--- a/crates/veld-core/src/config.rs
+++ b/crates/veld-core/src/config.rs
@@ -2731,6 +2731,40 @@ pub struct HealthCheck {
     pub interval_ms: u64,
 }
 
+impl HealthCheck {
+    /// Interpolate `${…}` in the string fields of a resolved probe — the HTTP
+    /// `path` and the `command` probe's `argv`/`shell` — exactly as a node's own
+    /// `argv` and `env` are resolved. Port names and the numeric knobs
+    /// (`expect_status`, `seconds`, `timeout_seconds`, `interval_ms`) are not
+    /// templates and are left untouched.
+    ///
+    /// Without this, `${vars.health_path}` in a probe `path` reached the server
+    /// as the literal text `${vars.health_path}` and the node failed with a 404
+    /// — structurally perfect, semantically impossible.
+    pub fn interpolate(
+        &self,
+        ctx: &crate::variables::VariableContext,
+    ) -> Result<Self, crate::variables::VariableError> {
+        let mut out = self.clone();
+        if let Some(path) = &self.path {
+            out.path = Some(crate::variables::interpolate(path, ctx)?);
+        }
+        if let Some(cmd) = self.cmd.spec() {
+            out.cmd = match cmd.interpolate(ctx)? {
+                CommandSpec::Argv(argv) => CommandKeys {
+                    argv: Some(argv),
+                    ..Default::default()
+                },
+                CommandSpec::Shell(shell) => CommandKeys {
+                    shell: Some(shell),
+                    ..Default::default()
+                },
+            };
+        }
+        Ok(out)
+    }
+}
+
 /// Default `settle` window. Long enough to catch a command that fails on
 /// startup (a missing binary, a bad flag, an occupied resource), short enough
 /// that it does not dominate a cold start.
@@ -8789,6 +8823,36 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(liveness.check_type, "command");
+    }
+
+    /// The example the schema ships (`${vars.health_path}` in a probe `path`)
+    /// used to reach the server as literal text — the corpus checked shape and
+    /// serde but never executed a probe. Interpolation must resolve the probe's
+    /// string fields (HTTP `path`, command `argv`/`shell`) with the node's
+    /// context, exactly as `argv` and `env` are.
+    #[test]
+    fn probe_string_fields_are_interpolated() {
+        let mut ctx = crate::variables::VariableContext::new();
+        ctx.set_var("health_path", "/healthz".to_owned());
+        ctx.set_var("probe_cmd", "pg_isready -h localhost".to_owned());
+
+        let hc: HealthCheck = serde_json::from_str(
+            r#"{
+                "type": "http",
+                "path": "${vars.health_path}"
+            }"#,
+        )
+        .unwrap();
+        let resolved = hc.interpolate(&ctx).unwrap();
+        assert_eq!(resolved.path.as_deref(), Some("/healthz"));
+
+        let cmd_hc: HealthCheck =
+            serde_json::from_str(r#"{ "type": "command", "shell": "${vars.probe_cmd}" }"#).unwrap();
+        let resolved = cmd_hc.interpolate(&ctx).unwrap();
+        assert_eq!(
+            resolved.cmd.shell.as_deref(),
+            Some("pg_isready -h localhost")
+        );
     }
 
     // -- Action config tests ---------------------------------------------------

--- a/crates/veld-core/src/health.rs
+++ b/crates/veld-core/src/health.rs
@@ -160,9 +160,14 @@ pub async fn wait_for_http(
 // ---------------------------------------------------------------------------
 
 /// Run a command as a health check. Exit 0 = healthy.
+///
+/// `env` is the environment the probe command runs with — the node's veld-owned
+/// vars plus its declared `env`, so a probe can be parameterised the same way
+/// the node it probes is. Pass an empty map for no extra environment.
 pub async fn wait_for_command_check(
     command: &CommandSpec,
     working_dir: &Path,
+    env: &std::collections::HashMap<String, String>,
     hc: &HealthCheck,
     on_attempt: Option<&AttemptNotifier>,
 ) -> Result<(), HealthError> {
@@ -172,6 +177,15 @@ pub async fn wait_for_command_check(
     let cmd = command.clone();
     let dir = working_dir.to_path_buf();
 
+    // A probe's stderr is the *diagnosis* when it fails, so it cannot be thrown
+    // at /dev/null: capture the last few lines of each failing attempt and the
+    // most recent exit status, and surface them in the timeout error. Without
+    // this a probe that prints "DATABASE_URL is not set" to stderr reports
+    // only "health check timed out after 60s".
+    const TAIL_LINES: usize = 5;
+    let mut tail: Vec<String> = Vec::new();
+    let mut last_exit: Option<i32> = None;
+
     let result = timeout(deadline, async {
         let mut attempt: u32 = 0;
         loop {
@@ -179,13 +193,14 @@ pub async fn wait_for_command_check(
             if let Some(f) = &on_attempt {
                 f(attempt);
             }
-            // Rebuilt each attempt: a `Command` is consumed by `status()`.
-            let status = match crate::process::tokio_command(&cmd) {
+            // Rebuilt each attempt: a `Command` is consumed by `output()`.
+            let output = match crate::process::tokio_command(&cmd) {
                 Ok(mut c) => {
                     c.current_dir(&dir)
+                        .envs(env)
                         .stdout(std::process::Stdio::null())
-                        .stderr(std::process::Stdio::null())
-                        .status()
+                        .stderr(std::process::Stdio::piped())
+                        .output()
                         .await
                 }
                 Err(e) => {
@@ -197,12 +212,26 @@ pub async fn wait_for_command_check(
                 }
             };
 
-            match status {
-                Ok(s) if s.success() => return Ok(()),
-                Ok(s) => {
+            match output {
+                Ok(out) if out.status.success() => return Ok(()),
+                Ok(out) => {
+                    last_exit = Some(out.status.code().unwrap_or(-1));
+                    if !out.stderr.is_empty() {
+                        let stderr = String::from_utf8_lossy(&out.stderr);
+                        for line in stderr.lines() {
+                            let line = line.trim_end();
+                            if !line.is_empty() {
+                                tail.push(line.to_owned());
+                            }
+                        }
+                        let drop = tail.len().saturating_sub(TAIL_LINES);
+                        if drop > 0 {
+                            tail.drain(..drop);
+                        }
+                    }
                     tracing::debug!(
                         command = cmd.display(),
-                        exit_code = s.code().unwrap_or(-1),
+                        exit_code = out.status.code().unwrap_or(-1),
                         "command health check: not yet healthy"
                     );
                 }
@@ -217,10 +246,24 @@ pub async fn wait_for_command_check(
 
     match result {
         Ok(inner) => inner,
-        Err(_) => Err(HealthError::Timeout {
-            timeout_seconds: hc.timeout_seconds,
-            hint: String::new(),
-        }),
+        Err(_) => {
+            let mut hint = String::new();
+            if let Some(code) = last_exit {
+                hint.push_str(&format!(" — last attempt exited with code {code}"));
+            }
+            if !tail.is_empty() {
+                hint.push_str(" — last stderr:\n");
+                for line in &tail {
+                    hint.push_str("    ");
+                    hint.push_str(line);
+                    hint.push('\n');
+                }
+            }
+            Err(HealthError::Timeout {
+                timeout_seconds: hc.timeout_seconds,
+                hint,
+            })
+        }
     }
 }
 
@@ -266,7 +309,14 @@ pub async fn run_health_check(
                     command = cmd.display(),
                     "health check phase 2: running command check"
                 );
-                wait_for_command_check(&cmd, working_dir, hc, None).await?;
+                wait_for_command_check(
+                    &cmd,
+                    working_dir,
+                    &std::collections::HashMap::new(),
+                    hc,
+                    None,
+                )
+                .await?;
                 tracing::info!("health check phase 2: command check passed");
             }
         }
@@ -282,4 +332,68 @@ pub async fn run_health_check(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{CommandKeys, HealthCheck};
+
+    fn failing_probe() -> HealthCheck {
+        HealthCheck {
+            check_type: "command".to_owned(),
+            path: None,
+            expect_status: None,
+            cmd: CommandKeys {
+                shell: Some("echo boom-to-stderr >&2; exit 3".to_owned()),
+                ..Default::default()
+            },
+            port: None,
+            seconds: None,
+            timeout_seconds: 1,
+            interval_ms: 100,
+        }
+    }
+
+    /// A failing command probe used to report only "health check timed out
+    /// after 1s" — its stderr went to /dev/null and its exit status was
+    /// discarded. The whole diagnosis (an echo, a missing env var, a typo'd
+    /// binary) had to be re-derived by hand. The timeout error must carry the
+    /// exit code and the last few stderr lines.
+    #[tokio::test]
+    async fn a_failing_command_probe_reports_its_stderr_and_exit_code() {
+        let hc = failing_probe();
+        let cmd = hc.cmd.spec().expect("probe declares a shell command");
+        let env = std::collections::HashMap::new();
+        let err = wait_for_command_check(&cmd, std::path::Path::new("."), &env, &hc, None)
+            .await
+            .expect_err("a probe that always exits 3 must time out");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("code 3"),
+            "timeout error should name the exit code, got: {msg}"
+        );
+        assert!(
+            msg.contains("boom-to-stderr"),
+            "timeout error should include the captured stderr, got: {msg}"
+        );
+    }
+
+    /// A passing probe still succeeds, and the captured-output machinery must
+    /// not change that.
+    #[tokio::test]
+    async fn a_passing_command_probe_succeeds() {
+        let hc = HealthCheck {
+            cmd: CommandKeys {
+                shell: Some("exit 0".to_owned()),
+                ..Default::default()
+            },
+            ..failing_probe()
+        };
+        let cmd = hc.cmd.spec().unwrap();
+        let env = std::collections::HashMap::new();
+        wait_for_command_check(&cmd, std::path::Path::new("."), &env, &hc, None)
+            .await
+            .expect("an exit-0 probe is healthy");
+    }
 }

--- a/crates/veld-core/src/orchestrator.rs
+++ b/crates/veld-core/src/orchestrator.rs
@@ -681,8 +681,103 @@ fn end_detail_for_error(e: &OrchestratorError) -> EndDetail {
 
 /// A port name as it appears in an environment variable suffix
 /// (`VELD_PORT_<NAME>`, `VELD_URL_<NAME>`).
-fn env_suffix(port_name: &str) -> String {
+pub fn env_suffix(port_name: &str) -> String {
     port_name.to_uppercase().replace('-', "_")
+}
+
+/// The veld-owned context every surface of a node is built from, so the same
+/// `VELD_*` variables reach the node process, its readiness probe, its
+/// `on_stop` hook, and `veld action`.
+#[derive(Debug, Clone)]
+pub struct NodeEnvContext {
+    /// `VELD_RUN` — the run name.
+    pub run_name: String,
+    /// `VELD_RUN_ID` — the run's uuid, when the run row is still live.
+    pub run_id: Option<String>,
+    /// `VELD_ROOT` — the project root.
+    pub project_root: std::path::PathBuf,
+    /// `VELD_PROJECT` — the config's project name.
+    pub project_name: String,
+    /// `VELD_NODE` — this node's name.
+    pub node: String,
+    /// `VELD_VARIANT` — this node's active variant.
+    pub variant: String,
+    /// `VELD_PORT` — the primary port.
+    pub port: Option<u16>,
+    /// `VELD_URL` — the primary routed URL.
+    pub primary_url: Option<String>,
+    /// `VELD_PORT_<NAME>` for each named port.
+    pub named_ports: Vec<(String, u16)>,
+    /// `VELD_HOST_<NAME>` + `VELD_URL_<NAME>` per endpoint
+    /// `(name, hostname, https_url)`.
+    pub endpoints: Vec<(String, String, Option<String>)>,
+}
+
+impl NodeEnvContext {
+    /// From a persisted [`crate::state::NodeState`] — used by the `on_stop`
+    /// hook, the liveness monitor, and `veld action`, which have the node's
+    /// recorded port, url and endpoints rather than the pre-computed start-time
+    /// server info.
+    pub fn from_node_state(
+        run_name: &str,
+        run_id: Option<String>,
+        project_root: &std::path::Path,
+        project_name: &str,
+        node_state: &crate::state::NodeState,
+    ) -> Self {
+        let mut named_ports = Vec::new();
+        let mut endpoints = Vec::new();
+        for (name, e) in node_state.endpoints_or_legacy() {
+            named_ports.push((name.clone(), e.port));
+            endpoints.push((name, e.hostname, e.url));
+        }
+        Self {
+            run_name: run_name.to_owned(),
+            run_id,
+            project_root: project_root.to_owned(),
+            project_name: project_name.to_owned(),
+            node: node_state.node_name.clone(),
+            variant: node_state.variant.clone(),
+            port: node_state.port,
+            primary_url: node_state.url.clone(),
+            named_ports,
+            endpoints,
+        }
+    }
+}
+
+/// Build the veld-owned environment (`VELD_RUN`, `VELD_ROOT`, the port/url/host
+/// family) shared by every surface of a node. One builder, used by all of them,
+/// so a variable cannot be reachable in one place and not another.
+pub fn veld_owned_env(ctx: &NodeEnvContext) -> std::collections::HashMap<String, String> {
+    let mut env = std::collections::HashMap::new();
+    env.insert("VELD_RUN".to_owned(), ctx.run_name.clone());
+    if let Some(rid) = &ctx.run_id {
+        env.insert("VELD_RUN_ID".to_owned(), rid.clone());
+    }
+    env.insert(
+        "VELD_ROOT".to_owned(),
+        ctx.project_root.to_string_lossy().into_owned(),
+    );
+    env.insert("VELD_PROJECT".to_owned(), ctx.project_name.clone());
+    env.insert("VELD_NODE".to_owned(), ctx.node.clone());
+    env.insert("VELD_VARIANT".to_owned(), ctx.variant.clone());
+    if let Some(port) = ctx.port {
+        env.insert("VELD_PORT".to_owned(), port.to_string());
+    }
+    if let Some(url) = &ctx.primary_url {
+        env.insert("VELD_URL".to_owned(), url.clone());
+    }
+    for (name, port) in &ctx.named_ports {
+        env.insert(format!("VELD_PORT_{}", env_suffix(name)), port.to_string());
+    }
+    for (name, host, url) in &ctx.endpoints {
+        env.insert(format!("VELD_HOST_{}", env_suffix(name)), host.clone());
+        if let Some(url) = url {
+            env.insert(format!("VELD_URL_{}", env_suffix(name)), url.clone());
+        }
+    }
+    env
 }
 
 /// One routed HTTP port: the hostname veld minted for it and the URL that
@@ -1858,13 +1953,25 @@ impl Orchestrator {
                 .unwrap_or_else(|| config::CommandSpec::Shell(String::new())),
         };
         let resolved_cmd = raw_cmd.interpolate(&var_ctx)?;
-        let (env, env_secret_keys) = build_env(
+        let (mut env, env_secret_keys) = build_env(
             resolved.env.as_ref(),
             &var_ctx,
             &format!("nodes.{}.variants.{}", sel.node, sel.variant),
             &self.project_root,
         )
         .await?;
+        env.extend(veld_owned_env(&NodeEnvContext {
+            run_name: run_name.to_owned(),
+            run_id: Some(run.run_id.to_string()),
+            project_root: self.project_root.clone(),
+            project_name: self.config.name.clone(),
+            node: sel.node.clone(),
+            variant: sel.variant.clone(),
+            port: None,
+            primary_url: None,
+            named_ports: Vec::new(),
+            endpoints: Vec::new(),
+        }));
 
         let key = RunState::node_key(&sel.node, &sel.variant);
 
@@ -2240,6 +2347,48 @@ impl Orchestrator {
             run.execution_order.clone()
         };
 
+        // Snapshot every node's recorded outputs so a stop-time
+        // `${nodes.<node>.<field>}` reference — e.g. the dev-daemon's port a
+        // wrapper hook must forget — resolves from persisted state. The node it
+        // names may already be stopped by the time the referencing hook runs,
+        // but its recorded outputs are exactly what teardown needs.
+        //
+        // Rebuild the same accessors the start path published per node
+        // (`port`, `ports.<name>`, `url` + pieces, `hosts.<name>`, `urls.<name>`)
+        // from each persisted state, because `NodeState.outputs` alone holds
+        // only `ports.<name>` — the bare `${nodes.X.port}` a teardown is most
+        // likely to reference is a separate field.
+        let all_node_outputs: std::collections::HashMap<
+            String,
+            std::collections::HashMap<String, String>,
+        > = run
+            .nodes
+            .values()
+            .map(|ns| {
+                let mut out = ns.outputs.clone();
+                if let Some(port) = ns.port {
+                    out.insert("port".to_owned(), port.to_string());
+                }
+                if let Some(url) = &ns.url {
+                    for (key, value) in url_builtins(url) {
+                        out.insert(key.to_owned(), value);
+                    }
+                }
+                for (name, endpoint) in ns.endpoints_or_legacy() {
+                    out.insert(
+                        format!("hosts.{name}"),
+                        url::hostname_of_url(&endpoint.hostname).to_owned(),
+                    );
+                    if let Some(url) = &endpoint.url {
+                        for (key, value) in port_url_builtins(&name, url) {
+                            out.insert(key, value);
+                        }
+                    }
+                }
+                (ns.node_name.clone(), out)
+            })
+            .collect();
+
         for key in node_keys.iter().rev() {
             if let Some(node_state) = run.nodes.get_mut(key) {
                 self.internal_log(&format!(
@@ -2262,8 +2411,14 @@ impl Orchestrator {
 
                 // Run on_stop hook if defined (skip nodes that never ran).
                 if node_state.status != NodeStatus::Pending {
-                    self.run_on_stop_hook(run_name, Some(run_id), &stop_vars, node_state)
-                        .await;
+                    self.run_on_stop_hook(
+                        run_name,
+                        Some(run_id),
+                        &stop_vars,
+                        &all_node_outputs,
+                        node_state,
+                    )
+                    .await;
                 }
 
                 node_state.status = NodeStatus::Stopped;
@@ -2541,11 +2696,17 @@ impl Orchestrator {
     }
 
     /// Run the `on_stop` hook for a node if one is defined in the config.
+    ///
+    /// `all_outputs` is every node's recorded outputs (keyed by node name), so
+    /// a stop-time `${nodes.<node>.<field>}` reference — the half of the
+    /// vocabulary that historically did *not* resolve at stop — finds the value
+    /// from persisted state just as the node's own `on_stop` did at start.
     async fn run_on_stop_hook(
         &self,
         run_name: &str,
         run_id: Option<uuid::Uuid>,
         vars: &HashMap<String, String>,
+        all_outputs: &HashMap<String, HashMap<String, String>>,
         node_state: &NodeState,
     ) {
         let variant_cfg = match self
@@ -2616,6 +2777,17 @@ impl Orchestrator {
                 ctx.set_builtin(k, v.clone());
             }
         }
+        // Cross-node `${nodes.<node>.<field>}` references resolve here too, from
+        // the persisted run state. This is the half of the vocabulary that used
+        // to *not* resolve at stop: `build_env` was all-or-nothing, so a single
+        // `${nodes.dev-daemon.port}` emptied the whole map and the hook ran
+        // blind. A node's teardown references a sibling's output precisely
+        // because that sibling is being torn down alongside it.
+        for (other_node, outputs) in all_outputs {
+            for (field, value) in outputs {
+                ctx.set_node_output(&format!("nodes.{other_node}.{field}"), value.clone());
+            }
+        }
         if let Some(port) = node_state.port {
             ctx.set_builtin("port", port.to_string());
         }
@@ -2679,10 +2851,10 @@ impl Orchestrator {
             }
         };
 
-        // Build env (variant > node > project).
+        // Build env (variant > node > project), then add the veld-owned vars.
         let node_cfg_opt = self.config.nodes.get(&node_state.node_name);
         let merged_env = resolved.env.clone();
-        let env = match build_env(
+        let mut env = match build_env(
             merged_env.as_ref(),
             &ctx,
             &format!(
@@ -2695,14 +2867,32 @@ impl Orchestrator {
         {
             Ok((env, _)) => env,
             Err(e) => {
+                // A teardown hook that cannot resolve its environment must NOT
+                // run with an empty one: the hook would execute and still be
+                // blind, which is how the wrapper it was meant to clean up
+                // outlives its run. Skip the hook and say so loudly, exactly as
+                // the command-interpolation failure path above does.
+                eprintln!(
+                    "  ! teardown hook for {}:{} was SKIPPED: could not resolve its environment: {e}\n    \
+                     Anything it was meant to clean up (containers, volumes, \
+                     temp state) has been left behind.",
+                    node_state.node_name, node_state.variant,
+                );
                 tracing::warn!(
                     node = node_state.node_name,
                     error = %e,
-                    "failed to resolve on_stop env variables, using empty env"
+                    "failed to resolve on_stop env variables — hook skipped"
                 );
-                HashMap::new()
+                return;
             }
         };
+        env.extend(veld_owned_env(&NodeEnvContext::from_node_state(
+            run_name,
+            run_id.map(|id| id.to_string()),
+            &self.project_root,
+            &self.config.name,
+            node_state,
+        )));
 
         // Resolve working directory (variant > node > project root).
         let working_dir = resolve_working_dir(
@@ -3654,28 +3844,29 @@ async fn execute_start_server_isolated(
     // Env keys declared `secret: true` are masked and encrypted at rest just like
     // sensitive outputs — same machinery, extended rather than duplicated.
     node_state.sensitive_keys.extend(env_secret_keys);
-    if let Some(port) = port {
-        env.insert("VELD_PORT".to_owned(), port.to_string());
-    }
-    for (name, value) in &precomputed.named_ports {
-        env.insert(format!("VELD_PORT_{}", env_suffix(name)), value.to_string());
-    }
-    if let Some(url) = &https_url {
-        env.insert("VELD_URL".to_owned(), url.clone());
-    }
-    // Mirrors `VELD_PORT_<NAME>`: a child can find a sibling endpoint without
-    // the config threading it through `env`. `VELD_HOST_<NAME>` exists for every
-    // port — it is the piece a connection string needs and the only one a `tcp`
-    // port has — while `VELD_URL_<NAME>` is routed ports only.
-    for (name, endpoint) in &precomputed.endpoints {
-        env.insert(
-            format!("VELD_HOST_{}", env_suffix(name)),
-            endpoint.hostname.clone(),
-        );
-        if let Some(url) = &endpoint.https_url {
-            env.insert(format!("VELD_URL_{}", env_suffix(name)), url.clone());
-        }
-    }
+    // The veld-owned environment — `VELD_RUN`/`VELD_ROOT`/`VELD_NODE`/… plus the
+    // port/url/host family — from the single builder every surface shares, so a
+    // var cannot be reachable in the node process but not its `on_stop` hook.
+    env.extend(veld_owned_env(&NodeEnvContext {
+        run_name: ctx.run_name.clone(),
+        run_id: Some(ctx.run_id.to_string()),
+        project_root: ctx.project_root.to_path_buf(),
+        project_name: ctx.config.name.clone(),
+        node: sel.node.clone(),
+        variant: sel.variant.clone(),
+        port,
+        primary_url: https_url.clone(),
+        named_ports: precomputed
+            .named_ports
+            .iter()
+            .map(|(n, v)| (n.clone(), *v))
+            .collect(),
+        endpoints: precomputed
+            .endpoints
+            .iter()
+            .map(|(n, e)| (n.clone(), e.hostname.clone(), e.https_url.clone()))
+            .collect(),
+    }));
 
     // Resolve synthetic outputs.
     //
@@ -3785,6 +3976,29 @@ async fn execute_start_server_isolated(
     .await;
     // Use probes.readiness if available, falling back to legacy health_check.
     if let Some(hc) = resolved.readiness.clone() {
+        // Interpolate the probe's `path`/`argv`/`shell` with the node's context,
+        // exactly as the node's own `argv` and `env` are. A `${vars.…}` that
+        // cannot resolve is a config the node could never pass, so fail it
+        // loudly here rather than 404-ing forever against a literal reference.
+        let hc = match hc.interpolate(var_ctx) {
+            Ok(hc) => hc,
+            Err(e) => {
+                return Err(OrchestratorError::NodeFailed {
+                    node: sel.node.clone(),
+                    variant: sel.variant.clone(),
+                    reason: format!("readiness probe could not be resolved: {e}"),
+                });
+            }
+        };
+        // The probe is an operation *on this node*, so it gets the node's own
+        // environment (declared `env` + veld-owned vars) plus the node's
+        // outputs as `$KEY` — the same `$KEY` an action on the node gets. A
+        // `command` probe must be able to see `VELD_PORT` and the node's env,
+        // or it cannot check anything parameterised.
+        let mut probe_env = env.clone();
+        for (k, v) in &node_state.outputs {
+            probe_env.insert(k.clone(), v.clone());
+        }
         node_state.status = NodeStatus::HealthChecking;
         node_state.readiness_phases.push(ReadinessPhase {
             phase: 1,
@@ -4023,6 +4237,7 @@ async fn execute_start_server_isolated(
                         health::wait_for_command_check(
                             &cmd,
                             &working_dir,
+                            &probe_env,
                             &hc,
                             Some(&phase2_notifier),
                         )
@@ -4170,7 +4385,7 @@ async fn execute_command_isolated(
     let resolved_cmd = raw_cmd.interpolate(var_ctx)?;
 
     // Build env (variant > node > project).
-    let (env, env_secret_keys) = build_env(
+    let (mut env, env_secret_keys) = build_env(
         resolved.env.as_ref(),
         var_ctx,
         &format!("nodes.{}.variants.{}", sel.node, sel.variant),
@@ -4178,6 +4393,20 @@ async fn execute_command_isolated(
     )
     .await?;
     node_state.sensitive_keys.extend(env_secret_keys);
+    // The veld-owned vars reach a `command` node too — it has no port, but it
+    // still gets VELD_RUN/VELD_ROOT/VELD_NODE/VELD_VARIANT.
+    env.extend(veld_owned_env(&NodeEnvContext {
+        run_name: ctx.run_name.clone(),
+        run_id: Some(ctx.run_id.to_string()),
+        project_root: ctx.project_root.to_path_buf(),
+        project_name: ctx.config.name.clone(),
+        node: sel.node.clone(),
+        variant: sel.variant.clone(),
+        port: None,
+        primary_url: None,
+        named_ports: Vec::new(),
+        endpoints: Vec::new(),
+    }));
 
     if let Some(files) = &resolved.files {
         crate::values::deliver_files(
@@ -4358,6 +4587,37 @@ async fn execute_command_isolated(
     if result.exit_code == 0 {
         // Run readiness probe if configured (probes.readiness on command nodes).
         if let Some(hc) = resolved.readiness.clone() {
+            // Interpolate the probe's `argv`/`shell` with the node's context.
+            let hc = match hc.interpolate(var_ctx) {
+                Ok(hc) => hc,
+                Err(e) => {
+                    return Err(OrchestratorError::NodeFailed {
+                        node: sel.node.clone(),
+                        variant: sel.variant.clone(),
+                        reason: format!("readiness probe could not be resolved: {e}"),
+                    });
+                }
+            };
+            // The probe sees the node's declared env plus the veld-owned vars
+            // (a command node has no port, but it still gets VELD_RUN/VELD_ROOT)
+            // plus the node's outputs as `$KEY`.
+            let mut probe_env = env.clone();
+            probe_env.extend(veld_owned_env(&NodeEnvContext {
+                run_name: ctx.run_name.clone(),
+                run_id: Some(ctx.run_id.to_string()),
+                project_root: ctx.project_root.to_path_buf(),
+                project_name: ctx.config.name.clone(),
+                node: sel.node.clone(),
+                variant: sel.variant.clone(),
+                port: None,
+                primary_url: None,
+                named_ports: Vec::new(),
+                endpoints: Vec::new(),
+            }));
+            for (k, v) in &node_state.outputs {
+                probe_env.insert(k.clone(), v.clone());
+            }
+
             node_state.status = NodeStatus::HealthChecking;
             emit_progress(
                 &ctx.progress_tx,
@@ -4373,8 +4633,14 @@ async fn execute_command_isolated(
             let probe_result = match hc.check_type.as_str() {
                 "command" | "bash" => {
                     if let Some(cmd) = hc.cmd.spec() {
-                        health::wait_for_command_check(&cmd, &working_dir, &hc, Some(&notifier))
-                            .await
+                        health::wait_for_command_check(
+                            &cmd,
+                            &working_dir,
+                            &probe_env,
+                            &hc,
+                            Some(&notifier),
+                        )
+                        .await
                     } else {
                         Ok(())
                     }
@@ -4509,7 +4775,10 @@ async fn wait_for_process_exit(pid: u32) {
 ///
 /// Returns the resolved values plus the keys declared `secret`, so the caller can
 /// mark them sensitive without the values themselves needing a wrapper type.
-async fn build_env(
+/// Resolve a node's declared `env` map against a context — the single resolver
+/// for every surface, so a value means the same thing in the node process, its
+/// `on_stop` hook, and `veld action`.
+pub async fn build_env(
     env_config: Option<&HashMap<String, config::ConfigValue>>,
     ctx: &VariableContext,
     at_prefix: &str,
@@ -4571,6 +4840,47 @@ fn whoami_hostname() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The veld-owned env must reach every surface from one builder, with the
+    /// same names — `VELD_RUN`/`VELD_ROOT`/`VELD_NODE`/… plus the port/url/host
+    /// family wherever the node has ports.
+    #[test]
+    fn veld_owned_env_builds_the_shared_variables() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = veld_owned_env(&NodeEnvContext {
+            run_name: "dev".to_owned(),
+            run_id: Some("abc-123".to_owned()),
+            project_root: tmp.path().to_path_buf(),
+            project_name: "myproj".to_owned(),
+            node: "api".to_owned(),
+            variant: "local".to_owned(),
+            port: Some(3456),
+            primary_url: Some("https://api.dev.localhost".to_owned()),
+            named_ports: vec![("debug".to_owned(), 9999)],
+            endpoints: vec![("db".to_owned(), "db.localhost".to_owned(), None)],
+        });
+        assert_eq!(env.get("VELD_RUN").map(String::as_str), Some("dev"));
+        assert_eq!(env.get("VELD_RUN_ID").map(String::as_str), Some("abc-123"));
+        assert_eq!(env.get("VELD_NODE").map(String::as_str), Some("api"));
+        assert_eq!(env.get("VELD_VARIANT").map(String::as_str), Some("local"));
+        assert_eq!(
+            env.get("VELD_ROOT").map(String::as_str),
+            Some(tmp.path().to_str().unwrap())
+        );
+        assert_eq!(env.get("VELD_PROJECT").map(String::as_str), Some("myproj"));
+        assert_eq!(env.get("VELD_PORT").map(String::as_str), Some("3456"));
+        assert_eq!(
+            env.get("VELD_URL").map(String::as_str),
+            Some("https://api.dev.localhost")
+        );
+        assert_eq!(env.get("VELD_PORT_DEBUG").map(String::as_str), Some("9999"));
+        assert_eq!(
+            env.get("VELD_HOST_DB").map(String::as_str),
+            Some("db.localhost")
+        );
+        // A `tcp` port has a hostname but no URL — that key must be absent.
+        assert!(!env.contains_key("VELD_URL_DB"));
+    }
 
     /// Records what a [`stats::StepObserver`] was told, in order.
     #[derive(Default)]
@@ -5498,6 +5808,71 @@ mod tests {
             resolved, "testrun|12345|svc|local|SHADOW|9999",
             "${{veld.run}} must stay the run name and ${{veld.port}} the allocated \
              port; the same-named outputs are reachable only as ${{output.*}}"
+        );
+    }
+
+    /// The second half of §4: a stop-time `${nodes.<other>.<field>}` reference
+    /// used to fail to resolve — `build_env` was all-or-nothing, so one
+    /// `${nodes.dev-daemon.port}` emptied the whole map and the hook ran blind.
+    /// Cross-node refs, including the bare `port` accessor, must now resolve
+    /// from the persisted run state.
+    #[tokio::test]
+    async fn on_stop_resolves_cross_node_references() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_root = tmp.path();
+        let marker = project_root.join("stop-marker");
+
+        let config: VeldConfig = serde_json::from_str(&format!(
+            r#"{{
+                "schemaVersion": "3",
+                "name": "testcfg",
+                "nodes": {{
+                    "dev-daemon": {{"default_variant": "local", "variants": {{
+                        "local": {{"type": "start_server", "shell": "sleep 30"}}
+                    }}}},
+                    "dev-link": {{"default_variant": "local", "variants": {{
+                        "local": {{
+                            "type": "command",
+                            "shell": "true",
+                            "on_stop": "printf '%s' \"${{nodes.dev-daemon.port}}|${{nodes.dev-daemon.url.hostname}}\" > {}"
+                        }}
+                    }}}}
+                }}
+            }}"#,
+            marker.display()
+        ))
+        .unwrap();
+
+        let mut orch = test_orchestrator(project_root, config.clone());
+        let mut run = RunState::new("testrun", &config.name);
+        run.status = RunStatus::Running;
+
+        let mut daemon = NodeState::new("dev-daemon", "local");
+        daemon.status = NodeStatus::Healthy;
+        daemon.port = Some(12345);
+        daemon.url = Some("https://dev-daemon.testrun.testcfg.localhost".to_owned());
+        run.nodes
+            .insert(RunState::node_key("dev-daemon", "local"), daemon);
+
+        let mut link = NodeState::new("dev-link", "local");
+        link.status = NodeStatus::Healthy;
+        run.nodes
+            .insert(RunState::node_key("dev-link", "local"), link);
+
+        // Started first, torn down last — so dev-link's hook runs while the
+        // daemon's state is still present.
+        run.execution_order
+            .push(RunState::node_key("dev-daemon", "local"));
+        run.execution_order
+            .push(RunState::node_key("dev-link", "local"));
+        orch.save_state(&run).unwrap();
+
+        orch.stop("testrun").await.expect("stop");
+
+        let resolved = std::fs::read_to_string(&marker).expect("dev-link on_stop must have run");
+        assert_eq!(
+            resolved, "12345|dev-daemon.testrun.testcfg.localhost",
+            "${{nodes.dev-daemon.port}} and its url.hostname must resolve at stop time"
         );
     }
 

--- a/crates/veld-daemon/src/monitor.rs
+++ b/crates/veld-daemon/src/monitor.rs
@@ -276,8 +276,17 @@ async fn run_liveness_checks(
                 .await;
         }
 
-        let check_result =
-            run_single_liveness_check(liveness, &working_dir, run, key, user_path).await;
+        let check_result = run_single_liveness_check(
+            liveness,
+            &working_dir,
+            run,
+            key,
+            project_root,
+            project_name,
+            run_name,
+            user_path,
+        )
+        .await;
 
         let node_state = match run.nodes.get_mut(key) {
             Some(ns) => ns,
@@ -513,11 +522,15 @@ impl LivenessFailure {
 
 /// Run a single liveness check for a node.
 /// Returns `Ok(())` if healthy, else why it did not pass — see [`LivenessFailure`].
+#[allow(clippy::too_many_arguments)]
 async fn run_single_liveness_check(
     liveness: &LivenessProbe,
     working_dir: &Path,
     run: &veld_core::state::RunState,
     node_key: &str,
+    project_root: &Path,
+    project_name: &str,
+    run_name: &str,
     user_path: &str,
 ) -> Result<(), LivenessFailure> {
     let node_state = match run.nodes.get(node_key) {
@@ -541,7 +554,18 @@ async fn run_single_liveness_check(
                         .current_dir(working_dir)
                         .stdout(std::process::Stdio::null())
                         .stderr(std::process::Stdio::piped())
-                        .env("PATH", user_path);
+                        .env("PATH", user_path)
+                        // The veld-owned vars — VELD_RUN, VELD_ROOT, the
+                        // port/url/host family — from the shared builder.
+                        .envs(veld_core::orchestrator::veld_owned_env(
+                            &veld_core::orchestrator::NodeEnvContext::from_node_state(
+                                run_name,
+                                Some(run.run_id.to_string()),
+                                project_root,
+                                project_name,
+                                node_state,
+                            ),
+                        ));
                     // Inject node outputs as environment variables so probe
                     // commands can reference them (e.g., pg_isready -h $DB_HOST).
                     for (key, value) in &node_state.outputs {
@@ -861,9 +885,18 @@ mod tests {
         // No port to connect to: unrunnable, whatever the node is doing.
         for check_type in ["port", "http"] {
             let run = run_with_node(None);
-            let err = run_single_liveness_check(&probe(check_type), &dir, &run, "web:local", "")
-                .await
-                .expect_err("a port-shaped probe with no port cannot pass");
+            let err = run_single_liveness_check(
+                &probe(check_type),
+                &dir,
+                &run,
+                "web:local",
+                &dir,
+                "proj",
+                "dev",
+                "",
+            )
+            .await
+            .expect_err("a port-shaped probe with no port cannot pass");
             assert!(
                 matches!(err, LivenessFailure::Unrunnable(_)),
                 "{check_type}: {}",
@@ -873,9 +906,18 @@ mod tests {
 
         // A type veld does not implement: also unrunnable, not "unhealthy".
         let run = run_with_node(Some(3000));
-        let err = run_single_liveness_check(&probe("htpp"), &dir, &run, "web:local", "")
-            .await
-            .expect_err("an unknown probe type cannot pass");
+        let err = run_single_liveness_check(
+            &probe("htpp"),
+            &dir,
+            &run,
+            "web:local",
+            &dir,
+            "proj",
+            "dev",
+            "",
+        )
+        .await
+        .expect_err("an unknown probe type cannot pass");
         assert!(
             matches!(err, LivenessFailure::Unrunnable(_)),
             "{}",
@@ -885,9 +927,18 @@ mod tests {
         // A real check against a port nothing is listening on DID run, and
         // failed — that one counts, because a restart can fix it.
         let run = run_with_node(Some(1));
-        let err = run_single_liveness_check(&probe("port"), &dir, &run, "web:local", "")
-            .await
-            .expect_err("nothing is listening on port 1");
+        let err = run_single_liveness_check(
+            &probe("port"),
+            &dir,
+            &run,
+            "web:local",
+            &dir,
+            "proj",
+            "dev",
+            "",
+        )
+        .await
+        .expect_err("nothing is listening on port 1");
         assert!(
             matches!(err, LivenessFailure::Failed(_)),
             "{}",

--- a/crates/veld/src/commands/action.rs
+++ b/crates/veld/src/commands/action.rs
@@ -142,7 +142,7 @@ pub async fn run(
         variant_cfg.and_then(|v| v.cwd.as_deref()),
     );
 
-    let env = match build_env(node_state, action, &ctx) {
+    let env = match build_env(&cfg, run_state, &project_root, node_state, action, &ctx).await {
         Ok(env) => env,
         Err(e) => {
             output::print_error(&format!("Failed to resolve action parameters: {e}"), json);
@@ -386,14 +386,57 @@ fn build_context(
 }
 
 /// Build the environment for the spawned shell: inherit the parent env, then
-/// export the node's live outputs and the action's resolved parameters as
-/// `$KEY` variables, plus a few `VELD_*` context variables.
-fn build_env(
+/// the node's declared `env`, the node's live outputs as `$KEY`, the action's
+/// resolved parameters, and the veld-owned `VELD_*` variables.
+///
+/// Precedence (lowest to highest): inherited parent env < node `env` < node
+/// outputs < action parameters. Outputs are the freshest truth about the live
+/// node, so they win over the env it was started with; the action's own params
+/// win over both. This is the same ordering the orchestrator uses, so an action
+/// sees what the node it runs against sees.
+async fn build_env(
+    config: &VeldConfig,
+    run_state: &RunState,
+    project_root: &Path,
     node_state: &NodeState,
     action: &ActionConfig,
     ctx: &VariableContext,
-) -> Result<HashMap<String, String>, variables::VariableError> {
+) -> Result<HashMap<String, String>, String> {
     let mut env: HashMap<String, String> = std::env::vars().collect();
+
+    // The node's declared `env` (variant > node > project), resolved with the
+    // same builder the node process uses, so an action on a node can read the
+    // very variables the node was started with — a `stop-container` action
+    // needs the `CONTAINER_NAME` the node was given. Previously an action had
+    // to re-derive it in its own argv.
+    //
+    // Best-effort, never action-fatal: an action's interpolation context has no
+    // `${vars.*}` (by design — see the Availability notes), so a node env that
+    // references a var cannot resolve here. That must not block the action it
+    // was attached to; it just means that env doesn't reach the action.
+    if let Some(resolved) = config.resolved(&node_state.node_name, &node_state.variant) {
+        if let Some(env_cfg) = resolved.env {
+            if let Ok((node_env, _)) = veld_core::orchestrator::build_env(
+                Some(&env_cfg),
+                ctx,
+                &format!(
+                    "nodes.{}.variants.{}",
+                    node_state.node_name, node_state.variant
+                ),
+                project_root,
+            )
+            .await
+            {
+                env.extend(node_env);
+            } else {
+                tracing::warn!(
+                    node = node_state.node_name,
+                    variant = node_state.variant,
+                    "action could not resolve the node's declared env — it will not be exposed to the action"
+                );
+            }
+        }
+    }
 
     // Node outputs first; parameters can intentionally override them.
     for (k, v) in &node_state.outputs {
@@ -401,12 +444,25 @@ fn build_env(
     }
     if let Some(params) = &action.parameters {
         for (k, v) in params {
-            env.insert(k.clone(), variables::interpolate(v, ctx)?);
+            env.insert(
+                k.clone(),
+                variables::interpolate(v, ctx).map_err(|e| e.to_string())?,
+            );
         }
     }
 
-    env.insert("VELD_NODE".to_owned(), node_state.node_name.clone());
-    env.insert("VELD_VARIANT".to_owned(), node_state.variant.clone());
+    // The veld-owned vars — `VELD_RUN`, `VELD_ROOT`, `VELD_PORT`/`VELD_URL`/
+    // `VELD_HOST_*`, `VELD_NODE`, `VELD_VARIANT` — from the shared builder, so
+    // an action sees the same family the node's own process and `on_stop` do.
+    env.extend(veld_core::orchestrator::veld_owned_env(
+        &veld_core::orchestrator::NodeEnvContext::from_node_state(
+            run_state.name.as_str(),
+            Some(run_state.run_id.to_string()),
+            project_root,
+            &config.name,
+            node_state,
+        ),
+    ));
 
     Ok(env)
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -659,6 +659,13 @@ object:
 "skip_if": { "shell": "test -f .migrated" }
 ```
 
+Probe fields — an `http` probe's `path`, and a `command` probe's `argv`/`shell`
+— are interpolated with the node's context too, exactly like the node's own
+`argv`/`env`. A `${vars.health_path}` in a probe `path` resolves to the var's
+value rather than being sent to the server as literal text. (The committed
+example `schema/v3/examples/vars-and-values.json` does exactly this and is the
+proof the fix works.)
+
 #### `command` (removed)
 
 `command` was the single shell-string form in `schemaVersion` 1 and 2. Neither
@@ -741,7 +748,16 @@ stop.
 
 #### Strategy: `command`
 
-Runs a shell command and checks the exit code. Exit code `0` means healthy.
+Runs a shell command and checks the exit code. Exit code `0` means healthy. The
+command runs with the node's declared `env`, the veld-owned `VELD_*` variables
+(including `VELD_PORT` on a node that has one), and the node's outputs as
+`$KEY` — so a probe can be parameterised the same way the node it probes is.
+
+When a `command` probe fails, its **stderr and exit code are included in the
+timeout error** rather than thrown away: `health check timed out after 30s —
+last attempt exited with code 1 — last stderr:
+    DATABASE_URL is not set`. A probe that prints why it failed no longer makes
+you re-derive the answer.
 
 ```json
 "health_check": {
@@ -821,7 +837,7 @@ Runs continuously after the node becomes healthy. Detects failures like dropped 
 
 - **`http`**: Polls an HTTP endpoint. Passes when the expected status code is returned.
 - **`port`**: Checks if a TCP port is accepting connections.
-- **`command`**: Runs an arbitrary shell command (via `sh -c`). Exit code `0` means healthy, non-zero means unhealthy. Pipes, redirects, and `&&` chains all work. The node's outputs are injected as environment variables, so you can reference them directly (e.g., `pg_isready -h $DB_HOST -p $DB_PORT`).
+- **`command`**: Runs an arbitrary shell command (via `sh -c`). Exit code `0` means healthy, non-zero means unhealthy. Pipes, redirects, and `&&` chains all work. The node's outputs, its declared `env`, and the veld-owned `VELD_*` variables are injected as environment variables, so you can reference them directly (e.g., `pg_isready -h $DB_HOST -p $DB_PORT`). A failing probe's stderr and exit code appear in the health message.
 
 `settle` is **not** one of them: it describes startup, so a liveness `settle`
 would pass forever. A node with no port has exactly one usable liveness type,
@@ -873,6 +889,23 @@ Extra environment variables injected into the process. Values support Veld varia
 **Precedence:** The merged `env` block takes strict precedence over the inherited shell environment. Shell variables not overridden by `env` are passed through unchanged.
 
 **Which shell environment gets inherited depends on who started the run.** `veld start` in a terminal passes your terminal's environment straight through, including anything exported from `.zprofile`/`.profile` and `.zshrc`. A run started from the management UI or Veld Desktop is spawned by the Veld daemon, which inherits only `PATH` — resolved from your login shell so `npx`, `pg_isready`, `op` and version-manager shims are found — and not the rest of your shell environment. So a node that depends on a variable you export from a shell rc file works from the terminal and not from the UI. Declare it in `env` and it works from both; that is the only form that doesn't depend on how the run was launched.
+
+#### The veld-owned environment
+
+In addition to your declared `env`, Veld injects a set of `VELD_*` variables on **every** surface of a node — the node's own process, its readiness and liveness probes, its `on_stop` hook, and `veld action` — so a variable is never reachable in one place and not another. The always-on ones:
+
+| Variable | Meaning |
+|---|---|
+| `VELD_RUN` | The run name (`--name`) |
+| `VELD_RUN_ID` | The run's UUID (absent on a stop path that has no live run row) |
+| `VELD_ROOT` | The project root |
+| `VELD_PROJECT` | The config's project name |
+| `VELD_NODE` | This node's name |
+| `VELD_VARIANT` | This node's active variant |
+
+A `long_running` node with ports gets the port/url/host family too, exactly the ones its process already had: `VELD_PORT` (primary), `VELD_PORT_<NAME>`, `VELD_URL` (primary), `VELD_URL_<NAME>` (routed ports only), and `VELD_HOST_<NAME>` (every port, `tcp` included). Port names are upper-cased with `-` → `_`.
+
+**Reachability:** an `action` on a node also receives the node's declared `env` (it previously did not), and a `command` probe receives the node's declared `env`, the veld-owned vars, and the node's outputs as `$KEY`. So an action can read the `CONTAINER_NAME` its node was started with, and a probe can check against `VELD_PORT` or any env the node itself has.
 
 ### `outputs`
 
@@ -995,7 +1028,14 @@ declaring its own, and **disables it with `"on_stop": null`**:
 The `on_stop` command receives the same variable context that was available during start:
 - Every `${veld.*}` built-in the node itself had — for a `long_running` node that includes `${veld.port}`, `${veld.url}`, `${veld.url.hostname}` and the rest of the URL family, and `${veld.ports.<name>}`. See [Availability](#availability).
 - This node's outputs as `${output.KEY}`, and its own as `${nodes.<self>.KEY}` (including the automatic `exit_code` of a `command` node)
-- Environment variables from the variant's `env` block
+- **Any** node's outputs as `${nodes.<node>.<field>}` — a cross-node reference resolves at stop time from the run's persisted state, so a teardown can forget the sibling it was told to point at (e.g. the `dev-daemon`'s port a wrapper must stop serving)
+- Environment variables from the variant's `env` block, plus the veld-owned `VELD_*` variables
+
+> **Changed in this release.** `on_stop` used to fail to resolve `${nodes.<other>.<field>}`
+> at stop time — only the node's own outputs were loaded. A single such reference used
+> to empty the hook's *whole* environment, which then ran anyway, blind. Both halves are
+> fixed: cross-node references now resolve, and a hook whose environment cannot be
+> resolved is **skipped loudly** rather than run with an empty one.
 
 Naming a resource after the same built-ins in `argv` and in `on_stop` is the point:
 a container called `${veld.project}-${veld.node}-${veld.run}` in both places cannot
@@ -2755,6 +2795,13 @@ An action's context is deliberately the smallest: it also has no `${vars.*}` and
 no `${nodes.<other>.…}`, because an action runs against one live node long after
 the plan that built it. `${veld.url}` and its pieces, and `${veld.ports.*}`, do
 resolve there — they come from the node's recorded state.
+
+The action's **environment** is richer than its interpolation context: it
+inherits your shell, then layers the node's declared `env` (so an action can
+read the `CONTAINER_NAME` its node was started with), the node's live outputs as
+`$KEY`, the action's `parameters`, and the veld-owned `VELD_*` variables.
+Precedence (lowest to highest): inherited parent env < node `env` < node outputs
+< action `parameters`.
 
 Notes:
 

--- a/skills/veld/SKILL.md
+++ b/skills/veld/SKILL.md
@@ -120,6 +120,7 @@ attached to. Inside `command` you can reference:
 - `${output.KEY}` — the same outputs, interpolated by Veld into the command string before it runs
 - `${param.KEY}` — the action's static `parameters`
 - `${veld.run}`, `${veld.node}`, `${veld.project}`, `${veld.root}`, `${veld.port}`, `${veld.url}`
+- The node's declared `env` (as `$KEY`, below the outputs in precedence) and the veld-owned `VELD_*` variables (`VELD_RUN`, `VELD_ROOT`, `VELD_NODE`, `VELD_VARIANT`, `VELD_PROJECT`, and the port/url/host family) — so an action can read the `CONTAINER_NAME` its node was started with
 
 > **Secrets — `$KEY` is better than `${output.KEY}`, but it is not automatically
 > safe.** `${output.DB_PASS}` is interpolated by Veld into the command string, so

--- a/skills/veld/reference/config.md
+++ b/skills/veld/reference/config.md
@@ -507,6 +507,8 @@ Every `long_running` variant requires a readiness probe — including a portless
 - `command`: Exit 0 = healthy.
 - `settle`: The process was still alive `seconds` after spawn (default 3). For a **portless** node. Deliberately a weak claim, but raced against process exit, so a command that dies on startup still fails the run. Prefer `command` whenever the process publishes something observable (a socket, a built file, a pid file).
 - `http`/`port` probe the **primary** port unless `"port": "<name>"` names another one from the node's `ports` map. On a node with no such port they are a `probe-needs-port` error and fail the run — they no longer report healthy. An unrecognised `type` is `unknown-probe-type`, for the same reason: a typo must never be the quiet way to turn a probe off.
+- **Probe fields are interpolated**: an `http` probe's `path` and a `command` probe's `argv`/`shell` resolve `${…}` with the node's context, like the node's own `argv`/`env` (`schema/v3/examples/vars-and-values.json` proves it).
+- A **`command` probe runs with the node's declared `env`**, the veld-owned `VELD_*` variables (including `VELD_PORT`), and the node's outputs as `$KEY`, so it can be parameterised. On failure its **stderr and exit code are included in the timeout error** rather than discarded.
 - Defaults: `timeout_seconds`: 60, `interval_ms`: 1000 (min: 100).
 
 ### Liveness (ongoing)
@@ -567,6 +569,7 @@ Substitution available inside `command` and `parameters` values:
 - `${output.KEY}` — the same outputs, interpolated by Veld into the command string before it runs
 - `${param.KEY}` — this action's parameters
 - `${veld.run}`, `${veld.node}`, `${veld.variant}`, `${veld.project}`, `${veld.root}`, `${veld.port}`, `${veld.url}`
+- The node's declared `env` (as `$KEY`, below the node outputs in precedence) and the veld-owned `VELD_*` variables — `VELD_RUN`, `VELD_RUN_ID`, `VELD_ROOT`, `VELD_PROJECT`, `VELD_NODE`, `VELD_VARIANT`, plus `VELD_PORT`/`VELD_URL`/`VELD_PORT_<NAME>`/`VELD_URL_<NAME>`/`VELD_HOST_<NAME>` on a node that has ports
 
 **Secrets — `$KEY` beats `${output.KEY}`, but is not automatically safe.** `${output.DB_PASS}` is interpolated by veld into the command string, so it is in `ps` for certain — a `secret-in-command` **error**. `$DB_PASS` is expanded by the *shell*, and where the expansion lands decides the outcome: `echo $DB_PASS` (builtin) and `PGPASSWORD=$DB_PASS psql -U u db` (environment assignment) leak nothing, while `psql "postgres://u:$DB_PASS@host/db"` makes the shell `execve` `psql` with the expanded value in *that* program's argv. The shell's own `ps` entry shows the literal `$DB_PASS`; the program it runs shows the value. veld cannot distinguish them, so this is a `secret-shell-expansion` **warning**. Prefer giving the program the variable *name* (`PGPASSWORD=`, `--password-file`, `-e NAME`). GUI clients launched with a connection URL (`open -a Postico "postgresql://$DB_USER:$DB_PASS@…"`) always expand into the launcher's argv — omit the password and let the client prompt.
 
@@ -597,7 +600,7 @@ real `//` comment.
 | `proxy` | project, node, variant | `{request?: {remove?: [str], set?: {k: v}}, response?: {...}}`. Reverse-proxy header rules for the local Caddy proxy + web gateway (NOT peer shares). Cascades: `remove` lists union, `set` maps merge (variant > node > project). Absent = no manipulation. See [Proxy](#proxy). |
 | `type` | node, variant | `long_running` (alias: `start_server`) or `command`. Lifecycle only — ports decide whether the node serves anything. Declare once on the node if all its variants agree. |
 | `argv` / `shell` | node, variant | What to run — exactly one of them. |
-| `on_stop` | node, variant | Per-node teardown, run on `veld stop`, in reverse dependency order. `{argv\|shell}`. |
+| `on_stop` | node, variant | Per-node teardown, run on `veld stop`, in reverse dependency order. `{argv\|shell}`. Cross-node `${nodes.<node>.<field>}` references resolve at stop time from the run's persisted state, and the veld-owned `VELD_*` vars are exported. A hook whose command **or environment** cannot be resolved is skipped loudly (it never runs with an empty env). |
 | `depends_on` | node, variant | `{node: variant}`. Both **literal** — no `${...}`; the graph is read before variables exist. `"node": null` erases. |
 | `outputs` | node, variant | List of captured names, or a map of computed values (both node types). Replaced wholesale by a variant. |
 | `share` | node, variant | Replaced wholesale by a variant, never merged — sharing is a consent decision. |

--- a/website/llms-full.txt
+++ b/website/llms-full.txt
@@ -584,6 +584,19 @@ Declare `env` at the project, node, or variant level. Variables cascade: variant
 }
 ```
 
+**The veld-owned environment** — `VELD_RUN`, `VELD_RUN_ID`, `VELD_ROOT`,
+`VELD_PROJECT`, `VELD_NODE`, `VELD_VARIANT`, plus `VELD_PORT`/`VELD_URL`/
+`VELD_PORT_<NAME>`/`VELD_URL_<NAME>`/`VELD_HOST_<NAME>` on a `long_running` node
+with ports — is injected on **every** surface of a node: the node's process, its
+readiness and liveness probes, its `on_stop` hook, and `veld action`. A
+`command` probe and an `action` also receive the node's declared `env` (and the
+probe gets the node's outputs as `$KEY`). Probe fields (`path`, `argv`/`shell`)
+are interpolated with the node's context, and a failing `command` probe's stderr
+and exit code appear in the health error. An `on_stop` hook resolves
+`${nodes.<node>.<field>}` cross-node references at stop time, and is skipped
+loudly — never run with an empty env — if its command or environment cannot be
+resolved.
+
 ### Outputs
 
 For `long_running` variants — object (synthetic templates):


### PR DESCRIPTION
Fixes the four halves of [issue #246](https://github.com/prosperity-solutions/veld/issues/246), where interpolation and environment reached three different subsets of a node's surfaces.

## What changed

**§1 — Probe fields are now interpolated.** An `http` probe's `path` and a `command` probe's `argv`/`shell` resolve `${…}` with the node's context, exactly as the node's own `argv`/`env` are. Previously `${vars.health_path}` reached the server as literal text and 404'd forever — the committed example (`schema/v3/examples/vars-and-values.json`) was structurally perfect and semantically impossible. It is now semantically valid, and is the proof the fix works.

**§2 — A failing command probe no longer discards the child's output.** The timeout error now includes the last exit code and the last few stderr lines (`health check timed out after 60s — last attempt exited with code 1 — last stderr: …`). This is what turned §1 into an hour of debugging: the probe's stderr was the whole diagnosis and nobody read it.

**§3 — One builder for the veld-owned environment.** `veld_owned_env` supplies `VELD_RUN`, `VELD_RUN_ID`, `VELD_ROOT`, `VELD_PROJECT`, `VELD_NODE`, `VELD_VARIANT`, plus the port/url/host family (`VELD_PORT`, `VELD_PORT_<NAME>`, `VELD_URL`, `VELD_URL_<NAME>`, `VELD_HOST_<NAME>`) to **every** surface: the node process, both probe types, the `on_stop` hook, and `veld action`. A `command` probe and an `action` on a node also receive the node's declared `env` (previously an action could not read `CONTAINER_NAME`, and a probe got no environment at all). Actions keep documented precedence: parent env < node `env` < node outputs < params.

**§4 — `on_stop` resolves cross-node refs and fails loudly.** `${nodes.<node>.<field>}` — including the bare `.port`/`.url` accessors — now resolves at stop time from the persisted run state (previously one `${nodes.dev-daemon.port}` emptied the whole env and the hook ran blind). A hook whose **environment** cannot be resolved is now **skipped loudly**, never run with an empty one (matching the existing command-interpolation failure path).

## Out of scope (per the issue's suggested split)
`VELD_RUN_DIR` (§5) and per-variant `on_exit` (§6) are features that want their own discussion; this PR intentionally does not touch them.

## Test evidence
- `cargo test --workspace` green; `cargo clippy --workspace --all-targets` clean; `cargo fmt --check` clean; `tests/validate-schema.sh` 19/19.
- New tests: `probe_string_fields_are_interpolated`, `a_failing_command_probe_reports_its_stderr_and_exit_code`, `veld_owned_env_builds_the_shared_variables`, `on_stop_resolves_cross_node_references`.
- `veld lint` on a config using `${vars.health_path}` in a probe `path` lints clean (the §1 example).

## Review notes
- The liveness monitor injects the veld-owned env + node outputs + PATH into `command` probes, but deliberately does **not** re-resolve the node's declared `env` there: that would run config-declared secret sources in the monitor's hot loop (the daemon-PATH concern in AGENTS.md). The readiness probe (in the orchestrator, with full context) does resolve it, which is what §3's "a probe gets no environment" was really about.
- An action resolves the node's env best-effort — it is never action-fatal, since an action's interpolation context has no `${vars.*}` by design.
- `Cargo.lock` bumps crate versions 16.13.0 → 16.15.0 to match the already-committed manifests (a stale lock my build corrected).

Known follow-ups (not this PR): §5 `VELD_RUN_DIR`, §6 `on_exit`.
