### PR TITLE
feat(ide): proactive dirty-state handling in the worktree trash/delete flow

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -180,6 +180,17 @@ Three rules that make it worth the spend rather than theatre:
   as you go. For a JS/TS change, run the Biome `lint` + `typecheck`/`test` in the
   affected surface too (`desktop/`, `crates/veld-daemon/ui`, `crates/veld-daemon/frontend`)
   — `just lint` and `just test` cover all of it in one command each.
+- **Leave the worktree clean before you stop.** Building and running tests
+  drifts `Cargo.lock`, and experiment scaffolding lands untracked (`.idea/`,
+  a scratch dir, a prototype) — but a worktree carrying uncommitted changes or
+  untracked files cannot be trashed and deleted in the IDE: `git worktree
+  remove` refuses on them. Before a checkpoint hand-off, before a draft, and
+  before `gh pr ready`, run `git status --short` and revert incidental
+  `Cargo.lock`/build drift and untracked scaffolding. Deliberate uncommitted
+  work is fine while the PR is in flight — it is the *incidental* mess that
+  blocks the user (and future agents) from cleaning up. This is also what makes
+  the trash flow surface these files: the IDE now lists them at trash/delete
+  time, so a clean tree is the happy path for everyone.
 - If Step 0 chose a pre-review checkpoint — the default *one checkpoint, before
   review*, or the two-checkpoint variant: this is **checkpoint one**. Finish the
   whole feature (including the docs audit in Step 3), leave it building and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,17 @@ and several were paid for in this codebase already.
   Design context that must outlive a working document belongs in the PR
   description, commit messages, or `docs/` — don't cite `notes/` files from
   code comments, since readers of the repo can't see them.
+- **Leave a worktree clean before you stop in it.** Building and running tests
+  drifts `Cargo.lock`, and experiment scaffolding lands untracked (`.idea/`,
+  a scratch dir, a prototype). A worktree carrying uncommitted changes or
+  untracked files can't be trashed and deleted in the IDE — `git worktree
+  remove` refuses on them — so an agent that leaves incidental `Cargo.lock`
+  drift or untracked scaffolding behind is the reason a stale worktree can't
+  be cleaned up. Run `git status --short` before a hand-off/draft/PR-ready and
+  revert the incidental stuff; deliberate uncommitted work is fine while a PR
+  is in flight. The IDE surfaces these files at trash/delete time (the
+  `git status` / `revert` worktree endpoints), so a clean tree is the happy
+  path for both.
 - **CI runs only on a PR that is ready for review, so marking one ready is a
   spending decision.** Every job in `ci.yml` and `release.yml` carries
   `if: github.event_name != 'pull_request' || github.event.pull_request.draft == false`,

--- a/crates/veld-daemon/src/desktop.rs
+++ b/crates/veld-daemon/src/desktop.rs
@@ -46,6 +46,8 @@ pub fn routes() -> Router {
         )
         .route("/api/worktrees/{id}/start", post(start_worktree_run))
         .route("/api/worktrees/{id}/restore", post(restore_worktree))
+        .route("/api/worktrees/{id}/status", get(worktree_status))
+        .route("/api/worktrees/{id}/revert", post(revert_worktree))
         .route("/api/worktrees/{id}/delete", post(delete_trashed_worktree))
         .route("/api/trash", delete(empty_trash))
         .route(
@@ -386,9 +388,13 @@ fn open_desktop_db() -> Result<Db, ApiError> {
 // Git plumbing
 // ---------------------------------------------------------------------------
 
-/// Run `git -C <dir> <args…>` with the user's login-shell PATH. Returns
-/// trimmed stdout, or the trimmed stderr as the error message.
-pub(super) async fn git(dir: &FsPath, args: &[&str]) -> Result<String, String> {
+/// Run `git -C <dir> <args…>` with the user's login-shell PATH and return the
+/// raw stdout bytes, **untrimmed**. Trimming is done by [`git`] for callers that
+/// want a clean line; this raw form exists for [`git_status`], whose porcelain
+/// codes carry a significant leading space (` M` is an unstaged edit) that a
+/// `.trim()` would silently destroy — which is exactly the bug that shipped
+/// when `git_status` used [`git`] and plain edits went undetected.
+async fn git_raw(dir: &FsPath, args: &[&str]) -> Result<Vec<u8>, String> {
     let path_env = cached_user_path().await;
     let output = tokio::process::Command::new("git")
         .arg("-C")
@@ -399,7 +405,7 @@ pub(super) async fn git(dir: &FsPath, args: &[&str]) -> Result<String, String> {
         .await
         .map_err(|e| format!("failed to run git: {e}"))?;
     if output.status.success() {
-        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+        Ok(output.stdout)
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         Err(if stderr.is_empty() {
@@ -408,6 +414,143 @@ pub(super) async fn git(dir: &FsPath, args: &[&str]) -> Result<String, String> {
             stderr
         })
     }
+}
+
+/// Run `git -C <dir> <args…>` with the user's login-shell PATH. Returns
+/// trimmed stdout, or the trimmed stderr as the error message.
+pub(super) async fn git(dir: &FsPath, args: &[&str]) -> Result<String, String> {
+    Ok(String::from_utf8_lossy(&git_raw(dir, args).await?)
+        .trim()
+        .to_string())
+}
+
+/// One file that stops `git worktree remove` from succeeding, as reported by
+/// [`git_status`].
+///
+/// The two fields are the two things the UI needs to let the user decide:
+/// *what* is in the way (`path`) and *why* (`kind`). `kind` is a stable
+/// short label, not the raw porcelain code, so the client renders "modified"
+/// rather than decoding `" M"` itself — and so a future porcelain code that
+/// appears in the wild cannot silently become an empty label.
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct DirtyFile {
+    /// Path relative to the worktree root.
+    path: String,
+    /// Human label: `modified`, `untracked`, `deleted`, `added`, `renamed`,
+    /// `copied`, `conflicted`, or `changed` for anything unclassified.
+    kind: &'static str,
+}
+
+/// The dirty state of a worktree, as the trash/delete flow needs it.
+#[derive(Debug, Serialize)]
+struct StatusView {
+    /// Whether `git worktree remove` would refuse this checkout right now.
+    dirty: bool,
+    /// The files in the way, in git's own (path) order. Empty when `dirty` is
+    /// false.
+    files: Vec<DirtyFile>,
+}
+
+/// Map a porcelain v1 status pair to the label [`DirtyFile::kind`] carries.
+///
+/// The porcelain codes are `<index><worktree>`; either side being non-space is
+/// a change, and untracked is the literal `??`. Unmerged/conflicted codes
+/// (`DD`, `AU`, `UD`, `UU`, …) all carry a `U` in one of the two positions, so
+/// they are caught before the single-letter tests below.
+fn dirty_kind(code: &str) -> &'static str {
+    let b = code.as_bytes();
+    if code == "??" {
+        return "untracked";
+    }
+    // Unmerged/conflicted states. Most carry a `U`, but the `AA` (both added)
+    // and `DD` (both deleted) unmerged codes do not — so the literal pair must
+    // be matched too, not just the `U` presence.
+    let any = |c: u8| b[0] == c || b[1] == c;
+    if any(b'U') || code == "AA" || code == "DD" {
+        return "conflicted";
+    }
+    // Rename/copy before the single-letter tests: a staged rename that is also
+    // modified (`RM`) should read "renamed", not "modified" — the move is the
+    // story the file list is telling.
+    if any(b'R') {
+        return "renamed";
+    }
+    if any(b'C') {
+        return "copied";
+    }
+    if any(b'M') {
+        return "modified";
+    }
+    if any(b'A') {
+        return "added";
+    }
+    if any(b'D') {
+        return "deleted";
+    }
+    "changed"
+}
+
+/// Parse `git status --porcelain=v1 -z` output into a file list.
+///
+/// The `-z` form is NUL-delimited and path-safe (no quoting, no mangled
+/// spaces or newlines), which is why it is chosen over the line-oriented
+/// `--porcelain` for something that renders paths back to a human. Each record
+/// is `<XY> <path>\0`; a rename or copy adds a trailing `<original>\0` (the
+/// origin), which is not a record of its own and must be skipped.
+///
+/// The paths reported are the *destination* paths, exactly as `git worktree
+/// remove` would refuse them — this list is the set of files that are in the
+/// way, not a diff summary, so showing the dest for a rename is the honest
+/// answer to "what would be discarded?"
+fn parse_git_status(porcelain: &str) -> Vec<DirtyFile> {
+    let mut files = Vec::new();
+    let mut i = 0usize;
+    let fields: Vec<&str> = porcelain.split('\0').collect();
+    while i < fields.len() {
+        let f = fields[i];
+        i += 1;
+        if f.is_empty() {
+            continue;
+        }
+        // The record is `<XY> <path>` where `XY` is two status characters and
+        // **the first of them may itself be a space** (e.g. `" M a.txt"`), so
+        // the separator is at byte 2, not the first space. Splitting on the
+        // first space would read `" M a.txt"` as an empty code and a path of
+        // `"M a.txt"` — dropping every leading-space code.
+        if f.len() < 4 || f.as_bytes()[2] != b' ' {
+            continue;
+        }
+        let code = &f[..2];
+        let path = &f[3..];
+        if path.is_empty() {
+            continue;
+        }
+        files.push(DirtyFile {
+            path: path.to_string(),
+            kind: dirty_kind(code),
+        });
+        // A rename/copy record is followed by its `<original>` as its own
+        // NUL-delimited field with no `<XY> ` prefix; skip it so it is not
+        // rendered as a second (pathless) file.
+        if code.as_bytes()[1] == b'R' || code.as_bytes()[1] == b'C' {
+            i += 1;
+        }
+    }
+    files
+}
+
+/// Run `git status --porcelain=v1 -z` in a directory and parse the result.
+///
+/// Returns an empty list for a clean worktree. An error means git could not
+/// run at all (a missing checkout, a broken repo), which the caller surfaces
+/// rather than guessing at the dirty state.
+async fn git_status(dir: &FsPath) -> Result<Vec<DirtyFile>, String> {
+    // Via `git_raw`, not `git`: the porcelain codes for unstaged changes begin
+    // with a space (` M`), and the shared helper's `.trim()` would strip it,
+    // turning an unstaged edit into an empty-looking record. This is the bug
+    // the integration test below pins.
+    let out = git_raw(dir, &["status", "--porcelain=v1", "-z"]).await?;
+    Ok(parse_git_status(&String::from_utf8_lossy(&out)))
 }
 
 /// Parse `git worktree list --porcelain` output. The first entry is the main
