### PR TITLE
feat(ide): refine first-run worktree, start-config and sharing UI

### DIFF
--- a/crates/veld-daemon/ui/src/App.tsx
+++ b/crates/veld-daemon/ui/src/App.tsx
@@ -59,6 +59,8 @@ import {
   worktreeStatus,
   worstStatus,
   DELETING_LANE,
+  DETACHED_LANE,
+  isDetached,
   TRASH_LANE,
   type PendingAction,
   type RailGroup,
@@ -108,6 +110,7 @@ import {
   IconWorld,
   IconListDetails,
   IconX,
+  IconHelp,
 } from "@tabler/icons-react";
 import { Notifications } from "@mantine/notifications";
 import { ContextMenuProvider, useContextMenu } from "mantine-contextmenu";
@@ -197,6 +200,7 @@ import {
   parseStartSelection,
   pruneStartSelection,
   resolveStartSelection,
+  resolveStoredSelection,
   startBody,
   startSelectionLabel,
   startStorageKey,
@@ -1363,10 +1367,19 @@ function AppInner(props: {
   // hook can't be called per row.
   const startKey = startStorageKey(worktree?.path ?? "_");
   const [startRaw, setStartRaw] = usePersisted(startKey, "");
-  const effectiveStart = worktree
-    ? (pruneStartSelection(worktree, parseStartSelection(startRaw)) ??
-      defaultStartSelection(worktree))
+  // The user's *deliberate* choice, if any. `null` on a worktree that has never
+  // been started here — the point of the first-user-test change: nothing is
+  // pre-selected, and the start button offers the picker instead of guessing.
+  const storedStart = worktree
+    ? pruneStartSelection(worktree, parseStartSelection(startRaw))
     : null;
+  const effectiveStart = worktree
+    ? (storedStart ?? defaultStartSelection(worktree))
+    : null;
+  // Whether the Start-configuration modal is open, and whether Done should start
+  // (true when it was opened from the ▶ start button on a selection-less worktree).
+  const [startConfigOpen, setStartConfigOpen] = useState(false);
+  const startAfterDone = useRef(false);
 
   // Worktrees this window has asked to delete *permanently* and that have not
   // yet vanished. The daemon reports the true point of no return as
@@ -1713,6 +1726,28 @@ function AppInner(props: {
     const r = target ?? targetRun(w);
     if (r) void act(w, r.name, "stop", () => api.stopRun(runRef(w.path, r)));
   };
+
+  /**
+   * The rail's per-row ▶. With a stored choice it starts straight through, like
+   * the top bar; with **no** choice yet it selects the worktree and opens the
+   * same picker the top bar uses, so a first start is "choose, then Done" on the
+   * row you clicked — not a silent default run of the first preset.
+   */
+  const onRailStart = (w: Worktree) => {
+    if (resolveStoredSelection(w)) {
+      startWorktree(w);
+      return;
+    }
+    // No deliberate choice yet. Claim the row first (a row another window holds
+    // cannot be driven from here), then open the picker for it.
+    void (async () => {
+      const ok = await selectWorktree(w);
+      if (!ok) return;
+      startAfterDone.current = true;
+      setStartConfigOpen(true);
+    })();
+  };
+
   const restartWorktree = (w: Worktree, target?: RunInfo | null) => {
     const r = target ?? targetRun(w);
     if (!r) return;
@@ -3333,6 +3368,37 @@ function AppInner(props: {
     await refresh();
   };
 
+  /** Move every detached checkout to the trash, in one go (revertible).
+   *
+   *  The Detached lane exists because detached checkouts are usually
+   *  throwaways, so this is the action that matches the lane's point: clear them
+   *  out without deleting each one by hand. Clean ones bin immediately; a dirty
+   *  one (uncommitted changes) refuses, as `git worktree remove` does, and stays
+   *  in the lane with the reason on its row. */
+  const trashAllDetached = async () => {
+    const detached = worktrees.filter((w) => isDetached(w) && !w.trashed_at);
+    if (detached.length === 0) return;
+    let trashed = 0;
+    for (const w of detached) {
+      // Never the main checkout: it cannot be detached in the first place (git
+      // keeps a repo's main on a branch) and binning it would take the
+      // repository with it.
+      if (w.is_main) continue;
+      try {
+        await api.deleteWorktree(w.id, false);
+        trashed += 1;
+      } catch (e) {
+        notifyError(`Could not move ${worktreeLabel(w)} to the trash`, e);
+      }
+    }
+    if (trashed > 0) {
+      notifyDone(
+        trashed === 1 ? "Moved 1 detached worktree to the trash" : `Moved ${trashed} detached worktrees to the trash`,
+      );
+    }
+    await refresh();
+  };
+
   // Above both bars so the crossfade survives ModeSwitch remounting as it moves
   // between them — see the component's own note. Focus does *not* survive that
   // remount either, which is a real gap the `:focus-visible` rules make more
@@ -4019,8 +4085,20 @@ function AppInner(props: {
           worktree && canRunWorktreeNow(worktree) ? (
             <StartConfig
               worktree={worktree}
-              value={effectiveStart}
+              value={storedStart}
+              opened={startConfigOpen}
+              onOpen={() => setStartConfigOpen(true)}
+              onClose={() => {
+                setStartConfigOpen(false);
+                startAfterDone.current = false;
+              }}
               onChange={(sel) => setStartRaw(JSON.stringify(sel))}
+              onDone={() => {
+                setStartConfigOpen(false);
+                const shouldStart = startAfterDone.current;
+                startAfterDone.current = false;
+                if (shouldStart && worktree) startWorktree(worktree);
+              }}
             />
           ) : null
         }
@@ -4085,7 +4163,17 @@ function AppInner(props: {
         // The bound run, named explicitly: the top bar is the run-level surface,
         // and ■ here must end the run whose name the selector is showing — never
         // whichever one `activeRun` would have picked.
-        onStart={() => worktree && startWorktree(worktree)}
+        onStart={() => {
+          // A worktree with no selection yet opens the picker instead of
+          // guessing: the user asked to run, so the first gesture is choosing
+          // what. Once a choice exists, ▶ starts it directly.
+          if (worktree && !storedStart) {
+            startAfterDone.current = true;
+            setStartConfigOpen(true);
+          } else if (worktree) {
+            startWorktree(worktree);
+          }
+        }}
         onStop={() => worktree && stopWorktree(worktree, run)}
         onRestart={() => worktree && restartWorktree(worktree, run)}
         onSearch={() => setDialog({ kind: "search" })}
@@ -4174,7 +4262,7 @@ function AppInner(props: {
             onSelect={(w) => void selectWorktree(w)}
             onAdd={(lane) => setDialog({ kind: "new-worktree", lane })}
             onMenu={(e, w) => worktreeMenu(w)(e)}
-            onStart={startWorktree}
+            onStart={onRailStart}
             onStop={stopWorktree}
             onDiagnose={diagnoseWorktree}
             onAddLane={() => setDialog({ kind: "new-lane" })}
@@ -4183,6 +4271,7 @@ function AppInner(props: {
             onMoveLane={(lane, onto) => void moveLaneTo(lane, onto)}
             onRestore={restoreWorktree}
             onEmptyTrash={emptyTrash}
+            onTrashAllDetached={trashAllDetached}
             onTrashDrop={trashWorktree}
             deleting={deletingIds}
           />
@@ -4264,6 +4353,7 @@ function AppInner(props: {
           usedBy={markerUsedBy.emoji}
           colorUsedBy={markerUsedBy.color}
           markerStyle={markerStyle(settings ?? {})}
+          onStyleChange={(style) => void saveSettings({ "worktree.markerStyle": style })}
           createFrom={gitCreateFrom(settings ?? {})}
           onCreate={async (body) => {
             let created: Worktree;
@@ -4403,6 +4493,7 @@ function AppInner(props: {
           usedBy={markerUsedBy.emoji}
           colorUsedBy={markerUsedBy.color}
           style={markerStyle(settings ?? {})}
+          onStyleChange={(style) => void saveSettings({ "worktree.markerStyle": style })}
           onClose={closeDialog}
           onPick={async (patch) => {
             await api.patchWorktree(dialog.worktree.id, patch);
@@ -5284,6 +5375,9 @@ function Rail(props: {
   onMoveLane: (lane: string, onto: string) => void;
   onRestore: (w: Worktree) => void;
   onEmptyTrash: () => void;
+  /** Move every detached checkout to the trash (revertible) — the Detached
+   *  lane's one batch action. */
+  onTrashAllDetached: () => void;
   /** Dropping a dragged worktree onto the trash — bins it (revertible), which is
    *  not a lane move. Receives the dragged worktree's path. */
   onTrashDrop: (path: string) => void;
@@ -5637,65 +5731,104 @@ function Rail(props: {
                     its note): a hover-revealed control discovers nothing, and it
                     cannot be reached by keyboard. */}
                 {group.addable && (
-                  <button
-                    type="button"
-                    className="lane-edit"
-                    /* Described by the *lane*, not by the header text, because
-                       `UNGROUPED_LABEL` is itself a legal lane name — a repo with
-                       a lane called "Worktrees" would otherwise give two sections
-                       byte-identical accessible names, which a screen reader
-                       cannot tell apart at all. */
-                    title={
+                  <Tooltip
+                    label={
                       group.lane === ""
                         ? "New worktree, not in a lane"
                         : `New worktree in ${group.lane}`
                     }
-                    aria-label={
-                      group.lane === ""
-                        ? "New worktree, not in a lane"
-                        : `New worktree in lane ${group.lane}`
-                    }
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      props.onAdd(group.lane);
-                    }}
                   >
-                    <IconPlus size={12} />
-                  </button>
+                    <button
+                      type="button"
+                      className="lane-edit"
+                      /* Described by the *lane*, not by the header text, because
+                         `UNGROUPED_LABEL` is itself a legal lane name — a repo with
+                         a lane called "Worktrees" would otherwise give two sections
+                         byte-identical accessible names, which a screen reader
+                         cannot tell apart at all. */
+                      aria-label={
+                        group.lane === ""
+                          ? "New worktree, not in a lane"
+                          : `New worktree in lane ${group.lane}`
+                      }
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        props.onAdd(group.lane);
+                      }}
+                    >
+                      <IconPlus size={12} />
+                    </button>
+                  </Tooltip>
                 )}
                 {/* The trash's own action, in the place a lane keeps its menu:
                     emptying it is the only thing the section as a whole can do. */}
                 {group.key === TRASH_LANE && (
-                  <button
-                    type="button"
-                    className="lane-edit"
-                    title="Delete everything in the trash"
-                    aria-label="Empty the trash"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      props.onEmptyTrash();
-                    }}
-                  >
-                    <IconTrash size={12} />
-                  </button>
+                  <Tooltip label="Delete everything in the trash">
+                    <button
+                      type="button"
+                      className="lane-edit"
+                      aria-label="Empty the trash"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        props.onEmptyTrash();
+                      }}
+                    >
+                      <IconTrash size={12} />
+                    </button>
+                  </Tooltip>
+                )}
+                {/* The Detached lane's own header actions: a question mark that
+                    says what the lane is, and the batch trash that matches its
+                    point (detached checkouts are usually throwaways). The trash
+                    button sits where a lane keeps its menu — like the trash lane,
+                    this section has no real menu, so its one action lives there. */}
+                {group.key === DETACHED_LANE && (
+                  <>
+                    <Tooltip
+                      label="Detached: these checkouts are not on any branch (a detached HEAD). They can’t be pulled or committed to a branch until one is checked out — usually they’re throwaway, so you can clear them all at once."
+                      maw={260}
+                    >
+                      <span
+                        className="lane-edit lane-help"
+                        role="img"
+                        aria-label="What are detached worktrees?"
+                      >
+                        <IconHelp size={12} />
+                      </span>
+                    </Tooltip>
+                    <Tooltip label="Move all detached worktrees to the trash">
+                      <button
+                        type="button"
+                        className="lane-edit"
+                        aria-label="Move all detached worktrees to the trash"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          props.onTrashAllDetached();
+                        }}
+                      >
+                        <IconTrash size={12} />
+                      </button>
+                    </Tooltip>
+                  </>
                 )}
                 {/* Right-click alone is not an affordance — nothing on screen says
                     the header has a menu. The same ⋮ the rows carry, so the two read
                     as the same gesture. Only on a real lane: the trash and the
                     ungrouped section have nothing to rename or delete. */}
                 {group.editable && (
-                  <button
-                    type="button"
-                    className="lane-edit"
-                    title={`Lane menu for ${group.label}`}
-                    aria-label={`Menu for lane ${group.label}`}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      props.onLaneMenu(e, group.lane);
-                    }}
-                  >
-                    <IconDotsVertical size={12} />
-                  </button>
+                  <Tooltip label={`Menu for lane ${group.label}`}>
+                    <button
+                      type="button"
+                      className="lane-edit"
+                      aria-label={`Menu for lane ${group.label}`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        props.onLaneMenu(e, group.lane);
+                      }}
+                    >
+                      <IconDotsVertical size={12} />
+                    </button>
+                  </Tooltip>
                 )}
               </div>
             )}
@@ -6042,25 +6175,45 @@ function Rail(props: {
       style={props.wide ? { width: props.width } : undefined}
     >
       <div className="rail-head">
-        <ActionIcon
-          size="sm"
-          variant="subtle"
-          color="gray"
-          title="Expand / collapse"
-          onClick={props.onToggle}
-        >
-          {props.wide ? <IconChevronLeft size={13} /> : <IconChevronRight size={13} />}
-        </ActionIcon>
-        {props.wide && (
+        <Tooltip label={props.wide ? "Collapse the worktree rail" : "Expand the worktree rail"}>
           <ActionIcon
             size="sm"
             variant="subtle"
             color="gray"
-            title="New lane"
-            onClick={props.onAddLane}
+            aria-label={props.wide ? "Collapse the worktree rail" : "Expand the worktree rail"}
+            onClick={props.onToggle}
           >
-            <IconFolderPlus size={14} />
+            {props.wide ? <IconChevronLeft size={13} /> : <IconChevronRight size={13} />}
           </ActionIcon>
+        </Tooltip>
+        {/* Push the create actions to the right edge of the head — collapse stays
+            put on the left, and the two creates sit together at the far end. */}
+        <div style={{ flex: 1 }} />
+        {props.wide && (
+          <>
+            <Tooltip label="New lane">
+              <ActionIcon
+                size="sm"
+                variant="subtle"
+                color="gray"
+                aria-label="New lane"
+                onClick={props.onAddLane}
+              >
+                <IconFolderPlus size={14} />
+              </ActionIcon>
+            </Tooltip>
+            <Tooltip label="New worktree">
+              <ActionIcon
+                size="sm"
+                variant="subtle"
+                color="gray"
+                aria-label="New worktree"
+                onClick={() => props.onAdd("")}
+              >
+                <IconPlus size={14} />
+              </ActionIcon>
+            </Tooltip>
+          </>
         )}
         {/* Collapsed only, mirroring "New lane" above it — and for the same
             reason, inverted. Expanded, every section that can hold a worktree
@@ -6070,15 +6223,17 @@ function Rail(props: {
             files into the ungrouped section, which is where the old toolbar
             button always put things anyway. */}
         {!props.wide && (
-          <ActionIcon
-            size="sm"
-            variant="subtle"
-            color="gray"
-            title="New worktree"
-            onClick={() => props.onAdd("")}
-          >
-            <IconPlus size={14} />
-          </ActionIcon>
+          <Tooltip label="New worktree">
+            <ActionIcon
+              size="sm"
+              variant="subtle"
+              color="gray"
+              aria-label="New worktree"
+              onClick={() => props.onAdd("")}
+            >
+              <IconPlus size={14} />
+            </ActionIcon>
+          </Tooltip>
         )}
       </div>
       <div

--- a/crates/veld-daemon/ui/src/components/StartConfig.test.ts
+++ b/crates/veld-daemon/ui/src/components/StartConfig.test.ts
@@ -2,7 +2,9 @@ import { beforeEach, describe, expect, it } from "vitest";
 import type { Preset, Worktree } from "../api";
 import {
   defaultStartSelection,
+  modeForSelection,
   parseStartSelection,
+  resolveStoredSelection,
   presetHeading,
   pruneStartSelection,
   resolveStartSelection,
@@ -47,6 +49,15 @@ const wt = (over: Partial<Worktree> = {}): Worktree => ({
   machine_vars: 0,
   ide: { quicklinks: [], permissions: [], panes: [] },
   ...over,
+});
+
+describe("modeForSelection", () => {
+  it("maps a selection to the panel the modal opens on", () => {
+    expect(modeForSelection({ kind: "preset", name: "a" })).toBe("preset");
+    expect(modeForSelection({ kind: "nodes", selections: ["api:dev"] })).toBe("nodes");
+    // No selection yet → the two-card choice screen.
+    expect(modeForSelection(null)).toBe("choose");
+  });
 });
 
 describe("parseStartSelection", () => {
@@ -168,6 +179,37 @@ const store = (() => {
     },
   } satisfies Storage;
 })();
+
+describe("resolveStoredSelection", () => {
+  beforeEach(() => {
+    globalThis.localStorage = store;
+    store.clear();
+  });
+
+  const w = wt({
+    presets: [preset("full")],
+    nodes: [{ name: "api", variants: ["dev"], default_variant: "dev" }],
+  });
+
+  it("returns the stored choice, without the default fallback", () => {
+    // The top bar's ▶ (and the rail's) open the picker on this state instead of
+    // silently running the first preset — the point of the change.
+    expect(resolveStoredSelection(w)).toBeNull();
+    store.setItem(
+      startStorageKey(w.path),
+      JSON.stringify({ kind: "preset", name: "full" }),
+    );
+    expect(resolveStoredSelection(w)).toEqual({ kind: "preset", name: "full" });
+  });
+
+  it("returns null for a stored choice the config no longer offers", () => {
+    store.setItem(
+      startStorageKey(w.path),
+      JSON.stringify({ kind: "preset", name: "renamed-away" }),
+    );
+    expect(resolveStoredSelection(w)).toBeNull();
+  });
+});
 
 describe("resolveStartSelection", () => {
   beforeEach(() => {

--- a/crates/veld-daemon/ui/src/components/StartConfig.tsx
+++ b/crates/veld-daemon/ui/src/components/StartConfig.tsx
@@ -1,13 +1,13 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Button,
   Checkbox,
-  Grid,
   Group,
   Modal,
   NativeSelect,
   Radio,
   ScrollArea,
+  SegmentedControl,
   Stack,
   Text,
 } from "@mantine/core";
@@ -24,6 +24,16 @@ import type { Preset, Worktree } from "../api";
 export type StartSelection =
   | { kind: "preset"; name: string }
   | { kind: "nodes"; selections: string[] };
+
+/** Which panel the modal is showing. `"choose"` is the two-card choice a
+ *  worktree with no selection yet opens on. */
+export type StartMode = "choose" | "preset" | "nodes";
+
+/** The panel a committed selection opens on. */
+export function modeForSelection(sel: StartSelection | null): StartMode {
+  if (sel === null) return "choose";
+  return sel.kind === "preset" ? "preset" : "nodes";
+}
 
 /**
  * The presets this surface can offer.
@@ -102,11 +112,13 @@ export function startStorageKey(path: string): string {
 }
 
 /**
- * What ▶ would start for `w`, resolved straight from localStorage. The rail's
- * per-row controls need this for worktrees other than the selected one, where
- * the `usePersisted` hook backing the top bar isn't available.
+ * The user's *stored* choice for `w` — without the fallback to the default.
+ *
+ * `null` means the user has not deliberately picked a preset/node set yet. The
+ * top bar's ▶ (and the rail's) open the picker on this state rather than
+ * guessing at the default — the point of the first-user-test change.
  */
-export function resolveStartSelection(w: Worktree): StartSelection | null {
+export function resolveStoredSelection(w: Worktree): StartSelection | null {
   let raw = "";
   try {
     // `globalThis`, not `window`: identical in the browser, but it also lets
@@ -115,9 +127,16 @@ export function resolveStartSelection(w: Worktree): StartSelection | null {
   } catch {
     // Private-mode / disabled storage: fall through to the default.
   }
-  return (
-    pruneStartSelection(w, parseStartSelection(raw)) ?? defaultStartSelection(w)
-  );
+  return pruneStartSelection(w, parseStartSelection(raw));
+}
+
+/**
+ * What ▶ would start for `w`, resolved straight from localStorage. The rail's
+ * per-row controls need this for worktrees other than the selected one, where
+ * the `usePersisted` hook backing the top bar isn't available.
+ */
+export function resolveStartSelection(w: Worktree): StartSelection | null {
+  return resolveStoredSelection(w) ?? defaultStartSelection(w);
 }
 
 /**
@@ -168,100 +187,256 @@ export function startSelectionLabel(
   return n === 1 ? sel.selections[0] : `${n} nodes`;
 }
 
+/** The fixed height of the two scrollable lists, so the scrollbar is always
+ *  visible (`ScrollArea type="always"`) — the first test's user did not notice
+ *  the lists scrolled, so this makes the scroll affordance impossible to miss. */
+const LIST_HEIGHT = 340;
+
 /**
- * Start-configuration modal: presets as one-click picks (left panel), custom
- * per-node variant selection (right panel). A modal, not a popover — real
- * configs carry dozens of presets/nodes and need independent scrolling.
+ * Start-configuration modal.
+ *
+ * The design answers the first user test: on a worktree with **no selection yet**
+ * it opens on two big cards — "Select a preset" (the simple, curated path) and
+ * "Custom node selection" (advanced) — so nobody is handed a pre-selected preset
+ * they did not choose. Once something is selected the modal shows only the
+ * relevant panel, with a segmented control to switch to the other. The preset and
+ * node lists are tall always-scrollable regions so it is obvious they scroll.
+ *
+ * The modal is **controlled** (`opened`/`onOpen`/`onClose` live in the app): the
+ * ▶ start button opens the same modal on a worktree with no selection, so
+ * "choose, then Done" is the one gesture for a first start.
  */
 export function StartConfig(props: {
   worktree: Worktree;
+  /** The committed selection, or `null` when the user has not picked one yet. */
   value: StartSelection | null;
+  opened: boolean;
+  onOpen: () => void;
+  onClose: () => void;
   onChange: (sel: StartSelection) => void;
+  /** Called when the user clicks Done. The app decides whether that also starts
+   *  (it does when the modal was opened from the ▶ start button). */
+  onDone: () => void;
 }) {
-  const [opened, setOpened] = useState(false);
   const w = props.worktree;
-  const sel = props.value ?? defaultStartSelection(w);
   const hasPresets = offered(w).length > 0;
+  const hasNodes = w.nodes.length > 0;
+  // A local draft, committed only on Done — picking inside the modal must not
+  // touch storage (or the rail's rows) until the user confirms.
+  const [draft, setDraft] = useState<StartSelection | null>(props.value);
+  const [mode, setMode] = useState<StartMode>(modeForSelection(props.value));
+  // Re-seed the draft each time the modal opens: the committed value may have
+  // changed (another window, a re-read) while it was closed.
+  useEffect(() => {
+    if (props.opened) {
+      setDraft(props.value);
+      setMode(modeForSelection(props.value));
+    }
+    // `props.value` is deliberately not a dependency — the draft is reset on
+    // open, not on every change while the modal is showing.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.opened]);
 
   const selectedVariant = (node: string): string | null => {
-    if (sel?.kind !== "nodes") return null;
-    const hit = sel.selections.find((s) => s.split(":")[0] === node);
+    if (draft?.kind !== "nodes") return null;
+    const hit = draft.selections.find((s) => s.split(":")[0] === node);
     return hit ? (hit.split(":")[1] ?? null) : null;
   };
 
   const toggleNode = (node: string, variant: string, on: boolean) => {
     const current =
-      sel?.kind === "nodes"
-        ? sel.selections.filter((s) => s.split(":")[0] !== node)
-        : [];
-    props.onChange({
-      kind: "nodes",
-      selections: on ? [...current, `${node}:${variant}`] : current,
-    });
+      draft?.kind === "nodes" ? draft.selections.filter((s) => s.split(":")[0] !== node) : [];
+    const selections = on ? [...current, `${node}:${variant}`] : current;
+    // Empty custom selection means "nothing picked" again — back to the cards.
+    if (selections.length === 0) {
+      setDraft(null);
+      setMode("choose");
+    } else {
+      setDraft({ kind: "nodes", selections });
+    }
   };
 
   const customPanel = (
     <Stack gap={0} style={{ minWidth: 0 }}>
       <Text size="xs" fw={600} c="dimmed" tt="uppercase" pb={6}>
-        Custom selection
+        Custom node selection
       </Text>
-      <ScrollArea.Autosize mah={380}>
-        <Stack gap={8} pr={8}>
-          {w.nodes.length === 0 && (
-            <Text size="xs" c="dimmed">
-              No startable nodes in this config.
-            </Text>
-          )}
-          {w.nodes.map((n) => {
-            const variant = selectedVariant(n.name);
-            const fallback = n.default_variant ?? n.variants[0];
-            return (
-              <Group key={n.name} gap="xs" wrap="nowrap">
-                <Checkbox
-                  size="xs"
-                  label={n.name}
-                  checked={variant !== null}
-                  onChange={(e) =>
-                    toggleNode(n.name, fallback, e.currentTarget.checked)
-                  }
-                  styles={{
-                    body: { alignItems: "center" },
-                    labelWrapper: { minWidth: 0 },
-                    label: {
-                      fontFamily: "var(--mantine-font-family-monospace)",
-                      whiteSpace: "nowrap",
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                      display: "block",
-                    },
-                  }}
-                  style={{ flex: 1, minWidth: 0, overflow: "hidden" }}
-                />
-                {n.variants.length > 1 && (
-                  <NativeSelect
+      {hasNodes ? (
+        <ScrollArea type="always" offsetScrollbars style={{ height: LIST_HEIGHT }}>
+          <Stack gap={8} pr={10}>
+            {w.nodes.map((n) => {
+              const variant = selectedVariant(n.name);
+              const fallback = n.default_variant ?? n.variants[0];
+              return (
+                <Group key={n.name} gap="xs" wrap="nowrap">
+                  <Checkbox
                     size="xs"
-                    w={130}
-                    style={{ flex: "none" }}
-                    value={variant ?? fallback}
-                    disabled={variant === null}
+                    label={n.name}
+                    checked={variant !== null}
                     onChange={(e) =>
-                      toggleNode(n.name, e.currentTarget.value, true)
+                      toggleNode(n.name, fallback, e.currentTarget.checked)
                     }
-                    data={n.variants}
                     styles={{
-                      input: {
+                      body: { alignItems: "center" },
+                      labelWrapper: { minWidth: 0 },
+                      label: {
                         fontFamily: "var(--mantine-font-family-monospace)",
+                        whiteSpace: "nowrap",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        display: "block",
                       },
                     }}
+                    style={{ flex: 1, minWidth: 0, overflow: "hidden" }}
                   />
-                )}
-              </Group>
-            );
-          })}
-        </Stack>
-      </ScrollArea.Autosize>
+                  {n.variants.length > 1 && (
+                    <NativeSelect
+                      size="xs"
+                      w={130}
+                      style={{ flex: "none" }}
+                      value={variant ?? fallback}
+                      disabled={variant === null}
+                      onChange={(e) =>
+                        toggleNode(n.name, e.currentTarget.value, true)
+                      }
+                      data={n.variants}
+                      styles={{
+                        input: {
+                          fontFamily: "var(--mantine-font-family-monospace)",
+                        },
+                      }}
+                    />
+                  )}
+                </Group>
+              );
+            })}
+          </Stack>
+        </ScrollArea>
+      ) : (
+        <Text size="xs" c="dimmed">
+          No startable nodes in this config.
+        </Text>
+      )}
     </Stack>
   );
+
+  const presetsPanel = (
+    <Stack gap={0} style={{ minWidth: 0 }}>
+      <Text size="xs" fw={600} c="dimmed" tt="uppercase" pb={6}>
+        Presets
+      </Text>
+      <ScrollArea type="always" offsetScrollbars style={{ height: LIST_HEIGHT }}>
+        <Radio.Group
+          value={draft?.kind === "preset" ? draft.name : null}
+          onChange={(name) => setDraft({ kind: "preset", name })}
+        >
+          <Stack gap={7} pr={10}>
+            {offered(w).map((p, i) => {
+              const heading = presetHeading(offered(w), i);
+              return (
+                <div key={p.name}>
+                  {heading != null && (
+                    <Text
+                      size="xs"
+                      fw={600}
+                      c="dimmed"
+                      pt={i === 0 ? 0 : 8}
+                      pb={4}
+                    >
+                      {heading}
+                    </Text>
+                  )}
+                  <Radio
+                    value={p.name}
+                    size="xs"
+                    label={
+                      <Stack gap={0}>
+                        <Group gap={6} wrap="nowrap">
+                          <Text size="xs" c="dimmed" ff="monospace">
+                            {p.key}
+                          </Text>
+                          <Text size="xs">{p.label ?? p.name}</Text>
+                          {p.is_default && (
+                            <Text size="xs" c="dimmed">
+                              default
+                            </Text>
+                          )}
+                        </Group>
+                        {p.when_to_use && (
+                          <Text size="xs" c="dimmed">
+                            {p.when_to_use}
+                          </Text>
+                        )}
+                      </Stack>
+                    }
+                  />
+                </div>
+              );
+            })}
+          </Stack>
+        </Radio.Group>
+      </ScrollArea>
+    </Stack>
+  );
+
+  /** The segmented control shown once something is selected, switching between
+   *  the preset and custom panels without losing the choice. */
+  const tabs = (hasPresets || hasNodes) && mode !== "choose" && (
+    <SegmentedControl
+      size="xs"
+      fullWidth
+      value={mode}
+      onChange={(v) => setMode(v as StartMode)}
+      data={[
+        ...(hasPresets ? [{ value: "preset", label: "Presets" }] : []),
+        ...(hasNodes ? [{ value: "nodes", label: "Custom nodes" }] : []),
+      ]}
+    />
+  );
+
+  /** The two-card choice shown when nothing has been picked yet. */
+  const choiceCards = (
+    <Stack gap="md" pt="xs">
+      <Text size="sm" c="dimmed">
+        Choose how to start this worktree. Nothing is pre-selected — pick the
+        option that fits, or close to decide later.
+      </Text>
+      <Group grow align="stretch" wrap="nowrap">
+        {hasPresets && (
+          <button
+            type="button"
+            className="start-mode-card"
+            onClick={() => setMode("preset")}
+          >
+            <Text size="sm" fw={700}>
+              Select a preset
+            </Text>
+            <Text size="xs" c="dimmed">
+              The simplest option. The project&apos;s author curated ready-made
+              setups — pick one and go.
+            </Text>
+          </button>
+        )}
+        {hasNodes && (
+          <button
+            type="button"
+            className="start-mode-card"
+            onClick={() => setMode("nodes")}
+          >
+            <Text size="sm" fw={700}>
+              Custom node selection
+            </Text>
+            <Text size="xs" c="dimmed">
+              For advanced use. Choose exactly which nodes run and which variant
+              each uses.
+            </Text>
+          </button>
+        )}
+      </Group>
+    </Stack>
+  );
+
+  const nothingToStart = !hasPresets && !hasNodes;
 
   return (
     <>
@@ -278,16 +453,16 @@ export function StartConfig(props: {
         size="compact-sm"
         variant="default"
         rightSection={<IconChevronDown size={12} />}
-        onClick={() => setOpened(true)}
+        onClick={props.onOpen}
         title="What ▶ will start next — not what is running now"
       >
-        Start: {startSelectionLabel(sel, w)}
+        {props.value ? `Start: ${startSelectionLabel(props.value, w)}` : "Choose preset or nodes"}
       </Button>
       <Modal
-        opened={opened}
-        onClose={() => setOpened(false)}
+        opened={props.opened}
+        onClose={props.onClose}
         title="Start configuration"
-        size={hasPresets ? 680 : 440}
+        size={760}
         yOffset={88}
         radius="lg"
         overlayProps={{ backgroundOpacity: 0.42 }}
@@ -296,85 +471,51 @@ export function StartConfig(props: {
           body: { paddingTop: "var(--mantine-spacing-md)" },
         }}
       >
-        {hasPresets ? (
-          <Grid gap="lg">
-            <Grid.Col span={6}>
-              <Stack gap={0}>
-                <Text size="xs" fw={600} c="dimmed" tt="uppercase" pb={6}>
-                  Presets
-                </Text>
-                <ScrollArea.Autosize mah={380}>
-                  <Radio.Group
-                    value={sel?.kind === "preset" ? sel.name : null}
-                    onChange={(name) => {
-                      props.onChange({ kind: "preset", name });
-                      setOpened(false);
-                    }}
-                  >
-                    <Stack gap={7} pr={8}>
-                      {offered(w).map((p, i) => {
-                        const heading = presetHeading(offered(w), i);
-                        return (
-                          <div key={p.name}>
-                            {heading != null && (
-                              <Text
-                                size="xs"
-                                fw={600}
-                                c="dimmed"
-                                pt={i === 0 ? 0 : 8}
-                                pb={4}
-                              >
-                                {heading}
-                              </Text>
-                            )}
-                            <Radio
-                              value={p.name}
-                              size="xs"
-                              label={
-                                <Stack gap={0}>
-                                  <Group gap={6} wrap="nowrap">
-                                    <Text size="xs" c="dimmed" ff="monospace">
-                                      {p.key}
-                                    </Text>
-                                    <Text size="xs">
-                                      {p.label ?? p.name}
-                                    </Text>
-                                    {p.is_default && (
-                                      <Text size="xs" c="dimmed">
-                                        default
-                                      </Text>
-                                    )}
-                                  </Group>
-                                  {p.when_to_use && (
-                                    <Text size="xs" c="dimmed">
-                                      {p.when_to_use}
-                                    </Text>
-                                  )}
-                                </Stack>
-                              }
-                            />
-                          </div>
-                        );
-                      })}
-                    </Stack>
-                  </Radio.Group>
-                </ScrollArea.Autosize>
-              </Stack>
-            </Grid.Col>
-            <Grid.Col span={6}>{customPanel}</Grid.Col>
-          </Grid>
+        {nothingToStart ? (
+          <Text size="xs" c="dimmed" py="sm">
+            Nothing to start — this config declares no presets and no startable
+            nodes.
+          </Text>
+        ) : mode === "choose" ? (
+          choiceCards
         ) : (
-          customPanel
+          <Stack gap="md">
+            {tabs}
+            <div style={{ minHeight: LIST_HEIGHT }}>
+              {mode === "preset" ? presetsPanel : customPanel}
+            </div>
+          </Stack>
         )}
         <Group
-          justify="end"
+          justify="space-between"
           pt="md"
           mt="md"
           style={{ borderTop: "1px solid var(--border)" }}
         >
-          <Button size="compact-sm" onClick={() => setOpened(false)}>
-            Done
-          </Button>
+          <Text size="xs" c="dimmed">
+            {draft
+              ? `Will start: ${startSelectionLabel(draft, w)}`
+              : "Nothing selected yet."}
+          </Text>
+          <Group gap="sm">
+            <Button size="compact-sm" variant="default" onClick={props.onClose}>
+              Cancel
+            </Button>
+            <Button
+              size="compact-sm"
+              disabled={draft === null}
+              onClick={() => {
+                if (!draft) return;
+                props.onChange(draft);
+                // `onDone` before `onClose`: the app reads a flag that `onClose`
+                // clears, so starting must happen before the modal shuts down.
+                props.onDone();
+                props.onClose();
+              }}
+            >
+              Done
+            </Button>
+          </Group>
         </Group>
       </Modal>
     </>

--- a/crates/veld-daemon/ui/src/components/dialogs.tsx
+++ b/crates/veld-daemon/ui/src/components/dialogs.tsx
@@ -8,6 +8,7 @@ import {
   Loader,
   Modal as MantineModal,
   ScrollArea,
+  SegmentedControl,
   Stack,
   Text,
   TextInput,
@@ -226,6 +227,10 @@ export function NewWorktreeDialog(props: {
   colorUsedBy: Record<string, EmojiHolder[]>;
   /** Which marker face the rail renders, so the grids can label it. */
   markerStyle: MarkerStyle;
+  /** Switch the rail's marker face — a settings change, offered right in the
+   *  dialog so a user who sees one face never has to find Settings to reach the
+   *  other (the first test's confusion). */
+  onStyleChange: (style: MarkerStyle) => void;
   /** Where a new branch is cut from (`git.createFrom`) — shown so the create
    *  states where the worktree starts, rather than leaving it a guess. */
   createFrom: GitCreateFrom;
@@ -418,6 +423,7 @@ export function NewWorktreeDialog(props: {
               usedBy={props.usedBy}
               colorUsedBy={props.colorUsedBy}
               style={props.markerStyle}
+              onStyleChange={props.onStyleChange}
               // Local until the worktree exists, so nothing is ever in flight.
               busy={null}
               loaded={loaded}
@@ -429,8 +435,8 @@ export function NewWorktreeDialog(props: {
               }
             />
             <Text size="xs" c="dimmed">
-              A free colour and glyph are picked at random — change either, or leave
-              them.
+              A free one is picked at random — change it, or leave it. The other
+              face is saved too, so it is there if you switch.
             </Text>
           </Stack>
         </Stack>
@@ -541,6 +547,9 @@ export function MarkerGrids(props: {
   busy: string | null;
   /** The lists from [`useMarkerChoices`], hoisted so a caller can preselect. */
   loaded: ReturnType<typeof useMarkerChoices>;
+  /** Switch the rail's marker face — a settings change, offered *inside* the picker
+   *  so a user who sees one face never has to find the setting to reach the other. */
+  onStyleChange: (style: MarkerStyle) => void;
   onPick: (patch: { emoji?: string; marker_color?: string }) => void;
 }) {
   const busy = props.busy;
@@ -549,116 +558,140 @@ export function MarkerGrids(props: {
   const pick = (patch: { emoji?: string; marker_color?: string }) =>
     props.onPick(patch);
 
+  const colourGrid = colors !== null ? (
+    <>
+      <Text size="xs" fw={600} c="dimmed">
+        Colour
+      </Text>
+      <div className="swatch-grid">
+        {colors.map((color) => {
+          const isCurrent = color === props.color;
+          // Same treatment as the glyph grid. It matters more here: eight
+          // colours against a repo that can hold more checkouts than that
+          // means a within-repo duplicate is likely, and within-repo is the
+          // only scope where distinctness is claimed.
+          const others = (props.colorUsedBy[color] ?? []).filter(
+            (h) => h.id !== props.worktreeId,
+          );
+          const taken = others.map((h) => h.label).join(", ");
+          return (
+            <button
+              key={color}
+              type="button"
+              className={`swatch-cell${isCurrent ? " current" : ""}`}
+              disabled={busy !== null}
+              aria-pressed={isCurrent}
+              aria-label={
+                taken
+                  ? `Colour ${color} — in use by ${taken}`
+                  : `Colour ${color}${isCurrent ? " — current" : ""}`
+              }
+              title={
+                [
+                  isCurrent ? "Current" : color,
+                  taken ? `In use by ${taken}` : "",
+                ]
+                  .filter(Boolean)
+                  .join(" · ") || undefined
+              }
+              onClick={() => pick({ marker_color: color })}
+            >
+              {busy === color ? (
+                <Loader size={14} />
+              ) : (
+                /* Classed, not styled by position. `.swatch-cell > span`
+                   also matched the `.marker-taken` marker below and — being
+                   the more specific selector — inflated that 4px dot to a
+                   16px circle. */
+                <span className="swatch-dot" style={{ background: color }} />
+              )}
+              {taken && <span className="marker-taken" />}
+            </button>
+          );
+        })}
+      </div>
+    </>
+  ) : null;
+
+  const emojiGrid = choices ? (
+    <>
+      <Text size="xs" fw={600} c="dimmed">
+        Glyph
+      </Text>
+      <div className="emoji-grid">
+        {choices.map((e) => {
+          const isCurrent = e === props.emoji;
+          // Every holder that isn't this worktree. Compared by id, not
+          // alias, and covering all holders rather than the first: a
+          // collision with another project's identically-named worktree
+          // is precisely what the picker exists to surface.
+          const others = (props.usedBy[e] ?? []).filter(
+            (h) => h.id !== props.worktreeId,
+          );
+          const taken = others.map((h) => h.label).join(", ");
+          return (
+            <button
+              key={e}
+              type="button"
+              className={`emoji-cell${isCurrent ? " current" : ""}`}
+              disabled={busy !== null}
+              aria-pressed={isCurrent}
+              aria-label={taken ? `${e} — in use by ${taken}` : e}
+              title={
+                [
+                  isCurrent ? "Current" : "",
+                  taken ? `In use by ${taken}` : "",
+                ]
+                  .filter(Boolean)
+                  .join(" · ") || undefined
+              }
+              onClick={() => pick({ emoji: e })}
+            >
+              {busy === e ? (
+                <Loader size={14} />
+              ) : (
+                <span aria-hidden="true">{e}</span>
+              )}
+              {taken && <span className="marker-taken" />}
+            </button>
+          );
+        })}
+      </div>
+    </>
+  ) : null;
+
   return (
     <>
       {loadError && <ErrorText error={loadError} />}
-        {colors !== null && (
-          <>
-            <Text size="xs" fw={600} c="dimmed">
-              Colour{props.style === "color" ? " (shown in the rail)" : ""}
-            </Text>
-            <div className="swatch-grid">
-              {colors.map((color) => {
-                const isCurrent = color === props.color;
-                // Same treatment as the glyph grid. It matters more here: eight
-                // colours against a repo that can hold more checkouts than that
-                // means a within-repo duplicate is likely, and within-repo is the
-                // only scope where distinctness is claimed.
-                const others = (props.colorUsedBy[color] ?? []).filter(
-                  (h) => h.id !== props.worktreeId,
-                );
-                const taken = others.map((h) => h.label).join(", ");
-                return (
-                  <button
-                    key={color}
-                    type="button"
-                    className={`swatch-cell${isCurrent ? " current" : ""}`}
-                    disabled={busy !== null}
-                    aria-pressed={isCurrent}
-                    aria-label={
-                      taken
-                        ? `Colour ${color} — in use by ${taken}`
-                        : `Colour ${color}${isCurrent ? " — current" : ""}`
-                    }
-                    title={
-                      [
-                        isCurrent ? "Current" : color,
-                        taken ? `In use by ${taken}` : "",
-                      ]
-                        .filter(Boolean)
-                        .join(" · ") || undefined
-                    }
-                    onClick={() => pick({ marker_color: color })}
-                  >
-                    {busy === color ? (
-                      <Loader size={14} />
-                    ) : (
-                      /* Classed, not styled by position. `.swatch-cell > span`
-                         also matched the `.marker-taken` marker below and — being
-                         the more specific selector — inflated that 4px dot to a
-                         16px circle. */
-                      <span className="swatch-dot" style={{ background: color }} />
-                    )}
-                    {taken && <span className="marker-taken" />}
-                  </button>
-                );
-              })}
-            </div>
-            <Text size="xs" fw={600} c="dimmed">
-              Glyph{props.style === "emoji" ? " (shown in the rail)" : ""}
-            </Text>
-          </>
-        )}
-        {!choices && !loadError && (
-          <Group justify="center" py="lg">
-            <Loader size="sm" aria-label="Loading emoji" />
-          </Group>
-        )}
-        {choices && (
-          <div className="emoji-grid">
-            {choices.map((e) => {
-              const isCurrent = e === props.emoji;
-              // Every holder that isn't this worktree. Compared by id, not
-              // alias, and covering all holders rather than the first: a
-              // collision with another project's identically-named worktree
-              // is precisely what the picker exists to surface.
-              const others = (props.usedBy[e] ?? []).filter(
-                (h) => h.id !== props.worktreeId,
-              );
-              const taken = others.map((h) => h.label).join(", ");
-              return (
-                <button
-                  key={e}
-                  type="button"
-                  className={`emoji-cell${isCurrent ? " current" : ""}`}
-                  disabled={busy !== null}
-                  aria-pressed={isCurrent}
-                  aria-label={taken ? `${e} — in use by ${taken}` : e}
-                  title={
-                    [
-                      isCurrent ? "Current" : "",
-                      taken ? `In use by ${taken}` : "",
-                    ]
-                      .filter(Boolean)
-                      .join(" · ") || undefined
-                  }
-                  onClick={() => pick({ emoji: e })}
-                >
-                  {busy === e ? (
-                    <Loader size={14} />
-                  ) : (
-                    <span aria-hidden="true">{e}</span>
-                  )}
-                  {taken && <span className="marker-taken" />}
-                </button>
-              );
-            })}
-          </div>
-        )}
-        <Text size="xs" c="dimmed">
-          A dot marks a colour or glyph another checkout of this repo already uses.
-          Picking it is allowed — the rail just won&apos;t identify them apart.
-        </Text>
+      {/* The two faces, switchable right here. The first user test confused the
+          two marker types when both grids sat in one dialog, so only the face
+          the rail renders is shown — and the other face is switched to by
+          changing the setting in place, so nobody has to go find Settings. */}
+      <SegmentedControl
+        size="xs"
+        fullWidth
+        value={props.style}
+        onChange={(v) => props.onStyleChange(v as MarkerStyle)}
+        data={[
+          { value: "color", label: "Colour" },
+          { value: "emoji", label: "Emoji" },
+        ]}
+      />
+      <Text size="xs" c="dimmed">
+        {props.style === "color"
+          ? "This is what the rail shows. The glyph is still saved, so it is there if you switch."
+          : "This is what the rail shows. The colour is still saved, so it is there if you switch."}
+      </Text>
+      {props.style === "color" ? colourGrid : emojiGrid}
+      {props.style === "emoji" && !choices && !loadError && (
+        <Group justify="center" py="lg">
+          <Loader size="sm" aria-label="Loading emoji" />
+        </Group>
+      )}
+      <Text size="xs" c="dimmed">
+        A dot marks a colour or glyph another checkout of this repo already uses.
+        Picking it is allowed — the rail just won&apos;t identify them apart.
+      </Text>
     </>
   );
 }
@@ -679,6 +712,8 @@ export function ChangeMarkerDialog(props: {
   usedBy: Record<string, EmojiHolder[]>;
   colorUsedBy: Record<string, EmojiHolder[]>;
   style: MarkerStyle;
+  /** Switch the rail's marker face — see `MarkerGrids`. */
+  onStyleChange: (style: MarkerStyle) => void;
   onPick: (patch: { emoji?: string; marker_color?: string }) => Promise<void>;
   onClose: () => void;
 }) {
@@ -708,15 +743,15 @@ export function ChangeMarkerDialog(props: {
           colorUsedBy={props.colorUsedBy}
           worktreeId={props.worktreeId}
           style={props.style}
+          onStyleChange={props.onStyleChange}
           busy={busy}
           loaded={loaded}
           onPick={(patch) => void pick(patch)}
         />
         <ErrorText error={error} />
         <Text size="xs" c="dimmed">
-          Both halves are always saved, so you can set the one you aren&apos;t
-          currently showing and it will be waiting if you switch. Which one the
-          rail renders is under Settings → General.
+          Both halves are always saved, so the one you aren&apos;t currently
+          showing is waiting if you switch the face up top.
         </Text>
       </Stack>
     </Modal>

--- a/crates/veld-daemon/ui/src/model.test.ts
+++ b/crates/veld-daemon/ui/src/model.test.ts
@@ -32,6 +32,7 @@ import {
   worktreeStatus,
   worstStatus,
   DELETING_LANE,
+  DETACHED_LANE,
   TRASH_LANE,
 } from "./model";
 
@@ -896,6 +897,59 @@ describe("railGroups", () => {
   it("omits the deleting lane when nothing is being deleted", () => {
     const groups = railGroups([rw("/wts/a")], []);
     expect(groups.some((g) => g.key === DELETING_LANE)).toBe(false);
+  });
+
+  it("groups detached checkouts into their own lane, between ungrouped and lanes", () => {
+    // A detached HEAD is a state worth surfacing on its own, so detached
+    // checkouts get a virtual lane of their own after the ungrouped worktrees
+    // and before the real lanes.
+    const groups = railGroups(
+      [
+        rw("/wts/a"),
+        rw("/wts/det", { branch: "(detached)" }),
+        rw("/wts/b", { lane: "review" }),
+      ],
+      [lane("review", 0)],
+    );
+    const live = groups.filter(
+      (g) => g.key !== TRASH_LANE && g.key !== DELETING_LANE,
+    );
+    expect(live.map((g) => g.key)).toEqual(["", DETACHED_LANE, "review"]);
+    const det = live.find((g) => g.key === DETACHED_LANE)!;
+    expect(det.label).toBe("Detached");
+    expect(det.pinned).toBe(true);
+    // Pinned and not a drop target — you cannot file a checkout *as* detached.
+    expect(det.addable).toBe(false);
+    expect(det.editable).toBe(false);
+    expect(det.worktrees.map((w) => w.path)).toEqual(["/wts/det"]);
+  });
+
+  it("pulls a detached checkout out of its lane while it is detached", () => {
+    // Being detached overrides where the row belongs (same rule the trash
+    // applies to trashed rows): it leaves the lane and returns when a branch is
+    // checked out again.
+    const groups = railGroups(
+      [rw("/wts/det", { branch: "(detached)", lane: "review" })],
+      [lane("review", 0)],
+    );
+    expect(groups.find((g) => g.key === DETACHED_LANE)?.worktrees).toHaveLength(1);
+    expect(groups.find((g) => g.key === "review")?.worktrees).toHaveLength(0);
+  });
+
+  it("omits the detached lane when nothing is detached", () => {
+    const groups = railGroups([rw("/wts/a")], []);
+    expect(groups.some((g) => g.key === DETACHED_LANE)).toBe(false);
+  });
+
+  it("keeps a detached main checkout out of the detached lane", () => {
+    // git keeps a repo's main on a branch, so a detached main is not a real
+    // state — but the row must not silently disappear from the rail either.
+    const groups = railGroups([rw("/repo", { is_main: true, branch: "(detached)" })], []);
+    const live = groups.filter(
+      (g) => g.key !== TRASH_LANE && g.key !== DELETING_LANE,
+    );
+    expect(live.map((g) => g.key)).toEqual(["main", ""]);
+    expect(live[0].worktrees.map((w) => w.path)).toEqual(["/repo"]);
   });
 });
 

--- a/crates/veld-daemon/ui/src/model.ts
+++ b/crates/veld-daemon/ui/src/model.ts
@@ -471,6 +471,29 @@ export const TRASH_LANE = "\u0000trash";
 export const DELETING_LANE = "\u0000deleting";
 
 /**
+ * Group key for the virtual "Detached" lane — checkouts with a detached HEAD.
+ *
+ * Like [`TRASH_LANE`] / [`DELETING_LANE`], not a lane name: a leading NUL cannot
+ * occur in a lane name, so a repo lane can never collide with it.
+ *
+ * A detached checkout is a git state, not a lane the user filed something into,
+ * so it gets a section of its own (between the ungrouped worktrees and the real
+ * lanes) and never joins the lane it was assigned while detached — being detached
+ * is the more important thing to say about it. `branch === "(detached)"` is the
+ * daemon's spelling (`crates/veld-daemon/src/desktop.rs`); the constant below is
+ * the one place the UI names it, so a rename lives here rather than at call sites.
+ */
+export const DETACHED_LANE = "\u0000detached";
+
+/** The branch a checkout carries when its HEAD is detached. Mirrors the daemon. */
+export const DETACHED_BRANCH = "(detached)";
+
+/** Whether a worktree is on a detached HEAD — the thing the Detached lane groups. */
+export function isDetached(w: Worktree): boolean {
+  return w.branch === DETACHED_BRANCH;
+}
+
+/**
  * Header for the section that holds every worktree the user has not filed into a
  * lane.
  *
@@ -488,8 +511,9 @@ export const DELETING_LANE = "\u0000deleting";
 export const UNGROUPED_LABEL = "Worktrees";
 
 /**
- * Split a repo's worktrees into rail sections: ungrouped first, then each lane in
- * its own order, then the terminal "Deleting" lane, then the trash.
+ * Split a repo's worktrees into rail sections: ungrouped first, then the detached
+ * checkouts, then each lane in its own order, then the terminal "Deleting" lane,
+ * then the trash.
  *
  * The daemon already sorts the worktrees into this order (`WT_ORDER`), so this
  * only *segments* the list — it must not re-sort, or the manual order the user
@@ -499,8 +523,8 @@ export const UNGROUPED_LABEL = "Worktrees";
  * still needs somewhere to drop a worktree. The **trash is always kept too** — it
  * is the rail's permanent bottom anchor, rendered as an empty lane rather than
  * hidden — so the user always has a place that means "trash exists". The
- * Deleting lane is conditional: it is a transient state, so an empty one would be
- * permanent clutter.
+ * Deleting lane and the Detached lane are conditional: each is a state, so an
+ * empty one would be permanent clutter.
  */
 export function railGroups(worktrees: Worktree[], lanes: Lane[]): RailGroup[] {
   const live = worktrees.filter((w) => !w.trashed_at);
@@ -509,17 +533,27 @@ export function railGroups(worktrees: Worktree[], lanes: Lane[]): RailGroup[] {
   // but the two states are not the same thing and must not share a lane.
   const deleting = worktrees.filter((w) => w.deleting);
   const trashed = worktrees.filter((w) => w.trashed_at && !w.deleting);
+  // Detached checkouts come out of every other section, whatever lane they were
+  // filed into: a detached HEAD is a state that overrides where a row belongs
+  // (same rule the trash applies to trashed rows).
+  const detached = live.filter((w) => isDetached(w) && !w.is_main);
   const known = new Set(lanes.map((l) => l.name));
   // A worktree whose lane no longer exists counts as ungrouped rather than
   // vanishing. `delete_lane` clears assignments in the same transaction, so this
   // should not arise — but a row the client cannot place is a row the user cannot
   // reach, and that is the worse failure.
-  const ungrouped = live.filter((w) => !w.lane || !known.has(w.lane));
+  const ungrouped = live.filter(
+    (w) => !w.is_main && !isDetached(w) && (!w.lane || !known.has(w.lane)),
+  );
   // The main checkout gets a section of its own — it is the repository, not one of
   // the branches you are juggling, and a divider under it says so. Only while it is
   // ungrouped: assigned to a lane it belongs in that lane, because the user put it
-  // there on purpose.
-  const main = ungrouped.filter((w) => w.is_main);
+  // there on purpose. A *detached* main leads the rail too (and is never a
+  // throwaway in the Detached lane — it is the repo), but is not a lane member
+  // while detached, because detached overrides lane like every other row.
+  const main = live.filter(
+    (w) => w.is_main && (isDetached(w) || !w.lane || !known.has(w.lane)),
+  );
   const groups: RailGroup[] = [];
   if (main.length > 0) {
     groups.push({
@@ -545,7 +579,26 @@ export function railGroups(worktrees: Worktree[], lanes: Lane[]): RailGroup[] {
     editable: false,
     worktrees: ungrouped.filter((w) => !w.is_main),
   });
+  // The virtual Detached lane, between the ungrouped worktrees and the real
+  // lanes. Conditional like Deleting: an empty one would be permanent clutter.
+  // Pinned and not a drop target — a checkout cannot be *filed* as detached, it
+  // is detected. It carries the group's action (trash all) in its header, so
+  // `addable`/`editable` both stay false and the section renders header actions
+  // by `key` instead.
+  if (detached.length > 0) {
+    groups.push({
+      key: DETACHED_LANE,
+      lane: DETACHED_LANE,
+      label: "Detached",
+      pinned: true,
+      addable: false,
+      editable: false,
+      worktrees: detached,
+    });
+  }
   for (const l of lanes) {
+    // A detached checkout stays out of its lane while it is detached; it returns
+    // when it is put back on a branch.
     groups.push({
       key: l.name,
       lane: l.name,
@@ -553,7 +606,7 @@ export function railGroups(worktrees: Worktree[], lanes: Lane[]): RailGroup[] {
       pinned: false,
       addable: true,
       editable: true,
-      worktrees: live.filter((w) => w.lane === l.name),
+      worktrees: live.filter((w) => w.lane === l.name && !isDetached(w)),
     });
   }
   if (deleting.length > 0) {

--- a/crates/veld-daemon/ui/src/shared/Sharing.tsx
+++ b/crates/veld-daemon/ui/src/shared/Sharing.tsx
@@ -15,8 +15,10 @@
 
 import { Badge, Button, Checkbox, Group, Stack, Text, Tooltip } from "@mantine/core";
 import {
+  IconAlertCircle,
   IconChevronDown,
   IconChevronRight,
+  IconCircleCheck,
   IconEye,
   IconEyeOff,
 } from "@tabler/icons-react";
@@ -139,10 +141,17 @@ export function ConnBadges(props: { share: ShareInfo }) {
 /**
  * Start/stop controls for a run's shares.
  *
- * Starting a peer share copies the join link straight to the clipboard — that is
- * the entire point of starting one — and confirms it with a toast, because the
- * button that was clicked is replaced by "Stop sharing" in the same breath and so
- * cannot carry the confirmation itself.
+ * The two modes are independent, so each stays available even while the other is
+ * live: "share with another Veld user" is offered whenever there is no peer
+ * share, and "share publicly" whenever there is no web share. Starting a peer
+ * share copies the join link straight to the clipboard — that is the entire
+ * point of starting one — and confirms it with a toast, because the button that
+ * was clicked is replaced by "Stop sharing" in the same breath and so cannot
+ * carry the confirmation itself.
+ *
+ * Stop buttons are deliberately the loudest thing here (`filled` red): the
+ * first test's user read "share privately" at the top and missed the stop
+ * control a beat, so a live share's exit must not be one more quiet button.
  */
 export function ShareControls(props: {
   run: RunRef;
@@ -182,18 +191,18 @@ export function ShareControls(props: {
             })
           }
         >
-          Share privately
+          Share with another Veld user
         </Button>
       )}
       {props.peer && (
         <Button
           size="compact-xs"
           color="red"
-          variant="light"
+          variant="filled"
           loading={busy === "stop-share"}
           onClick={() => void act("stop-share", "Stop sharing", () => api.stopShare(props.peer!.id))}
         >
-          Stop private share
+          {MODE_COPY.peer.stop}
         </Button>
       )}
       {props.running && props.web.length === 0 && (
@@ -204,10 +213,112 @@ export function ShareControls(props: {
           title="A public URL anyone can open in a browser, no Veld needed — routed through the veld gateway"
           onClick={() => void act("web-share", "Share to the web", () => api.startShare(props.run, { web: true }))}
         >
-          Share to the web
+          Share publicly
         </Button>
       )}
     </>
+  );
+}
+
+/** The structured copy for one sharing mode — kept as data so the card is
+ *  scannable (a short use case, a short pros list, one requirement) instead of
+ *  one long paragraph. The same mode names are the start buttons' copy, and the
+ *  stop buttons mirror them. */
+const MODE_COPY = {
+  peer: {
+    title: "Share with another Veld user",
+    bestFor: "Real access — databases, internal tools",
+    pros: [
+      "More services are eligible",
+      "Safer: direct end-to-end encrypted tunnel",
+      "No public URL",
+    ],
+    requires: "They need Veld installed",
+    warning: true,
+    cta: "Start sharing",
+    stop: "Stop sharing with Veld user",
+  },
+  web: {
+    title: "Share publicly",
+    bestFor: "People without Veld — or your phone, via QR",
+    pros: [
+      "No Veld needed on the other end",
+      "Open it on any device from a link or QR code",
+      "Perfect for mobile testing on your phone",
+    ],
+    requires: undefined,
+    warning: false,
+    cta: "Start sharing",
+    stop: "Stop public share",
+  },
+} as const;
+
+type ShareModeKind = keyof typeof MODE_COPY;
+
+/**
+ * One big card explaining a sharing mode — and the button that starts it.
+ *
+ * The whole card is the button (a nested button would be invalid HTML), with a
+ * short scannable layout: a one-line use case, a pros list, and one requirement.
+ * That replaces the earlier terse-but-paragraph form, which a first user read
+ * as a label rather than an action.
+ */
+export function ShareStartCard(props: {
+  kind: ShareModeKind;
+  /** The live run to share. */
+  run: RunRef;
+  onChanged: () => void;
+}) {
+  const { busy, act } = useShareAction(props.onChanged);
+  const copy = MODE_COPY[props.kind];
+  const starting = busy === "share" || busy === "web-share";
+  const start = () => {
+    if (props.kind === "peer") {
+      void act("share", "Start sharing", async () => {
+        const r = await api.startShare(props.run);
+        if (!r?.join_url) return;
+        try {
+          await navigator.clipboard.writeText(r.join_url);
+          notifyDone("Sharing — join link copied to the clipboard");
+        } catch {
+          notifyDone("Sharing — use Copy link to get the invite");
+        }
+      });
+    } else {
+      void act("web-share", "Share to the web", () =>
+        api.startShare(props.run, { web: true }),
+      );
+    }
+  };
+  return (
+    <button
+      type="button"
+      className="share-mode-card"
+      onClick={start}
+      disabled={starting}
+    >
+      <Text size="sm" fw={700}>
+        {copy.title}
+      </Text>
+      <Text size="xs" c="dimmed" className="share-mode-bestfor">
+        <b>Main use case:</b> {copy.bestFor}
+      </Text>
+      <div className="share-mode-list">
+        {copy.pros.map((p) => (
+          <Text size="xs" key={p} className="share-mode-li">
+            <IconCircleCheck size={12} /> {p}
+          </Text>
+        ))}
+      </div>
+      {copy.requires && (
+        <Text size="xs" className={`share-mode-note${copy.warning ? " warn" : ""}`}>
+          <IconAlertCircle size={12} /> {copy.requires}
+        </Text>
+      )}
+      <span className={`share-mode-cta${starting ? " starting" : ""}`}>
+        {starting ? "Starting…" : copy.cta}
+      </span>
+    </button>
   );
 }
 
@@ -400,10 +511,10 @@ export function WebShareStrip(props: {
         <Button
           size="compact-xs"
           color="red"
-          variant="light"
+          variant="filled"
           onClick={() => void act("stop-share", "Stop the web share", () => api.stopShare(w.id))}
         >
-          Stop web
+          {MODE_COPY.web.stop}
         </Button>
       </Group>
       {/* Scrolls past four services rather than growing without limit: a run can share
@@ -538,29 +649,46 @@ export function RunSharePanel(props: {
   }
   const { peer, web } = sharesForRun(props.shares, props.runId);
   const idle = !peer && web.length === 0;
+  // The two-mode framing, only in the modal's idle state: a first user is
+  // choosing *how* to share, so each approach gets a card that says what it is
+  // for. Once something is live, compact controls take over and the strips carry
+  // the detail.
+  const startCards =
+    idle && props.running && props.run ? (
+      <>
+        <Text size="xs" c="dimmed" px={12} pt={10}>
+          Share this run two ways. Pick the one that fits who you are sharing with.
+        </Text>
+        <div className="share-mode-cards">
+          <ShareStartCard kind="peer" run={props.run} onChanged={props.onChanged} />
+          <ShareStartCard kind="web" run={props.run} onChanged={props.onChanged} />
+        </div>
+        {props.unknown && (
+          <Text size="xs" c="dimmed" px={12} pb={8}>
+            Can&apos;t read the share list right now — retrying.
+          </Text>
+        )}
+      </>
+    ) : null;
+
   return (
     <div className="share-panel">
-      <Group gap={6} px={12} pt={10} pb={idle ? 10 : 6} wrap="wrap">
-        <ShareControls
-          run={props.run}
-          running={props.running}
-          peer={peer}
-          web={web}
-          onChanged={props.onChanged}
-        />
-        {idle && !props.running && (
-          <Text size="xs" c="dimmed">
-            {props.emptyHint}
-          </Text>
-        )}
-        {idle && props.running && (
-          <Text size="xs" c="dimmed">
-            {props.unknown
-              ? "Can't read the share list right now — retrying."
-              : "This run has nothing shared yet."}
-          </Text>
-        )}
-      </Group>
+      {startCards ?? (
+        <Group gap={6} px={12} pt={10} pb={idle ? 10 : 6} wrap="wrap">
+          <ShareControls
+            run={props.run}
+            running={props.running}
+            peer={peer}
+            web={web}
+            onChanged={props.onChanged}
+          />
+          {idle && !props.running && (
+            <Text size="xs" c="dimmed">
+              {props.emptyHint}
+            </Text>
+          )}
+        </Group>
+      )}
       {peer && (
         <PeerShareStrip share={peer} onChanged={props.onChanged} />
       )}

--- a/crates/veld-daemon/ui/src/styles.css
+++ b/crates/veld-daemon/ui/src/styles.css
@@ -725,6 +725,15 @@ body[data-fullscreen="true"] .topbar.electron {
   background: var(--elev);
   color: var(--text);
 }
+/* The Detached lane's question mark is informational, not a button — it opens a
+   tooltip but takes no action, so it reads as a hint rather than a control and
+   must not invite a click that does nothing. */
+.lane-help {
+  cursor: help;
+}
+.lane-help:hover {
+  background: none;
+}
 /* Pending removal is a state, not a lane — coloured so it does not read as a
    group the user made. */
 .rail-group.trash .lane-head {
@@ -2874,6 +2883,86 @@ body[data-theme="light"] .swatch-cell > .swatch-dot {
   flex-direction: column;
 }
 
+/* The two-mode framing of the sharing modal: side-by-side cards, each explaining
+   one way to share and offering its start button. */
+.share-mode-cards {
+  display: flex;
+  gap: 12px;
+  padding: 12px;
+}
+.share-mode-card {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--mantine-radius-md);
+  background: var(--elev);
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 120ms ease, background 120ms ease;
+}
+.share-mode-card:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+.share-mode-card:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+.share-mode-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.share-mode-li {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text);
+}
+.share-mode-li svg {
+  color: var(--accent);
+  flex: none;
+}
+.share-mode-note {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--faint);
+  margin-bottom: 14px;
+}
+.share-mode-note svg {
+  flex: none;
+}
+/* The one real caveat ("they need Veld installed") reads as a warning, not a
+   neutral note — red, so a user scanning the two cards sees the cost up front. */
+.share-mode-note.warn {
+  color: var(--danger);
+}
+.share-mode-note.warn svg {
+  color: var(--danger);
+}
+.share-mode-cta {
+  /* Full-width, so the start action is unmistakable inside the card. `margin-top:
+     auto` keeps both cards' buttons bottom-aligned; the note's `margin-bottom`
+     guarantees a fixed gap above it even when the card is full height. */
+  align-self: stretch;
+  text-align: center;
+  margin-top: auto;
+  padding: 6px 12px;
+  border-radius: var(--mantine-radius-sm);
+  background: var(--accent);
+  color: var(--bg);
+  font-size: 12px;
+  font-weight: 600;
+}
+.share-mode-cta.starting {
+  opacity: 0.8;
+}
+
 /* Pending join requests, above the panes: a prompt someone is waiting on, so it
    sits in the layout rather than behind a popover. `flex: none` for the same
    reason the offline banner has it — the panes below own the remaining height. */
@@ -3161,6 +3250,30 @@ body[data-theme="light"] .swatch-cell > .swatch-dot {
   gap: 4px;
   max-height: 320px;
   overflow-y: auto;
+}
+
+/* The two big choice cards in the Start-configuration modal, shown when a
+   worktree has no selection yet. Clickable like buttons, sized like cards, so
+   the "pick how to start" moment reads as a real choice rather than a list. */
+.start-mode-card {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-start;
+  text-align: left;
+  padding: 18px 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--mantine-radius-md);
+  background: var(--elev);
+  color: var(--text);
+  cursor: pointer;
+  transition: border-color 120ms ease, background 120ms ease;
+}
+.start-mode-card:hover {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--elev) 60%, var(--accent) 8%);
 }
 
 .emoji-cell {


### PR DESCRIPTION
First-user-test feedback on the /ide management UI.

## Worktree creation markers
- Show only the marker face the user setting renders (Colour or Emoji), with a segmented control to switch the setting right in the dialog. Both halves are still stored, so switching is lossless.

## Rail discoverability
- Added a **New worktree** button beside **New lane**, grouped at the rail head's right edge.
- Tooltips on every rail button (collapse/expand, +, lane menu, trash).

## Detached worktrees
- Grouped into their own virtual lane between the ungrouped worktrees and the custom lanes.
- Question-mark tooltip explaining what they are, plus a **trash-all** action.

## Start configuration
- No more implicit first-preset selection. A fresh worktree reads **"Choose preset or nodes"**, and the start button (top bar and rail rows) opens the picker on no selection.
- The modal no longer auto-closes on a preset pick — confirm with Done (which starts when opened from the start button).
- Larger modal, opens on two choice cards, switches via a segmented control, always-visible scrollbars.

## Sharing
- Two explanatory cards (Veld-user peer share vs public web share) that are themselves the buttons, with scannable pros/cons and a full-width start action.
- Each mode stays startable while the other is live; stop buttons are prominent and their copy aligns with the start copy.

## Fix
- Blank IDE on first render: `effectiveStart` no longer reads a null worktree's `presets`.

Local pre-pass green (tsc, 679 vitest tests, vite build, biome lint).