### PR TITLE
feat(ui): binary split target when dragging onto an unsplit pane

### DIFF
--- a/crates/veld-daemon/ui/src/panes/PaneArea.tsx
+++ b/crates/veld-daemon/ui/src/panes/PaneArea.tsx
@@ -291,6 +291,16 @@ export function PaneArea(props: {
   const { layout, onLayout } = props;
   const areaRef = useRef<HTMLDivElement>(null);
   const bothVisible = dockVisible(layout, 0) && dockVisible(layout, 1);
+  /**
+   * The same fact, readable from a closure captured once at mount.
+   *
+   * `resolveRemote` is registered with the shell in a `[]` effect, so it closes
+   * over the first render — reading `bothVisible` there directly would freeze
+   * the split-mode decision at mount. The ref carries the live value instead,
+   * the same pattern `dragOutsideRef` uses for the same reason.
+   */
+  const bothVisibleRef = useRef(bothVisible);
+  bothVisibleRef.current = bothVisible;
 
   /**
    * A terminal tab whose close is waiting on a confirmation, or `null`.
@@ -429,7 +439,7 @@ export function PaneArea(props: {
       setRemoteTarget(at ? { at: { dock, ...at } } : { zone: { where: "into", dock } });
       return;
     }
-    setRemoteTarget({ zone: zoneAt(area.getBoundingClientRect(), x, dock) });
+    setRemoteTarget({ zone: zoneAt(area.getBoundingClientRect(), x, dock, !bothVisibleRef.current) });
   };
 
   // Same backstop as the per-dock indicator below: a committed layout retires
@@ -668,7 +678,7 @@ export function PaneArea(props: {
     e.dataTransfer.dropEffect = "move";
     const area = areaRef.current?.getBoundingClientRect();
     if (!area) return;
-    const next = zoneAt(area, e.clientX, dock);
+    const next = zoneAt(area, e.clientX, dock, !bothVisible);
     setDropZone((prev) => (sameZone(prev, next) ? prev : next));
   };
 
@@ -679,7 +689,7 @@ export function PaneArea(props: {
     endTabDragEverywhere();
     if (!id || !area) return;
     e.preventDefault();
-    const zone = zoneAt(area, e.clientX, dock);
+    const zone = zoneAt(area, e.clientX, dock, !bothVisible);
     onLayout(
       zone.where === "into"
         ? moveTab(layout, id, zone.dock)

--- a/crates/veld-daemon/ui/src/panes/dropModel.test.ts
+++ b/crates/veld-daemon/ui/src/panes/dropModel.test.ts
@@ -38,29 +38,29 @@ describe("edgeWidth", () => {
 describe("zoneAt", () => {
   it("reads the edges off the pane area, not the dock under the cursor", () => {
     // The whole point: the same x means the same thing whichever dock is there.
-    expect(zoneAt(area, 150, 0)).toEqual({ where: "left" });
-    expect(zoneAt(area, 150, 1)).toEqual({ where: "left" });
-    expect(zoneAt(area, 1050, 0)).toEqual({ where: "right" });
-    expect(zoneAt(area, 1050, 1)).toEqual({ where: "right" });
+    expect(zoneAt(area, 150, 0, false)).toEqual({ where: "left" });
+    expect(zoneAt(area, 150, 1, false)).toEqual({ where: "left" });
+    expect(zoneAt(area, 1050, 0, false)).toEqual({ where: "right" });
+    expect(zoneAt(area, 1050, 1, false)).toEqual({ where: "right" });
   });
 
   it("is 'into' everywhere between the edges, carrying the hovered dock", () => {
-    expect(zoneAt(area, 600, 0)).toEqual({ where: "into", dock: 0 });
-    expect(zoneAt(area, 600, 1)).toEqual({ where: "into", dock: 1 });
+    expect(zoneAt(area, 600, 0, false)).toEqual({ where: "into", dock: 0 });
+    expect(zoneAt(area, 600, 1, false)).toEqual({ where: "into", dock: 1 });
   });
 
   it("puts the boundary itself in the edge zone", () => {
     // Inclusive on purpose: the pixel where the highlight appears must be one
     // the drop honours, or the preview and the result disagree by one pixel.
-    expect(zoneAt(area, 196, 0)).toEqual({ where: "left" });
-    expect(zoneAt(area, 197, 0)).toEqual({ where: "into", dock: 0 });
-    expect(zoneAt(area, 1004, 1)).toEqual({ where: "right" });
-    expect(zoneAt(area, 1003, 1)).toEqual({ where: "into", dock: 1 });
+    expect(zoneAt(area, 196, 0, false)).toEqual({ where: "left" });
+    expect(zoneAt(area, 197, 0, false)).toEqual({ where: "into", dock: 0 });
+    expect(zoneAt(area, 1004, 1, false)).toEqual({ where: "right" });
+    expect(zoneAt(area, 1003, 1, false)).toEqual({ where: "into", dock: 1 });
   });
 
   it("resolves a pointer outside the area to the nearer edge", () => {
-    expect(zoneAt(area, -20, 0)).toEqual({ where: "left" });
-    expect(zoneAt(area, 5000, 1)).toEqual({ where: "right" });
+    expect(zoneAt(area, -20, 0, false)).toEqual({ where: "left" });
+    expect(zoneAt(area, 5000, 1, false)).toEqual({ where: "right" });
   });
 
   it("prefers left when the zones would overlap in a tiny area", () => {
@@ -68,7 +68,28 @@ describe("zoneAt", () => {
     // order of the checks is what decides. Left is the one that also exists in
     // the one-dock case, so it is the safer answer to make deterministic.
     const tiny = { left: 0, right: 40, width: 40 };
-    expect(zoneAt(tiny, 20, 0)).toEqual({ where: "left" });
+    expect(zoneAt(tiny, 20, 0, false)).toEqual({ where: "left" });
+  });
+
+  it("splits a single pane on the center line instead of an 'into' zone", () => {
+    // The discovery behaviour: on an unsplit view every drop is a split, and
+    // which side is decided by the center line, not the narrow edges.
+    expect(zoneAt(area, 100, 0, true)).toEqual({ where: "left" });
+    expect(zoneAt(area, 599, 0, true)).toEqual({ where: "left" });
+    expect(zoneAt(area, 601, 0, true)).toEqual({ where: "right" });
+    expect(zoneAt(area, 1100, 0, true)).toEqual({ where: "right" });
+  });
+
+  it("puts the center line itself in the right half", () => {
+    // Deterministic choice for the ambiguous pixel: at the exact midpoint the
+    // preview must agree with the drop, and right is the one chosen.
+    expect(zoneAt(area, 600, 0, true)).toEqual({ where: "right" });
+  });
+
+  it("ignores the hovered dock when the view is a single pane", () => {
+    // Whatever dock is under the cursor, the split is decided by the center.
+    expect(zoneAt(area, 200, 1, true)).toEqual({ where: "left" });
+    expect(zoneAt(area, 900, 1, true)).toEqual({ where: "right" });
   });
 });
 

--- a/crates/veld-daemon/ui/src/panes/dropModel.ts
+++ b/crates/veld-daemon/ui/src/panes/dropModel.ts
@@ -49,8 +49,23 @@ export function edgeWidth(areaWidth: number): number {
   return Math.max(28, Math.min(96, areaWidth * 0.16));
 }
 
-/** Which zone a pointer at `clientX` is in, given the dock it is over. */
-export function zoneAt(area: Rect, clientX: number, dock: DockIndex): DropZone {
+/**
+ * Which zone a pointer at `clientX` is in, given the dock it is over.
+ *
+ * `single` is true when the view shows one pane — the view is not split yet.
+ * Then there is nowhere to drop "into" (the whole area *is* the one dock), so
+ * the only useful targets are the two splits, decided by the center line
+ * rather than the narrow edge zones. That is the discovery behaviour: on an
+ * unsplit view a drag into either half visibly promises the split that half
+ * will create, instead of a whole-area "into" that hides the feature. With two
+ * docks visible the edge zones return, because "into" then means something
+ * real (joining the dock under the cursor) and the split is the outlying aim.
+ */
+export function zoneAt(area: Rect, clientX: number, dock: DockIndex, single: boolean): DropZone {
+  if (single) {
+    const mid = area.left + area.width / 2;
+    return clientX < mid ? { where: "left" } : { where: "right" };
+  }
   const edge = edgeWidth(area.width);
   if (clientX <= area.left + edge) return { where: "left" };
   if (clientX >= area.right - edge) return { where: "right" };


### PR DESCRIPTION
## What

Improves discoverability of pane splitting on an unsplit (single-pane) view.

On a view that is not split yet, dragging a tab over the pane **body** now resolves to a **binary split target** decided by the vertical center line:
- left half → **split left** (left-50% highlight)
- right half → **split right** (right-50% highlight)

The old whole-area "into" highlight in the center is gone. It was *correct* (dropping there joined the single dock as a tab) but it hid the split feature from first-time users, because split was only reachable through the thin edge zones.

**Two-dock behavior is unchanged:** the narrow edge zones split, and the center is "into" the hovered dock (join as a tab).

## Why

Discovery convenience — the split gesture on an unsplit pane should be obvious, not discoverable only by dragging to the very edge.

## Implementation

`zoneAt` in `dropModel.ts` gains a `single` flag. When true (single visible pane), the target is binary on the center line; otherwise the existing edge-zone + "into" logic runs unchanged.

`PaneArea.tsx` passes `!bothVisible`. The cross-window drop path (`resolveRemote`) reads it through a ref, because that closure is captured once at mount by a `[]` effect — same idiom as `dragOutsideRef`.

`splitWithTab` already handles the one-dock case (`side 0` splits left, `side 1` moves right), so the binary target needs no change there.

## Edge cases

- Exact center line → split right (deterministic; preview and drop use the same `zoneAt`, so they always agree).
- Single pane where the *other* physical dock happened to be the visible one — still binary, correct either way.
- Pointer outside the area in single-pane → resolves to the nearer side.

## Tests / verification

- `dropModel.test.ts`: new cases for the single-pane binary behavior (left/right halves, center-line boundary, dock-independent).
- Full UI suite: **675 tests pass**; `tsc --noEmit` clean; Biome lint exits 0 (only pre-existing warnings).
- Hand-verified by the maintainer (checkpoint): split left/right on the unsplit view, center-line drop, cross-window drag, and the two-dock "into" regression all confirmed.

## Review

Light review loop (trivia clause — <50-line, no-stakes UI diff): angles 4 & 5. Verdict: **ship it** (zero critical/major). One 🟢 deferred: `dropPreview`'s `if (!bothVisible) return whole-area` branch is now unreachable in single-pane (zone is never "into" there); left as a harmless defensive fallback.