@@ -1610,6 +1753,95 @@ async fn delete_worktree(
     }
 }
 
+/// Report the git dirty state of a worktree: the files that would stop
+/// `git worktree remove` from succeeding, and why.
+///
+/// Deliberately a separate, on-demand endpoint rather than a field on
+/// `WorktreeView`: the listing is polled by every IDE window, and running git
+/// in every checkout on every poll is the kind of cost that only shows up as a
+/// slow rail. The trash/delete flow fetches it when a decision is being made.
+///
+/// The read-only contract (`GET`s on this router have no side effects) is what
+/// makes it safe to call here — no CSRF header needed, and no state written.
+async fn worktree_status(Path(id): Path<i64>) -> Result<Json<StatusView>, ApiError> {
+    let db = open_desktop_db()?;
+    let wt = db
+        .get_worktree(id)
+        .map_err(db_err)?
+        .ok_or_else(|| err(StatusCode::NOT_FOUND, "worktree not found"))?;
+    let files = git_status(FsPath::new(&wt.path))
+        .await
+        .map_err(|e| err(StatusCode::UNPROCESSABLE_ENTITY, e))?;
+    Ok(Json(StatusView {
+        dirty: !files.is_empty(),
+        files,
+    }))
+}
+
+/// Discard a worktree's uncommitted changes so its deletion can succeed.
+///
+/// This is the "revert the changes" half of the trash/delete flow: it resets
+/// tracked files (staged and unstaged) to HEAD with `git restore`, then removes
+/// untracked files and directories with `git clean -fd`. **Ignored files are
+/// deliberately left alone** — `git worktree remove` does not refuse on those
+/// (verified, git 2.50), so removing them would discard work for nothing.
+///
+/// Destructive by nature, so it is gated the same way the force-delete path is:
+/// only on a non-main worktree, and only on an explicit request. The caller is
+/// expected to have shown the file list first — this endpoint does not ask a
+/// second question, but the UI that reaches it must. It returns the post-revert
+/// status so the caller can confirm the checkout is now clean rather than
+/// assuming the commands succeeded.
+///
+/// **Why not use `git worktree remove --force`?** Forcing discards the files as
+/// a side effect of deletion; this is the *reversible-in-spirit* alternative
+/// that leaves the worktree itself intact and lets the user change their mind
+/// (restore, or keep it) afterwards. The two answer different questions, and the
+/// trash flow now offers both.
+async fn revert_worktree(Path(id): Path<i64>) -> Result<Json<StatusView>, ApiError> {
+    let db = open_desktop_db()?;
+    let wt = db
+        .get_worktree(id)
+        .map_err(db_err)?
+        .ok_or_else(|| err(StatusCode::NOT_FOUND, "worktree not found"))?;
+    if wt.is_main {
+        return Err(err(
+            StatusCode::CONFLICT,
+            "the main checkout is never reverted — it is the repository itself",
+        ));
+    }
+    revert_git_changes(FsPath::new(&wt.path))
+        .await
+        .map_err(|e| err(StatusCode::UNPROCESSABLE_ENTITY, e))?;
+    let files = git_status(FsPath::new(&wt.path))
+        .await
+        .map_err(|e| err(StatusCode::UNPROCESSABLE_ENTITY, e))?;
+    Ok(Json(StatusView {
+        dirty: !files.is_empty(),
+        files,
+    }))
+}
+
+/// Discard a worktree's uncommitted changes: reset tracked files (staged and
+/// unstaged) to HEAD, then remove untracked files and directories.
+///
+/// Split out of [`revert_worktree`] so the destructive sequence can be pinned
+/// against real git rather than trusted to a hand-written command list.
+///
+/// **Ignored files are deliberately left alone** — `git worktree remove` does
+/// not refuse on them (verified, git 2.50), so removing them would discard work
+/// for nothing. Hence `clean -fd`, not `clean -fdx`.
+async fn revert_git_changes(path: &FsPath) -> Result<(), String> {
+    // Reset the index and working tree to HEAD: clears staged additions and
+    // staged/unstaged modifications to tracked files alike.
+    git(path, &["restore", "--staged", "--worktree", "."]).await?;
+    // Remove untracked files and directories. No `-x`: that would also remove
+    // ignored files, which `git worktree remove` does not refuse on and which
+    // may be the user's own tooling or notes.
+    git(path, &["clean", "-fd"]).await?;
+    Ok(())
+}
+
 /// Take a worktree out of the trash (undo).
 ///
 /// A real undo for the whole retention period, since binning deletes nothing. It can
