### PR TITLE
fix(release): keep Cargo.lock synced when the release bumps the workspace version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,6 +307,12 @@ jobs:
         with:
           node-version: "22"
 
+      # The `prepareCmd` regenerates Cargo.lock (`cargo update -w`) for the
+      # version bump, so cargo must be available here. Pin the same toolchain
+      # the build job uses. This is the `release` job only — the `plan` job's
+      # dry run never runs `prepare`, so it needs no toolchain.
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+
       - uses: cycjimmy/semantic-release-action@16ca923e6ccbb50770c415a0ccd43709a8c5f7a4
         id: semantic
         with:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,10 +4,10 @@
     ["@semantic-release/commit-analyzer", { "preset": "conventionalcommits" }],
     ["@semantic-release/release-notes-generator", { "preset": "conventionalcommits" }],
     ["@semantic-release/exec", {
-      "prepareCmd": "sed -i'' -e 's/Requires veld v[0-9][0-9.]*/Requires veld v${nextRelease.version}/' -e 's/version: \"[0-9][0-9.]*\"/version: \"${nextRelease.version}\"/' skills/veld/SKILL.md && sed -i'' -e \"s/^version = \\\"[^\\\"]*\\\"/version = \\\"${nextRelease.version}\\\"/\" Cargo.toml && (cd desktop && npm version --no-git-tag-version --allow-same-version ${nextRelease.version})"
+      "prepareCmd": "sed -i'' -e 's/Requires veld v[0-9][0-9.]*/Requires veld v${nextRelease.version}/' -e 's/version: \"[0-9][0-9.]*\"/version: \"${nextRelease.version}\"/' skills/veld/SKILL.md && sed -i'' -e \"s/^version = \\\"[^\\\"]*\\\"/version = \\\"${nextRelease.version}\\\"/\" Cargo.toml && cargo update -w && (cd desktop && npm version --no-git-tag-version --allow-same-version ${nextRelease.version})"
     }],
     ["@semantic-release/git", {
-      "assets": ["skills/veld/SKILL.md", "Cargo.toml", "desktop/package.json", "desktop/package-lock.json"],
+      "assets": ["skills/veld/SKILL.md", "Cargo.toml", "Cargo.lock", "desktop/package.json", "desktop/package-lock.json"],
       "message": "chore(release): v${nextRelease.version} [skip ci]"
     }]
   ]


### PR DESCRIPTION
## What & why

The repo's `Cargo.lock` kept drifting from the workspace manifests after
every release. Root cause: the release's `@semantic-release/git` step
committed the `Cargo.toml` version bump but **omitted `Cargo.lock`**, and
the `prepareCmd` never regenerated it. So the lock lagged one version
behind, and any `cargo build`/`cargo test`/`cargo clippy`/`just lint`/
`just test` in any worktree rewrote `Cargo.lock` — leaving the tree dirty.

A dirty worktree blocks the IDE trash/delete flow (`git worktree remove`
refuses on modified/untracked files), which is how this was surfaced
while working on the trash UX (#260). `interpolation-fixes-issue-246`,
`supply-chain-attack-hardening` and `terminal-notifications-and-window-
renaming` all carried a spurious ` M Cargo.lock`.

## The fix (this PR)

This is the **workflow fix**, not the one-off sync. The one-off lock sync
is already in `origin/main` (commit `d732688` synced it `16.15.0` →
`16.19.0`); this change keeps it from recurring:

1. **`.releaserc.json`** — the `prepareCmd` now runs `cargo update -w`
   after bumping `Cargo.toml`, regenerating `Cargo.lock` for exactly the
   version bump. `-w`/`--workspace` restricts the update to workspace
   members, so **dependency versions are never touched** — it is a pure
   version sync, not an upgrade.
2. **`.releaserc.json`** — added `Cargo.lock` to the `@semantic-release/git`
   `assets`, so the regenerated lock is committed alongside the `Cargo.toml`
   bump.
3. **`.github/workflows/release.yml`** — the `release` job gains the same
   pinned rust toolchain the `build` job uses (`dtolnay/rust-toolchain`), so
   `cargo update -w` is available. The `plan` job's dry run never runs
   `prepare`, so it needs no toolchain.

## Verification

- At HEAD, `Cargo.lock` = workspace = `16.19.0`; `git status --short` is
  clean of `Cargo.lock`.
- A fresh `cargo build --workspace` does **not** dirty `Cargo.lock`.
- `cargo update -w` at the synced HEAD is a no-op ("Locking 0 packages"),
  confirming it only bumps versions when they actually lag.
- `just workflow-gates` (validate-workflow-gates.py, selftest included)
  passes — the added step to the push-only `release` job doesn't disturb
  the draft-PR gate structure.
- `.releaserc.json` validates as strict JSON (semantic-release/cosmiconfig
  does not strip comments).

## One-off vs stay-fixed

**Stays fixed.** The root cause was the release process not re-syncing the
lock; this change makes the release itself keep it synced, so the recurring
dirty-worktree symptom is removed at its source rather than papered over.