### PR TITLE
fix(pty): make config panes confirm on close and render full-screen programs correctly

### DIFF
--- a/crates/veld-daemon/src/pty.rs
+++ b/crates/veld-daemon/src/pty.rs
@@ -4161,6 +4161,38 @@ mod tests {
             key
         }
 
+        /// Plant a ticket that runs a config-declared pane — the shape the
+        /// daemon's own `mint_ticket` produces for a `ide.panes[].type ==
+        /// "terminal"` launch. The pane's `argv` is what the holder spawns (the
+        /// login-shell wrapping happens upstream in `resolve_pane`), so `sh -c
+        /// 'sleep …'` stands in for the real `$SHELL -l -i -c '<command>'` the
+        /// pane path produces.
+        fn plant_pane_ticket(session: &str, cwd: &std::path::Path, argv: Vec<String>) -> String {
+            let key = uuid::Uuid::new_v4().simple().to_string();
+            TICKETS.lock().unwrap().insert(
+                key.clone(),
+                Ticket {
+                    session_id: session.to_owned(),
+                    worktree_id: 1,
+                    cwd: cwd.to_path_buf(),
+                    label: "test".to_owned(),
+                    pane: Some(PaneLaunch {
+                        spec_id: "probe".to_owned(),
+                        label: "Probe".to_owned(),
+                        argv,
+                        env: vec![("VELD_PANE_TOKEN".to_owned(), "tok-123".to_owned())],
+                        token: "tok-123".to_owned(),
+                        fresh: true,
+                    }),
+                    shell: TEST_SHELL.to_owned(),
+                    shell_flags: Vec::new(),
+                    shim_env: shims::session_env(session, TEST_SHELL, true, true, false),
+                    expires_at: Instant::now() + TICKET_TTL,
+                },
+            );
+            key
+        }
+
         /// The origin the daemon under test actually trusts. Derived from the
         /// allowlist rather than hardcoded, so this can't drift away from it.
         fn good_origin() -> String {
@@ -4415,6 +4447,25 @@ mod tests {
             let (ws, _) = tokio_tungstenite::connect_async(attach_request(
                 addr,
                 &format!("ticket={t}{extra}"),
+                Some(&good_origin()),
+            ))
+            .await
+            .expect("handshake");
+            ws
+        }
+
+        /// Open a session that runs a config-declared pane (a ticket with a
+        /// `pane`), the way the UI launches one.
+        async fn open_pane(
+            addr: SocketAddr,
+            sid: &str,
+            cwd: &std::path::Path,
+            argv: Vec<String>,
+        ) -> Client {
+            let t = plant_pane_ticket(sid, cwd, argv);
+            let (ws, _) = tokio_tungstenite::connect_async(attach_request(
+                addr,
+                &format!("ticket={t}"),
                 Some(&good_origin()),
             ))
             .await
@@ -5321,6 +5372,80 @@ mod tests {
                 !busy(&format!("/api/pty/sessions/{sid}/busy")).await,
                 "an idle prompt must not read as busy"
             );
+            end_session(&sid, "test cleanup").await;
+        }
+
+        /// A config-declared pane reads as **busy while its command runs**, even
+        /// though it never spawns a foreground job of its own. A pane's command
+        /// runs `$SHELL -l -i -c '<command>'`, and an interactive shell execs a
+        /// simple command into its own process group — so the `tcgetpgrp`-vs-pid
+        /// signal a shell uses would read a running pane as idle, and closing the
+        /// tab would hang the agent/pager without asking. "Busy" for a pane is
+        /// simply "its command has not exited", and that is what this pins end to
+        /// end through the same `/api/pty/sessions/{id}/busy` route.
+        #[tokio::test]
+        async fn a_config_pane_reads_busy_while_running_and_idle_after_it_exits() {
+            use axum::body::Body;
+            use tower::ServiceExt;
+
+            let addr = serve().await;
+            let dir = tempfile::tempdir().unwrap();
+            let sid = session_id();
+            // A stand-in for `$SHELL -l -i -c 'git …'`: the holder treats any
+            // `argv` it is handed as a pane. `sleep` leaves the shell alive but
+            // doing nothing a `tcgetpgrp` probe would see — the exact case that
+            // used to read as idle.
+            let mut ws = open_pane(
+                addr,
+                &sid,
+                dir.path(),
+                vec!["sh".to_owned(), "-c".to_owned(), "sleep 5".to_owned()],
+            )
+            .await;
+            read_control(&mut ws, "ready").await;
+
+            async fn busy(uri: &str) -> bool {
+                let res = routes()
+                    .oneshot(
+                        axum::http::Request::builder()
+                            .method("GET")
+                            .uri(uri)
+                            .body(Body::empty())
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap();
+                assert_eq!(
+                    res.status(),
+                    StatusCode::OK,
+                    "busy check must be a safe GET"
+                );
+                let bytes = axum::body::to_bytes(res.into_body(), 64).await.unwrap();
+                serde_json::from_slice::<serde_json::Value>(&bytes).unwrap()["busy"]
+                    .as_bool()
+                    .expect("busy is a bool")
+            }
+
+            // A freshly-started pane whose command is still running must be busy
+            // from the very first query — no poll-until-it-sticks needed, because
+            // it never relies on the pgrp switching.
+            assert!(
+                busy(&format!("/api/pty/sessions/{sid}/busy")).await,
+                "a running pane must read as busy"
+            );
+
+            // Once the command exits the pane is idle: closing no longer needs to
+            // ask, and `close_on_exit` can tidy it away.
+            let deadline = Instant::now() + Duration::from_secs(10);
+            let mut saw_idle = false;
+            while Instant::now() < deadline {
+                if !busy(&format!("/api/pty/sessions/{sid}/busy")).await {
+                    saw_idle = true;
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            assert!(saw_idle, "an exited pane must read as idle");
             end_session(&sid, "test cleanup").await;
         }
     }

--- a/crates/veld-daemon/src/pty/holder.rs
+++ b/crates/veld-daemon/src/pty/holder.rs
@@ -522,11 +522,22 @@ async fn serve(cfg: &HolderConfig, listener: UnixListener) -> anyhow::Result<()>
                                 // data; dropping it is fine, because the daemon's own
                                 // query times out and reports idle.
                                 if let Some(c) = conn.as_ref() {
-                                    let reply = (
-                                        wire::BUSY,
-                                        wire::encode_busy(session_busy(master.as_ref(), pid))
-                                            .to_vec(),
-                                    );
+                                    // A config-declared pane runs `$SHELL -l -i -c
+                                    // '<command>'`, and an interactive shell **execs** a
+                                    // simple command into its own process group rather
+                                    // than giving it one of its own — so `tcgetpgrp`
+                                    // equals `pid` for the whole life of a running pane
+                                    // (the git-log pane, a coding agent), and the pgrp
+                                    // heuristic below would read it as *idle* while it
+                                    // is busy. For a pane, "busy" simply means its
+                                    // command has not exited yet.
+                                    let busy = if cfg.argv.is_some() {
+                                        exit_code.is_none()
+                                    } else {
+                                        session_busy(master.as_ref(), pid)
+                                    };
+                                    let reply =
+                                        (wire::BUSY, wire::encode_busy(busy).to_vec());
                                     if c.out.try_send(reply).is_err() {
                                         debug!("dropping a busy reply: the daemon is behind");
                                     }

--- a/crates/veld-daemon/ui/src/panes/terminalHost.ts
+++ b/crates/veld-daemon/ui/src/panes/terminalHost.ts
@@ -24,7 +24,6 @@ import { terminalPrefs, type TerminalPrefs } from "../shared/settings";
 import { chromeless, layoutSlot, windowSeed } from "../shell";
 import {
   type PaneMount,
-  type StartPlan,
   parseLayouts,
   shouldCloseOnExit,
   startPlanFor,
@@ -416,8 +415,7 @@ function ensure(
   id: string,
   worktreeId: number,
   pane: PaneMount | undefined,
-  start: StartPlan,
-): Session {
+): { session: Session; created: boolean } {
   const existing = sessions.get(id);
   if (existing) {
     // The daemon refuses a cross-worktree resume with a 409; mirror that here,
@@ -429,7 +427,7 @@ function ensure(
         `terminal ${id} belongs to worktree ${existing.worktreeId}, not ${worktreeId}`,
       );
     }
-    return existing;
+    return { session: existing, created: false };
   }
 
   const p = prefs();
@@ -533,6 +531,23 @@ function ensure(
       s.ws.send(JSON.stringify({ type: "resize", cols, rows }));
     }
   });
+  // A wheel over a full-screen program (the alternate buffer: a pager like
+  // `git log`'s, a TUI) scrolls it, the way a native terminal does — xterm.js
+  // leaves the alternate buffer alone, so without this the wheel does nothing
+  // over `git log`/`less` while it scrolls fine in a plain terminal. Guarded on
+  // the two cases that must not also get cursor keys: the normal buffer (where
+  // the wheel scrolls xterm's own scrollback) and a program that has taken the
+  // mouse over itself (`term.modes.mouseTrackingMode` — vim/htop/`less --mouse`
+  // report their own wheel events and must not receive a second copy).
+  container.addEventListener("wheel", (e) => {
+    if (term.buffer.active.type !== "alternate") return;
+    if (term.modes.mouseTrackingMode !== "none") return;
+    e.preventDefault();
+    // One screen-scroll step per notch is the native feel; send the same
+    // sequences the wheel in a real terminal sends, so any full-screen program
+    // that scrolls with arrows behaves.
+    send(e.deltaY > 0 ? "\x1b[B" : "\x1b[A");
+  });
 
   // A process sets its own tab title with OSC 0/2 (`ESC ] 0;title BEL`). xterm
   // parses the sequence and reports the result here — the only parser worth
@@ -576,9 +591,11 @@ function ensure(
   });
 
   // `shell` and `reattach` both mean "no command to choose" — a login shell has
-  // none, and a reattach runs whatever is already there.
-  connect(s, start === "shell" || start === "reattach" ? undefined : start);
-  return s;
+  // none, and a reattach runs whatever is already there. The connection itself
+  // is established by the caller (`mountTerminal`) *after* the terminal has
+  // been opened and fitted, so the pty is minted at the real size rather than
+  // xterm's 80x24 default.
+  return { session: s, created: true };
 }
 
 function attachUrl(ticket: string, cols: number, rows: number): string {
@@ -1042,13 +1059,37 @@ export function mountTerminal(
   parent: HTMLElement,
   pane?: PaneMount,
 ): void {
-  const s = ensure(id, worktreeId, pane, startPlanFor(id, pane));
+  const start = startPlanFor(id, pane);
+  const { session: s, created } = ensure(id, worktreeId, pane);
   if (s.container.parentElement !== parent) parent.appendChild(s.container);
 
   if (!s.opened) {
     // Now that the container is in the document, xterm can measure the font.
     s.term.open(s.container);
     s.opened = true;
+  }
+
+  if (created) {
+    // Fit **synchronously** before the first connection, so the pty is created
+    // at the pane's real size rather than xterm's 80x24 default. A full-screen
+    // program — a pager like `git log`, a TUI — that starts before the resize
+    // enters its alternate screen at the wrong size and renders with a blank
+    // offset (and a pager whose scrolling looks dead). `requestFit` below is
+    // rAF-deferred, so it would run *after* the connection has already minted
+    // the pty at 80x24. `fit()` forces layout, so the real size is measurable
+    // right here for a container that is in the document; the same `< 2` guard
+    // `requestFit` uses keeps a not-yet-laid-out container from collapsing the
+    // grid (and the rAF fit and post-`ready` re-fit correct it once it is).
+    const rect = s.container.getBoundingClientRect();
+    if (rect.width >= 2 && rect.height >= 2) {
+      try {
+        s.fit.fit();
+      } catch {
+        // Container not laid out yet (a pane in a hidden dock); the rAF fit
+        // below and the post-`ready` re-fit correct the size as soon as it is.
+      }
+    }
+    connect(s, start === "shell" || start === "reattach" ? undefined : start);
   }
   requestFit(s);
 


### PR DESCRIPTION
## What & why

Two regressions from #273, which started running `ide.panes` inside the user's
login shell (`$SHELL -l -i -c '<command>'`):

1. **Close-confirmation never fired for config panes.** Closing a pane's tab
   hung a running command with no "a process is still running" prompt, even
   though a plain terminal asks. Root cause: the busy signal compares the
   terminal's foreground process group to the shell's pid (`tcgetpgrp`), but an
   interactive shell **execs** a simple command into its own process group —
   so `tcgetpgrp == pid` for the whole life of a running pane and it always
   read as idle. A pane is now busy while its command has not exited (pinned
   end-to-end through `/api/pty/sessions/{id}/busy` by a new test).

2. **Full-screen programs rendered with a blank offset (the `git log` pane).**
   The pane's pty was minted at xterm's 80×24 default because the terminal
   connected *before* it was opened and fitted; a pager then entered its
   alternate screen at the wrong size, leaving leading blank lines and making
   scrolling look dead. The terminal now fits **synchronously before the first
   connection**, so the pty starts at the pane's real size. Separately, wheel
   scrolls over the alternate buffer now translate into cursor keys (gated so a
   program that has claimed the mouse — vim/htop/`less --mouse` — never gets a
   second copy), matching a native terminal.

## Files

- `crates/veld-daemon/src/pty/holder.rs` — pane busy = command-not-exited
- `crates/veld-daemon/src/pty.rs` — new e2e test + pane-ticket test helper
- `crates/veld-daemon/ui/src/panes/terminalHost.ts` — fit-before-connect,
  wheel-over-alternate-buffer

## Test evidence

- `cargo test -p veld-daemon` 199 pass (new `a_config_pane_reads_busy…` included)
- UI `typecheck` + 716 tests pass; `vite build` succeeds
- clippy + `cargo fmt` clean across the workspace
- Hand-verified by the maintainer on the dev stack: confirm-on-close now fires
  for panes, the git-log resize/blank-line issue is gone, wheel scrolls the pager.

## Notes

- Docs/website: no change — bugfix with no new surface area.
- The `git log` pane in this repo's `veld.json` is unchanged; the fixes make it
  work with the config as committed.
- `binding_replaces_a_stale_socket_file` is a pre-existing intermittent flaky
  test (passes in isolation and in 4/4 re-runs; exercises `bind`, which this
  change never touches).