@@ -2062,6 +2294,158 @@ mod tests {
         let wts = parse_worktree_list(out);
         assert_eq!(wts.len(), 1);
         assert!(!wts[0].is_main);
+    }
+
+    /// The reported shape: a worktree blocked from deletion carries a mix of
+    /// tracked modifications, staged additions, deletions, untracked files and
+    /// renames. `-z` records are NUL-separated, so the fixture is built with the
+    /// literal `\0`, and the rename's origin (`src.txt`) must not be rendered as
+    /// a file of its own.
+    #[test]
+    fn git_status_parses_the_files_that_block_removal() {
+        let out = [
+            " M a.txt",       // unstaged modification
+            "M  staged.txt",  // staged modification
+            "A  new.txt",     // staged addition
+            " D gone.txt",    // unstaged deletion
+            "RM renamed.txt", // staged+unstaged rename; origin follows
+            "src.txt",        // the rename's origin — must be skipped
+            "?? untracked/",  // untracked directory
+        ]
+        .join("\0");
+        let files = parse_git_status(&out);
+        let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+        assert_eq!(
+            paths,
+            vec![
+                "a.txt",
+                "staged.txt",
+                "new.txt",
+                "gone.txt",
+                "renamed.txt",
+                "untracked/"
+            ],
+            "the rename origin must not appear as a file"
+        );
+        let kinds: Vec<&str> = files.iter().map(|f| f.kind).collect();
+        assert_eq!(
+            kinds,
+            vec![
+                "modified",
+                "modified",
+                "added",
+                "deleted",
+                "renamed",
+                "untracked"
+            ]
+        );
+    }
+
+    #[test]
+    fn git_status_is_empty_for_a_clean_worktree() {
+        assert!(parse_git_status("").is_empty());
+        // A lone trailing NUL (git emits one after the last record) is not a file.
+        assert!(parse_git_status("\0").is_empty());
+    }
+
+    #[test]
+    fn git_status_labels_conflicts_distinct_from_modifications() {
+        // All the unmerged codes carry a `U` in one position; the test pins that
+        // they are not misread as plain modifications.
+        for code in ["UU", "AA", "DD", "AU", "UD", "UA", "DU"] {
+            assert_eq!(
+                parse_git_status(&format!("{code} f\0"))[0].kind,
+                "conflicted",
+                "unmerged code {code} must be labelled conflicted"
+            );
+        }
+    }
+
+    /// The generated-status path, run against **real git**, not a hand-built
+    /// fixture: ``git_status`` is what the endpoint serves, and this pins that a
+    /// plain unstaged edit is reported just as reliably as a staged one (a
+    /// regression would show only staged changes, because those have no leading
+    /// space in the porcelain code).
+    #[tokio::test]
+    async fn git_status_reports_plain_edits_and_staged_changes_against_real_git() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = FsPath::new(dir.path());
+        // A tracked file, two commits apart is irrelevant — one commit suffices.
+        run_git(root, &["init", "-q"]).await;
+        run_git(root, &["config", "user.email", "t@t"]).await;
+        run_git(root, &["config", "user.name", "t"]).await;
+        std::fs::write(root.join("tracked.txt"), "one").unwrap();
+        run_git(root, &["add", "tracked.txt"]).await;
+        run_git(root, &["commit", "-qm", "init"]).await;
+
+        // Clean: nothing in the way.
+        assert!(git_status(root).await.unwrap().is_empty());
+
+        // A plain edit (unstaged, ` M`) — the case reported as not detected.
+        std::fs::write(root.join("tracked.txt"), "one-two").unwrap();
+        let unstaged = git_status(root).await.unwrap();
+        assert_eq!(unstaged.len(), 1, "a plain edit must be reported dirty");
+        assert_eq!(unstaged[0].path, "tracked.txt");
+        assert_eq!(unstaged[0].kind, "modified");
+
+        // Same file staged (`M `), still one file.
+        run_git(root, &["add", "tracked.txt"]).await;
+        let staged = git_status(root).await.unwrap();
+        assert_eq!(staged.len(), 1);
+        assert_eq!(staged[0].kind, "modified");
+
+        // A brand-new file nobody has `git add`ed (`??`) joins the list; the
+        // staged `tracked.txt` is still there, so the total is two.
+        std::fs::write(root.join("untracked.txt"), "new").unwrap();
+        let untracked = git_status(root).await.unwrap();
+        assert!(
+            untracked
+                .iter()
+                .any(|f| f.path == "untracked.txt" && f.kind == "untracked")
+        );
+    }
+
+    /// The destructive half, pinned against real git: after a revert the
+    /// worktree must be clean enough for `git worktree remove`, with staged,
+    /// unstaged and untracked changes all gone — but **ignored** files kept.
+    #[tokio::test]
+    async fn revert_git_changes_discards_uncommitted_but_keeps_ignored() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = FsPath::new(dir.path());
+        run_git(root, &["init", "-q"]).await;
+        run_git(root, &["config", "user.email", "t@t"]).await;
+        run_git(root, &["config", "user.name", "t"]).await;
+        std::fs::write(root.join("tracked.txt"), "one").unwrap();
+        std::fs::write(root.join(".gitignore"), "*.log\n").unwrap();
+        run_git(root, &["add", "."]).await;
+        run_git(root, &["commit", "-qm", "init"]).await;
+
+        // Make it dirty in every way a deletion can be blocked: unstaged edit,
+        // staged addition, and an untracked directory.
+        std::fs::write(root.join("tracked.txt"), "one-two").unwrap(); // unstaged
+        std::fs::write(root.join("staged.txt"), "s").unwrap();
+        run_git(root, &["add", "staged.txt"]).await; // staged addition
+        std::fs::create_dir(root.join("scratch")).unwrap();
+        std::fs::write(root.join("scratch/x"), "x").unwrap(); // untracked
+        std::fs::write(root.join("keep.log"), "k").unwrap(); // ignored — survives
+
+        assert_eq!(git_status(root).await.unwrap().len(), 3);
+        revert_git_changes(root)
+            .await
+            .expect("revert should succeed");
+        assert!(
+            git_status(root).await.unwrap().is_empty(),
+            "revert must leave nothing blocking a delete"
+        );
+        assert!(
+            root.join("keep.log").exists(),
+            "ignored files are not blocked by remove and must survive"
+        );
+    }
+
+    /// Wrapper so the integration test reads as assertions rather than shell.
+    async fn run_git(dir: &FsPath, args: &[&str]) {
+        git(dir, args).await.expect("git should succeed");
     }
 
     #[test]

