### PR TITLE
fix(desktop): recall the main window's size and position after it is closed

### DIFF
--- a/desktop/ARCHITECTURE.md
+++ b/desktop/ARCHITECTURE.md
@@ -892,7 +892,16 @@ Minimal by design. Main process only does:
    `userData/windows.json` (written to a temp file and renamed, since a torn file
    reopens as one window and the next persist makes that permanent) and reopened
    on launch, because a detached window holds live shells and reopening only the
-   main one abandons them to the detach grace.
+   main one abandons them to the detach grace. The file also carries
+   `lastMainBounds` — the last main window's size and position, kept apart from
+   the window set so a macOS red-X close (which empties the set while the tray
+   keeps the app alive) still lets the next fresh main window open at the size it
+   had. It is the fallback bounds for any main window opened with no explicit
+   bounds (the reopen, a restore fallback, ⌘N), clamped onto a display so a
+   monitor that has since been unplugged cannot strand the title bar off-screen;
+   a quit/relaunch path doesn't need it, because there the per-window bounds in
+   the set already survive. It is not a base — it is never reopened, only
+   recalled.
    `before-quit` stops both the hand-back and the persist: a quit is not a series
    of window closes, and treating it as one would record the app as having one
    window and reopen exactly that. That latch is **one-way**, cleared only by

--- a/desktop/src/windowState.js
+++ b/desktop/src/windowState.js
@@ -353,7 +353,7 @@ function livePid(pid) {
   }
 }
 