--- a/crates/veld-daemon/ui/src/App.tsx
+++ b/crates/veld-daemon/ui/src/App.tsx
@@ -14,6 +14,7 @@ import {
   type SettingsDoc,
   type StatsResponse,
   type Worktree,
+  type WorktreeGitStatus,
 } from "./api";
 import {
   hideDisabledActions,
@@ -199,12 +200,14 @@ import {
 import { ConfigVarsDialog } from "./components/ConfigVars";
 import {
   ChangeMarkerDialog,
+  ConfirmDeleteWorktreeDialog,
   ImportRepoDialog,
   LaneNameDialog,
   Modal,
   NewWorktreeDialog,
   RemoveRepoDialog,
   RenameWorktreeDialog,
+  TrashWorktreeDialog,
 } from "./components/dialogs";
 
 import {
@@ -1804,7 +1807,18 @@ function AppInner(props: {
      *  section, so "which lane" is decided by the click, not by the dialog. */
     | { kind: "new-worktree"; lane: string }
     | { kind: "sharing" }
-    | { kind: "rename"; worktree: Worktree; deleteFocus?: boolean }
+    | { kind: "rename"; worktree: Worktree }
+    /**
+     * The trash confirmation, split out of the edit dialog: fetches the git
+     * dirty state and offers trash-anyway vs revert-first.
+     */
+    | { kind: "trash"; worktree: Worktree }
+    /**
+     * A trashed worktree that is dirty, opened by the delete flow instead of
+     * enqueueing a removal that would refuse. `status` is the fetched dirty
+     * state; the dialog turns it into a choice (discard vs revert first).
+     */
+    | { kind: "confirm-delete"; worktree: Worktree; status: WorktreeGitStatus }
     | { kind: "marker"; worktree: Worktree }
     /** `worktree` set means "create it, then move this one into it". */
     | { kind: "new-lane"; worktree?: Worktree }
@@ -2053,8 +2067,7 @@ function AppInner(props: {
               // refusal and the force checkbox beside it. Without this entry the
               // only way back to a forced removal was a dialog that no longer
               // knew a removal had been refused.
-              onClick: () =>
-                setDialog({ kind: "rename", worktree: w, deleteFocus: true }),
+              onClick: () => setDialog({ kind: "trash", worktree: w }),
             },
             {
               key: "trash-error",
@@ -2070,8 +2083,7 @@ function AppInner(props: {
         title: "Move to trash…",
         color: "red",
         disabled: w.is_main,
-        onClick: () =>
-          setDialog({ kind: "rename", worktree: w, deleteFocus: true }),
+        onClick: () => setDialog({ kind: "trash", worktree: w }),
       },
     ]);
   };
@@ -3200,23 +3212,45 @@ function AppInner(props: {
     await refresh();
   };
 
+  /** Enqueue the worker to delete a trashed worktree, optimistically moving it
+   *  to the terminal "Deleting" lane (see the comment on the caller). */
+  const enqueueDelete = async (w: Worktree) => {
+    await api.deleteTrashedWorktree(w.id);
+    // Move it to the terminal "Deleting" lane immediately: the daemon only
+    // reports `deleting` once the removal is actually running, and the run
+    // teardown in between can take a while. From the confirm, the row is
+    // committed and must not read as recoverable trash.
+    setDeletingIds((cur) => {
+      const next = new Set(cur);
+      next.add(w.id);
+      return next;
+    });
+    notifyDone(`Deleting ${worktreeLabel(w)}`);
+    await refresh();
+  };
+
   const deleteTrashedWorktree = async (w: Worktree) => {
+    // Proactively check for a dirty state before enqueueing. `git worktree
+    // remove` refuses on uncommitted files, so enqueueing a dirty worktree
+    // fails a moment later and the row comes back with a `trash_error` the user
+    // has to chase down. If it is dirty, surface the files and ask how to
+    // proceed instead — discard, or revert first.
     try {
-      await api.deleteTrashedWorktree(w.id);
-      // Move it to the terminal "Deleting" lane immediately: the daemon only
-      // reports `deleting` once the removal is actually running, and the run
-      // teardown in between can take a while. From the confirm, the row is
-      // committed and must not read as recoverable trash.
-      setDeletingIds((cur) => {
-        const next = new Set(cur);
-        next.add(w.id);
-        return next;
-      });
-      notifyDone(`Deleting ${worktreeLabel(w)}`);
+      const status = await api.worktreeGitStatus(w.id);
+      if (status.dirty) {
+        setDialog({ kind: "confirm-delete", worktree: w, status });
+        return;
+      }
+    } catch {
+      // Status unavailable (git error, checkout gone): fall through to the
+      // enqueue and let the worker surface any refusal on the row, as before.
+    }
+    try {
+      await enqueueDelete(w);
     } catch (e) {
       notifyError(`Could not delete ${worktreeLabel(w)}`, e);
+      await refresh();
     }
-    await refresh();
   };
 
   const emptyTrash = async () => {
@@ -3271,6 +3305,20 @@ function AppInner(props: {
     // first place (the row gates on `!w.is_main`), so a drop can't reach here;
     // this is defence in depth so binning main can never be invoked silently.
     if (w.is_main) return;
+    // A dirty worktree can't be deleted later without either discarding or
+    // reverting its changes, so a drag-to-trash must not bin it silently —
+    // surface the files and let the user choose, the same as the context-menu
+    // "Remove worktree…". A clean worktree still bins immediately, as before.
+    try {
+      const status = await api.worktreeGitStatus(w.id);
+      if (status.dirty) {
+        setDialog({ kind: "trash", worktree: w });
+        return;
+      }
+    } catch {
+      // Status unavailable (git error, checkout gone): bin directly; any
+      // refusal surfaces later on the row.
+    }
     try {
       await api.deleteWorktree(w.id, false);
     } catch (e) {
@@ -3517,8 +3565,7 @@ function AppInner(props: {
           id: "wt:remove",
           group: "Worktree",
           label: `Remove worktree ${worktreeLabel(w)}…`,
-          run: () =>
-            setDialog({ kind: "rename", worktree: w, deleteFocus: true }),
+          run: () => setDialog({ kind: "trash", worktree: w }),
         });
       }
     }
@@ -4273,23 +4320,46 @@ function AppInner(props: {
              key. Without this the dialog crashed on `undefined.trim()` at save
              time — `worktreeLabel` already tolerates the same skew. */
           currentName={dialog.worktree.display_name ?? ""}
-          isMain={dialog.worktree.is_main}
-          /* Read off the LIVE row, not the one captured when the dialog opened: a
-             background removal can fail while it is open, and the force affordance
-             has to appear when the refusal arrives. */
-          trashError={
-            worktrees.find((w) => w.id === dialog.worktree.id)?.trash_error ?? ""
-          }
-          deleteFocus={dialog.deleteFocus ?? false}
           onClose={closeDialog}
           onRename={async (patch) => {
             await api.patchWorktree(dialog.worktree.id, patch);
             await refresh();
             closeDialog();
           }}
-          onDelete={async (force) => {
+        />
+      )}
+      {dialog.kind === "trash" && (
+        <TrashWorktreeDialog
+          /* Read off the LIVE row, not the one captured when the dialog opened: a
+             background removal can fail while it is open, and the force affordance
+             has to appear when the refusal arrives. */
+          trashError={
+            worktrees.find((w) => w.id === dialog.worktree.id)?.trash_error ?? ""
+          }
+          worktreeId={dialog.worktree.id}
+          onStatus={(id) => api.worktreeGitStatus(id)}
+          onRevert={(id) => api.revertWorktree(id)}
+          onClose={closeDialog}
+          onTrash={async (force) => {
             await api.deleteWorktree(dialog.worktree.id, force);
             await refresh();
+            closeDialog();
+          }}
+        />
+      )}
+      {dialog.kind === "confirm-delete" && (
+        <ConfirmDeleteWorktreeDialog
+          label={worktreeLabel(dialog.worktree)}
+          status={dialog.status}
+          onClose={closeDialog}
+          onDeleteDiscard={async () => {
+            await api.deleteWorktree(dialog.worktree.id, true);
+            await refresh();
+            closeDialog();
+          }}
+          onRevertThenDelete={async () => {
+            await api.revertWorktree(dialog.worktree.id);
+            await enqueueDelete(dialog.worktree);
             closeDialog();
           }}
         />

--- a/crates/veld-daemon/ui/src/api.ts
+++ b/crates/veld-daemon/ui/src/api.ts
@@ -125,6 +125,28 @@ export interface EnvironmentList {
   projects: ProjectInfo[];
 }
 
+/**
+ * One file that stops `git worktree remove` from succeeding.
+ *
+ * `kind` is a stable short label — `modified`, `untracked`, `deleted`,
+ * `added`, `renamed`, `conflicted`, `copied` — rendered beside the path so
+ * the user can tell a throwaway untracked file from real work.
+ */
+export interface DirtyFile {
+  path: string;
+  kind: string;
+}
+
+/**
+ * The git dirty state of a worktree, as reported by
+ * {@link api.worktreeGitStatus}.
+ */
+export interface WorktreeGitStatus {
+  /** Whether `git worktree remove` would refuse this checkout right now. */
+  dirty: boolean;
+  files: DirtyFile[];
+}
+
 export interface Worktree {
   id: number;
   repo_root: string;
@@ -968,6 +990,22 @@ export const api = {
    */
   deleteWorktree: (id: number, force: boolean) =>
     request<void>(`/api/worktrees/${id}?force=${force}`, { method: "DELETE" }),
+  /**
+   * The git dirty state of a worktree: the files that would stop
+   * `git worktree remove` from succeeding. Fetched on demand by the trash and
+   * delete flows, not carried on the (polled) listing.
+   */
+  worktreeGitStatus: (id: number) =>
+    request<WorktreeGitStatus>(`/api/worktrees/${id}/status`),
+  /**
+   * Discard a worktree's uncommitted changes so its deletion can succeed:
+   * tracked files (staged and unstaged) are reset to HEAD and untracked files
+   * are removed. Ignored files are left alone. Returns the post-revert status,
+   * so the caller can confirm the checkout is now clean. Destructive — the
+   * UI must ask before calling this.
+   */
+  revertWorktree: (id: number) =>
+    request<WorktreeGitStatus>(`/api/worktrees/${id}/revert`, { method: "POST" }),
   /**
    * Take a worktree out of the trash. Fails with 404 only if an explicit deletion
    * already got there.

--- a/crates/veld-daemon/ui/src/components/dialogs.tsx
+++ b/crates/veld-daemon/ui/src/components/dialogs.tsx
@@ -1,15 +1,26 @@
 import { type FormEvent, type ReactNode, useEffect, useRef, useState } from "react";
 import {
+  Alert,
+  Badge,
   Button,
   Checkbox,
   Group,
   Loader,
   Modal as MantineModal,
+  ScrollArea,
   Stack,
   Text,
   TextInput,
+  Tooltip,
 } from "@mantine/core";
-import { api, MAX_LANE_NAME_LEN, type EmojiHolder, type Repo } from "../api";
+import {
+  api,
+  MAX_LANE_NAME_LEN,
+  type DirtyFile,
+  type EmojiHolder,
+  type Repo,
+  type WorktreeGitStatus,
+} from "../api";
 import type { MarkerStyle } from "../shared/settings";
 import {
   aliasCollides,
@@ -708,6 +719,152 @@ export function ChangeMarkerDialog(props: {
  * it. The placeholder says which alias it would fall back to, so "empty" never
  * looks like "nameless".
  */
+/**
+ * One file that would stop `git worktree remove`, with a stable label.
+ *
+ * Used by both the trash confirmation and the delete confirmation, so the two
+ * surfaces cannot drift apart in how they present the same list.
+ */
+function DirtyFileList(props: { files: DirtyFile[] }) {
+  return (
+    <ScrollArea.Autosize mah={150} type="hover" scrollbarSize={6}>
+      <Stack gap={2}>
+        {props.files.map((f) => (
+          <Group key={f.path} gap={8} wrap="nowrap" align="center">
+            <Badge
+              size="xs"
+              variant="light"
+              color={kindColor(f.kind)}
+              style={{ flex: "none" }}
+            >
+              {f.kind}
+            </Badge>
+            <Text
+              size="xs"
+              style={{
+                fontFamily: "var(--mantine-font-family-monospace)",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {f.path}
+            </Text>
+          </Group>
+        ))}
+      </Stack>
+    </ScrollArea.Autosize>
+  );
+}
+
+/** Colour the change kind so untracked throwaways read differently from edits. */
+function kindColor(kind: string): string {
+  switch (kind) {
+    case "modified":
+    case "deleted":
+      return "red";
+    case "untracked":
+      return "orange";
+    case "added":
+      return "blue";
+    case "renamed":
+    case "copied":
+      return "teal";
+    case "conflicted":
+      return "grape";
+    default:
+      return "gray";
+  }
+}
+
+/**
+ * The destructive confirm for deleting a *trashed* worktree that is dirty.
+ *
+ * Deletion is where the dirty state actually bites: `git worktree remove`
+ * refuses on uncommitted files, so today the user only found out *after* the
+ * attempt failed and the row came back with `trash_error`. This surfaces the
+ * files up front and turns the refusal into a choice — delete and discard, or
+ * revert first and delete cleanly.
+ */
+export function ConfirmDeleteWorktreeDialog(props: {
+  /** The rail label, so the dialog says which worktree it means. */
+  label: string;
+  status: WorktreeGitStatus;
+  onClose: () => void;
+  /** Delete now, discarding the uncommitted changes (`git worktree remove --force`). */
+  onDeleteDiscard: () => Promise<void>;
+  /** Revert the changes, then delete the now-clean worktree. */
+  onRevertThenDelete: () => Promise<void>;
+}) {
+  const discard = useSubmit(props.onDeleteDiscard);
+  const revert = useSubmit(props.onRevertThenDelete);
+  const count = props.status.files.length;
+  const error = discard.error ?? revert.error;
+  return (
+    <Modal title="Delete worktree" onClose={props.onClose}>
+      <Stack gap="md">
+        <Alert color="yellow" variant="light" p="sm">
+          <Text size="sm" fw={600}>
+            “{props.label}” has {count} uncommitted change
+            {count === 1 ? "" : "s"} a delete would discard.
+          </Text>
+          <Text size="xs" c="dimmed" mt={2}>
+            These files are not saved to git yet.
+          </Text>
+          <div style={{ marginTop: 8 }}>
+            <DirtyFileList files={props.status.files} />
+          </div>
+        </Alert>
+        <Text size="sm" c="dimmed">
+          How do you want to proceed?
+        </Text>
+        <Group>
+          <Tooltip
+            label="Deletes the worktree now and discards these uncommitted changes. This cannot be undone."
+            multiline
+            w={260}
+          >
+            <Button
+              color="red"
+              loading={discard.busy}
+              onClick={(e) => {
+                e.preventDefault();
+                void discard.submit(e);
+              }}
+            >
+              Delete and discard changes
+            </Button>
+          </Tooltip>
+          <Tooltip
+            label="Reverts these changes first (reset to the last commit, remove untracked files), then deletes the worktree."
+            multiline
+            w={260}
+          >
+            <Button
+              color="yellow"
+              variant="light"
+              loading={revert.busy}
+              onClick={(e) => {
+                e.preventDefault();
+                void revert.submit(e);
+              }}
+            >
+              Revert, then delete
+            </Button>
+          </Tooltip>
+        </Group>
+        <ErrorText error={error} />
+      </Stack>
+    </Modal>
+  );
+}
+
+/**
+ * Edit a worktree's name and alias. Purely editing — trashing/deletion has its
+ * own dialog ([`TrashWorktreeDialog`]), so a rename action can never
+ * accidentally read as a delete, and the trash flow is never buried under a
+ * rename form.
+ */
 export function RenameWorktreeDialog(props: {
   currentAlias: string;
   /** The stored `display_name`, `""` when the row renders its alias. */
@@ -717,28 +874,10 @@ export function RenameWorktreeDialog(props: {
     alias?: string;
     display_name?: string;
   }) => Promise<void>;
-  onDelete: (force: boolean) => Promise<void>;
-  isMain: boolean;
-  /**
-   * Why the last deletion failed, or `""`.
-   *
-   * Load-bearing, not decoration. Deletion happens later than the click — on the
-   * retention sweep or from the trash — so git's refusal arrives on the row and can
-   * never land in this dialog's own `useSubmit` error. Gating the force checkbox on
-   * that error made `?force=true` unreachable: click → 202 → dialog closes →
-   * reopening gives a fresh, empty error. This is the durable record of the refusal,
-   * and it is what keeps forcing an answer to something the user has been shown
-   * rather than a checkbox offered up front.
-   */
-  trashError: string;
-  /** Open with the remove confirmation already expanded (context menu). */
-  deleteFocus: boolean;
   onClose: () => void;
 }) {
   const [alias, setAlias] = useState(props.currentAlias);
   const [name, setName] = useState(props.currentName);
-  const [confirmDelete, setConfirmDelete] = useState(props.deleteFocus);
-  const [force, setForce] = useState(false);
   const rename = useSubmit(() => {
     // **Only the fields that changed.** Both values are a snapshot taken when
     // the dialog opened, and this app runs up to eight windows against one
@@ -759,10 +898,6 @@ export function RenameWorktreeDialog(props: {
     }
     return props.onRename(patch);
   });
-  const del = useSubmit(() => props.onDelete(force));
-  // Either source of a refusal: this attempt's own (a 4xx from the forced path, or
-  // a rejected precondition) or the last background attempt's.
-  const refusal = del.error ?? (props.trashError || null);
   return (
     <Modal title="Edit worktree" onClose={props.onClose}>
       <form onSubmit={rename.submit}>
@@ -773,7 +908,7 @@ export function RenameWorktreeDialog(props: {
             placeholder={props.currentAlias}
             value={name}
             onChange={(e) => setName(e.currentTarget.value)}
-            data-autofocus={!props.deleteFocus}
+            data-autofocus
           />
           <TextInput
             label="Alias"
@@ -788,60 +923,164 @@ export function RenameWorktreeDialog(props: {
           </Button>
         </Stack>
       </form>
-      {!props.isMain && (
-        <Stack
-          gap="sm"
-          mt="md"
-          pt="md"
-          style={{ borderTop: "1px solid var(--border)" }}
-        >
-          {confirmDelete ? (
-            <>
-              <Text size="sm" c="dimmed">
-                Moves the checkout to the trash. Nothing is deleted yet — it
-                stays on disk and you can restore it from the rail. It is
-                deleted for good when its retention period runs out (Settings →
-                General, off by default) or when you delete it from the trash.
-                The branch itself is always kept.
-                {force
-                  ? " Forcing deletes it right now and discards uncommitted changes; it will not start if an environment is still running."
-                  : ""}
-              </Text>
-              <ErrorText error={refusal} />
-              {refusal && (
-                <Checkbox
-                  color="red"
-                  label="Delete now, discarding uncommitted changes"
-                  checked={force}
-                  onChange={(e) => setForce(e.currentTarget.checked)}
-                />
-              )}
-              <Button
-                color="red"
-                variant="light"
-                loading={del.busy}
-                onClick={(e) => {
-                  e.preventDefault();
-                  void del.submit(e);
-                }}
-              >
-                {force ? "Delete permanently" : "Move to trash"}
-              </Button>
-            </>
-          ) : (
+    </Modal>
+  );
+}
+
+/**
+ * The dedicated trash confirmation, split out of the edit dialog.
+ *
+ * Opens straight into the decision (no collapsed button): it exists to be shown
+ * when the user chooses to trash a checkout, so it fetches the dirty state on
+ * mount and turns the refusal the user would otherwise hit later into a choice
+ * now — trash anyway, or revert first.
+ */
+export function TrashWorktreeDialog(props: {
+  /** The row's id, to fetch this worktree's git dirty state on demand. */
+  worktreeId: number;
+  /** Fetch the worktree's git dirty state (the files blocking deletion). */
+  onStatus: (id: number) => Promise<WorktreeGitStatus>;
+  /** Discard the worktree's uncommitted changes; returns the new status. */
+  onRevert: (id: number) => Promise<WorktreeGitStatus>;
+  /** Bin the worktree, or with `force` delete it outright. */
+  onTrash: (force: boolean) => Promise<void>;
+  /**
+   * Why the last deletion failed, or `""`.
+   *
+   * Load-bearing, not decoration. Deletion happens later than the click — on the
+   * retention sweep or from the trash — so git's refusal arrives on the row and can
+   * never land in this dialog's own `useSubmit` error. Gating the force checkbox on
+   * that error made `?force=true` unreachable: click → 202 → dialog closes →
+   * reopening gives a fresh, empty error. This is the durable record of the refusal,
+   * and it is what keeps forcing an answer to something the user has been shown
+   * rather than a checkbox offered up front.
+   */
+  trashError: string;
+  onClose: () => void;
+}) {
+  const [force, setForce] = useState(false);
+  const [dirty, setDirty] = useState<WorktreeGitStatus | null>(null);
+  const [statusLoading, setStatusLoading] = useState(true);
+  useEffect(() => {
+    let cancelled = false;
+    props
+      .onStatus(props.worktreeId)
+      .then((s) => {
+        if (!cancelled) setDirty(s);
+      })
+      // An unavailable status (git error, checkout gone) must not block the
+      // trash: binning is non-destructive, so the panel degrades to the plain
+      // "Move to trash" flow and any refusal surfaces later on the row.
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setStatusLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.worktreeId]);
+
+  const del = useSubmit(() => props.onTrash(force));
+  // Either source of a refusal: this attempt's own (a 4xx from the forced path, or
+  // a rejected precondition) or the last background attempt's.
+  const refusal = del.error ?? (props.trashError || null);
+
+  // Discard the worktree's changes, then bin it. Destructive by nature, which
+  // is exactly what the tooltip on the button spells out — see the button below.
+  const revertAndTrash = useSubmit(async () => {
+    await props.onRevert(props.worktreeId); // throws on failure; dialog stays open
+    await props.onTrash(false); // bin the now-clean worktree
+  });
+
+  const dirtyFiles = dirty && dirty.dirty ? dirty.files : [];
+  return (
+    <Modal title="Move to trash" onClose={props.onClose}>
+      <Stack gap="sm">
+        <Text size="sm" c="dimmed">
+          Moves the checkout to the trash. Nothing is deleted yet — it stays on
+          disk and you can restore it from the rail. It is deleted for good when
+          its retention period runs out (Settings → General, off by default) or
+          when you delete it from the trash. The branch itself is always kept.
+          {force
+            ? " Forcing deletes it right now and discards uncommitted changes; it will not start if an environment is still running."
+            : ""}
+        </Text>
+
+        {statusLoading && (
+          <Group gap="xs">
+            <Loader size="xs" />
+            <Text size="sm" c="dimmed">
+              Checking for uncommitted changes…
+            </Text>
+          </Group>
+        )}
+
+        {!statusLoading && dirtyFiles.length > 0 && (
+          <Alert color="yellow" variant="light" p="sm">
+            <Text size="sm" fw={600}>
+              {dirtyFiles.length} uncommitted change
+              {dirtyFiles.length === 1 ? "" : "s"} would block a permanent
+              delete
+            </Text>
+            <Text size="xs" c="dimmed" mt={2}>
+              Trashing keeps these on disk — you can still change your mind.
+              But a later permanent delete will refuse until they are reverted
+              or discarded.
+            </Text>
+            <div style={{ marginTop: 8 }}>
+              <DirtyFileList files={dirtyFiles} />
+            </div>
+          </Alert>
+        )}
+
+        <ErrorText error={refusal} />
+        {refusal && (
+          <Checkbox
+            color="red"
+            label="Delete now, discarding uncommitted changes"
+            checked={force}
+            onChange={(e) => setForce(e.currentTarget.checked)}
+          />
+        )}
+
+        {!statusLoading && dirtyFiles.length > 0 && (
+          <Tooltip
+            label="Discards this worktree's uncommitted changes: tracked files are reset to the last commit and untracked files are removed. This cannot be undone — but it is what lets a later delete succeed cleanly."
+            multiline
+            w={280}
+          >
             <Button
-              color="red"
-              variant="subtle"
+              color="yellow"
+              variant="light"
+              loading={revertAndTrash.busy}
               onClick={(e) => {
                 e.preventDefault();
-                setConfirmDelete(true);
+                void revertAndTrash.submit(e);
               }}
             >
-              Move to trash…
+              Revert changes, then trash
             </Button>
-          )}
-        </Stack>
-      )}
+          </Tooltip>
+        )}
+        {revertAndTrash.error && <ErrorText error={revertAndTrash.error} />}
+
+        <Button
+          color="red"
+          variant="light"
+          loading={del.busy}
+          onClick={(e) => {
+            e.preventDefault();
+            void del.submit(e);
+          }}
+        >
+          {force
+            ? "Delete permanently"
+            : dirtyFiles.length > 0
+              ? "Trash anyway"
+              : "Move to trash"}
+        </Button>
+      </Stack>
     </Modal>
   );
 }


### PR DESCRIPTION
## Summary

When a worktree has uncommitted or untracked files, `git worktree remove` refuses to delete it. Binning a worktree is non-destructive (it stays on disk), so this only bites at a permanent delete — and today it surfaced *after* the attempt failed, with an opaque error and no way to judge which files were in the way.

This makes the trash/delete flow proactive: it detects a dirty checkout, lists the files, and lets the user choose — trash anyway, revert first, or delete-and-discard.

## What changed

**Two new daemon endpoints** (`crates/veld-daemon/src/desktop.rs`):
- `GET /api/worktrees/{id}/status` — the files blocking removal, each with a human label, parsed from raw `git status --porcelain=v1 -z`.
- `POST /api/worktrees/{id}/revert` — discards uncommitted changes (`git restore` + `git clean -fd`, keeping ignored files), non-main worktrees only.

**UI** (`ui/src/components/dialogs.tsx`, `App.tsx`):
- The edit dialog is now purely rename.
- A dedicated **"Move to trash"** dialog (opened by context menu, palette, or drag) fetches the dirty state and offers **Trash anyway** vs **Revert, then trash** (destructive, with an explaining tooltip).
- A **"Delete worktree"** confirm for a dirty *trashed* worktree: **Delete and discard changes** vs **Revert, then delete**, instead of enqueueing a removal that silently fails.

**Repo harness**: `AGENTS.md` + the `/ship` skill now tell agents to leave worktrees clean.

## The key bug fixed along the way

The shared `git()` helper did `.trim()` on its stdout, which strips the leading space of the porcelain code for an **unstaged** edit (` M`). So plain edits were invisible to the dirty check (staged-only), and the delete flow's dirty-check read "clean" and silently failed. `git_status` now reads raw bytes; a real-git integration test pins it.

## Verification
- New integration tests: status parsing against real git (plain edit, staged, untracked), and revert (discards staged/unstaged/untracked, keeps ignored).
- `just lint` and `just test` green.

## Note for the maintainer
Separate from this PR: the committed `Cargo.lock` lags the manifests' version (16.15.0 vs 16.17.3), so **any** `cargo build` in any veld worktree dirties `Cargo.lock` — likely the systemic root cause of the recurring dirty state across agent worktrees. Recommended as a small follow-up commit.