-function serializeWindowList(previousRaw, base, records, isPidAlive = livePid) {
+function serializeWindowList(previousRaw, base, records, isPidAlive = livePid, lastMainBounds = null) {
   let all = {};
   try {
     const parsed = JSON.parse(previousRaw);
@@ -390,7 +390,31 @@ function serializeWindowList(previousRaw, base, records, isPidAlive = livePid) {
     const pid = key.match(/^(?:main|dev)-(\d+)$/);
     if (pid && !isPidAlive(Number(pid[1]))) delete all[key];
   }
+  // The last main window's bounds, kept apart from the window set: closing the
+  // last window on macOS empties the set, and without this the next fresh main
+  // window would open at the default size. It is not a base — it is never
+  // reopened, only recalled as the size/position a new main window starts at.
+  all.lastMainBounds = lastMainBounds ? safeBounds(lastMainBounds) : null;
   return JSON.stringify(all);
+}
+
+/**
+ * The bounds a fresh main window should start at, or `null` when nothing has
+ * ever been remembered (a first launch, or an unreadable file).
+ *
+ * `safeBounds` guards the same way it does for a window record: a corrupted
+ * value must not render the app unresizable-in-practice.
+ */
+function readLastMainBounds(raw) {
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      return safeBounds(parsed.lastMainBounds);
+    }
+  } catch {
+    // Unreadable or absent: nothing remembered, which is the first-launch case.
+  }
+  return null;
 }
 
 module.exports = {
@@ -411,5 +435,6 @@ module.exports = {
   safeBounds,
   parseWindowRecord,
   parseWindowList,
+  readLastMainBounds,
   serializeWindowList,
 };

--- a/desktop/src/windowState.test.js
+++ b/desktop/src/windowState.test.js
@@ -14,6 +14,7 @@ const {
   ownsWorktree,
   parseWindowList,
   parseWindowRecord,
+  readLastMainBounds,
   releaseClaims,
   restoreBudget,
   safeBounds,
@@ -167,8 +168,11 @@ test("serializeWindowList leaves the other base alone", () => {
 
   // An unreadable previous file starts a fresh one rather than refusing to
   // write. An empty list is not worth a key: a base with no windows and a base
-  // that is absent reopen identically.
-  assert.deepEqual(JSON.parse(serializeWindowList("{oops", "main", [])), {});
+  // that is absent reopen identically. (`lastMainBounds` is null on a first
+  // launch, so it is always present but says nothing.)
+  assert.deepEqual(JSON.parse(serializeWindowList("{oops", "main", [])), {
+    lastMainBounds: null,
+  });
 });
 
 test("serializeWindowList prunes bases nobody will read again", () => {
@@ -194,7 +198,7 @@ test("serializeWindowList prunes bases nobody will read again", () => {
   );
   // `dev` is a real base, not a pid-derived one, so it survives whatever its
   // instance is doing; the two dead pid bases and the empty list go.
-  assert.deepEqual(Object.keys(written).sort(), ["dev", "main"]);
+  assert.deepEqual(Object.keys(written).sort(), ["dev", "lastMainBounds", "main"]);
 });
 
 test("serializeWindowList does not delete a live instance's windows", () => {
@@ -227,7 +231,37 @@ test("serializeWindowList keeps the pid-derived base it is currently writing", (
       () => false,
     ),
   );
-  assert.deepEqual(Object.keys(written), ["dev-41231"]);
+  assert.deepEqual(Object.keys(written), ["dev-41231", "lastMainBounds"]);
+});
+
+test("serializeWindowList writes the last main window's bounds", () => {
+  // The recalled size/position of a fresh main window, kept apart from the
+  // window set so it survives a macOS close that empties the set.
+  const written = JSON.parse(
+    serializeWindowList("", "main", [], () => false, { x: 40, y: 33, width: 1500, height: 887 }),
+  );
+  assert.deepEqual(written.lastMainBounds, { x: 40, y: 33, width: 1500, height: 887 });
+  // No remembered bounds yet (first launch): the key is present but null.
+  assert.equal(JSON.parse(serializeWindowList("", "main", [])).lastMainBounds, null);
+});
+
+test("lastMainBounds survives a close that empties the window set", () => {
+  // The macOS red-X path: the only window closes, the base is pruned to an
+  // empty array, but the recalled bounds must still be there for the next
+  // fresh window. This is the regression the fix exists for.
+  const bounds = { x: 12, y: 33, width: 1500, height: 887 };
+  const written = JSON.parse(serializeWindowList("", "main", [], () => false, bounds));
+  assert.deepEqual(Object.keys(written), ["lastMainBounds"]);
+  assert.deepEqual(readLastMainBounds(JSON.stringify(written)), bounds);
+});
+
+test("readLastMainBounds degrades to null", () => {
+  // Nothing remembered, unreadable, or corrupt all mean "no recall", which is
+  // the first-launch fallback to the default size.
+  assert.equal(readLastMainBounds(""), null);
+  assert.equal(readLastMainBounds("{oops"), null);
+  assert.equal(readLastMainBounds(JSON.stringify({})), null);
+  assert.equal(readLastMainBounds(JSON.stringify({ lastMainBounds: { width: 1, height: 1 } })), null);
 });
 
 test("handBackTarget prefers the window the tabs actually came from", () => {

--- a/desktop/src/windows.js
+++ b/desktop/src/windows.js
@@ -42,6 +42,7 @@ const {
 
   ownsWorktree,
   parseWindowList,
+  readLastMainBounds,
   releaseClaims: releaseClaimsIn,
 
   restoreBudget,
@@ -365,6 +366,13 @@ function readStateRaw() {
  * intermediate position is not a bug.
  */
 let persistTimer = null;
+/**
+ * The bounds a fresh main window starts at, kept alive across a macOS close
+ * that empties the window set. Updated from the live main window on every
+ * persist, loaded from disk at init, and written back in `serializeWindowList`
+ * — the one field in the state file that survives having no windows.
+ */
+let lastMainBounds = null;
 function persistWindows() {
   // A quit closes every window one by one, and each `closed` would shrink the
   // recorded set — the last write winning would be "one window", which is what
@@ -380,6 +388,15 @@ function persistWindows() {
     // point some windows are already destroyed and would be filtered out of the
     // very list the next launch reopens.
     if (!deps || quitting) return;
+    // The last live main window's normal bounds, captured *while it is still
+    // alive* — the fallback bounds a fresh main window opens at. Captured here
+    // rather than in `close` so it is current by the time the last window is
+    // being torn down: when `closed` empties the set this has already been
+    // updated by the resizes that led up to it, and writing it is what lets a
+    // macOS red-X close followed by a reopen recall the size. Normal bounds, so
+    // a window remembered while maximised restores to the size it had before.
+    const main = allRecords().find((r) => r.kind === "main" && !r.win.isDestroyed());
+    if (main) lastMainBounds = safeBounds(main.win.getNormalBounds());
     try {
       const records = allRecords()
         .filter((r) => !r.win.isDestroyed())
@@ -401,7 +418,10 @@ function persistWindows() {
       // window's layout — and the live shells its terminal ids name —
       // permanent.
       const tmp = `${deps.stateFile}.tmp`;
-      fs.writeFileSync(tmp, serializeWindowList(readStateRaw(), deps.slotBase, records));
+      fs.writeFileSync(
+        tmp,
+        serializeWindowList(readStateRaw(), deps.slotBase, records, undefined, lastMainBounds),
+      );
       fs.renameSync(tmp, deps.stateFile);
     } catch {
       // An unwritable userData costs the window set on the next launch and
@@ -524,6 +544,31 @@ function takenSuffixes() {
 }
 
 /**
+ * Clamp remembered bounds to a display, so a fresh window cannot be restored
+ * off-screen. A window remembered on a monitor that is gone (or on a smaller
+ * one) would otherwise open with its title bar unreachable — unrecoverable on
+ * macOS — so the position is moved onto whichever display the stored rect
+ * overlaps most, and the size is capped to that display's work area.
+ *
+ * `null` in, `null` out: nothing remembered is the first-launch case, and the
+ * caller falls back to the default size.
+ */
+function boundsOnScreen(bounds) {
+  if (!bounds) return null;
+  const area = screen.getDisplayMatching(bounds).workArea;
+  const width = Math.min(bounds.width, area.width);
+  const height = Math.min(bounds.height, area.height);
+  return {
+    width,
+    height,
+    // Clamped to the work area so the title bar can never land off-screen — the
+    // same rule `detachBounds` applies for the same reason.
+    x: Math.round(Math.max(area.x, Math.min(bounds.x, area.x + area.width - width))),
+    y: Math.round(Math.max(area.y, Math.min(bounds.y, area.y + area.height - height))),
+  };
+}
+
+/**
  * Open a window.
  *
  * `suffix === undefined` allocates the next free one; pass an explicit suffix
@@ -549,7 +594,9 @@ function openWindow(options = {}) {
 
   const bounds =
     safeBounds(options.bounds) ??
-    (detached ? detachBounds(options.originWindow ?? null) : { width: 1280, height: 800 });
+    (detached
+      ? detachBounds(options.originWindow ?? null)
+      : boundsOnScreen(lastMainBounds) ?? { width: 1280, height: 800 });
 
   const win = new BrowserWindow({
     // Titled by the app for a main window (the page's <title> is the daemon
@@ -1464,6 +1511,11 @@ function registerWindowIpc(ipcMain) {
 
 function initWindows(dependencies) {
   deps = dependencies;
+  // The size/position a fresh main window starts at. Read once, at init: the
+  // only path that needs it is opening a window without an explicit bounds
+  // (the macOS reopen, a restore fallback, ⌘N), and each of those writes it
+  // back the moment it has a live main window to read from.
+  lastMainBounds = readLastMainBounds(readStateRaw());
 }
 
 // Exactly what `main.js` calls. `recordFor` and `persistWindows` are internal:


### PR DESCRIPTION
## What & why

On macOS, clicking the red close button on the last window doesn't quit the app — it keeps running in the tray. The `closed` handler then **empties the persisted window set** (`windows.json` -> `{}`), discarding the remembered bounds. Reopening from the dock (`focusPrimary`) opened a fresh window at the default 1280x800 and immediately persisted *that* default, so the size was lost permanently. The Cmd+Q -> relaunch path already worked (`before-quit` blocks the empty write), which is why the bug was macOS-specific and inconsistent.

## Root cause

```
close last window (macOS)  ->  closed handler  ->  persistWindows writes {}  ->  bounds gone
reopen from dock           ->  focusPrimary -> openWindow(kind:main) -> default 1280x800 -> persisted
```

## Change

- **`windowState.js`** — the state file now carries a `lastMainBounds` field, kept **apart from the window set**, so it survives a close that empties the set. Added a degrading `readLastMainBounds` reader.
- **`windows.js`** — `persistWindows` captures the live main window's normal bounds into `lastMainBounds` on every persist (current by the time the last window tears down); `openWindow` uses it as the fallback bounds for any fresh main window (macOS reopen, restore fallback, Cmd+N, settings). Added `boundsOnScreen` so a remembered position/size is clamped onto a display — a window remembered on a now-unplugged monitor can't strand its title bar off-screen (unrecoverable on macOS).
- **`windowState.test.js`** — 3 new tests (serialize writes bounds, bounds survive an emptied set, reader degrades to null) + updated 3 existing assertions for the new key.
- **`ARCHITECTURE.md`** — documented the `lastMainBounds` design.

## Why not the obvious alternative

Keeping the closed window in the persisted set would reopen a window the user deliberately closed — the set's purpose is "windows to reopen on next launch", and closing a window is an explicit removal. `lastMainBounds` separates "which windows to reopen" from "what size a fresh main window starts at". Storing it globally (not per base) is deliberate: it's a rectangle, not a shell/terminal identity, so dev & packaged instances sharing `userData` clobbering it is cosmetic and self-corrects on first open.

## Test evidence

- 113 desktop unit tests pass; `npm run lint` exit 0.
- Real-Electron reproduction harness: resize -> 1500x887, red-X close -> `windows.json` = `{lastMainBounds:{1500x887}}`, reopen -> window at 1500x887 (position clamped to display). **Verified by the maintainer hands-on (checkpoint one) — "works flawlessly".**

## Reviewer-scope notes

- Purely a desktop-shell window-persistence fix. No daemon/helper/gateway/schema/config surface touched -> no docs-checklist rows beyond `ARCHITECTURE.md`.

## Known follow-ups

- `boundsOnScreen` (Electron-bound) has no unit test — matches the existing pattern where only the pure logic in `windowState.js` is `node --test`-able.
