### PR TITLE
fix(ui): close terminal toast immediately on click

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cmd=$(jq -r '.tool_input.command // empty'); if printf '%s' \"$cmd\" | grep -Eq '(^|[;&|(])[[:space:]]*find([[:space:]]+-[A-Za-z][A-Za-z0-9]*)*[[:space:]]+/([[:space:]]|$)'; then echo 'Blocked: find rooted at bare / scans the entire filesystem and can trigger macOS TCC permission prompts (Photos, Music, etc.) by walking into protected library folders. Scope the search to a real path, for example: find . -name pattern, or find /specific/path -name pattern.' >&2; exit 2; fi"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -48,14 +48,22 @@ in their request):
    - *Light (`SPAWNS: 6`, `ROUNDS: 2`)* — for a small / mechanical change. The
      doc's own trivia clause (§11) still applies underneath: a sub-50-line,
      no-stakes diff with a green pre-pass gets angles 4+5 at sonnet, one round.
+   - *Super light (`SPAWNS: 1`, `ROUNDS: 1`)* — for a tiny, obviously-scoped fix
+     (a handful of lines, one clear behavior change, no new surface). One sonnet
+     agent reads the diff once for correctness — no staged angles, no separate
+     verify pass — and reports findings directly. This is a further step down
+     from Light's own trivia-clause floor (§11's angles 4+5, one round); reach
+     for it only when a second opinion would be reading the same three lines
+     twice. Skips the loop's ledger and multi-round structure entirely — there
+     is no round two to carry state into.
    - *None* — skip review. AGENTS.md makes the multi-angle review **mandatory for
      every change**, so this is the maintainer explicitly overriding that step;
      confirm they mean it and note the risk in the PR body.
 
    The stakes override (§3.3 — privileged helper, secrets/relay tokens, gateway
    auth, proxy headers, daemon API, SQLite migrations) is **not** downgradable by
-   this answer. If *Light* is chosen and the diff turns out to touch one of those
-   paths, run the standard loop and say so in the final report.
+   this answer. If *Light* or *Super light* is chosen and the diff turns out to
+   touch one of those paths, run the standard loop and say so in the final report.
 2. **Merge policy** (AGENTS.md's default posture is **ask-first**; bypass is the
    exception and requires the maintainer's explicit upfront authorization, which
    this questionnaire captures)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,22 @@ and several were paid for in this codebase already.
   Design context that must outlive a working document belongs in the PR
   description, commit messages, or `docs/` — don't cite `notes/` files from
   code comments, since readers of the repo can't see them.
+- **Never root a filesystem search at `/`, or scan wider than the question
+  needs.** `find /`, `grep -r` from `/`, or any traversal that isn't scoped to
+  `.`, the repo root, or a specific real path can walk into macOS's TCC-
+  protected folders (Photos Library, Music Library, Mail, and others) — even a
+  plain `stat` of those directories triggers a permission dialog, repeatedly,
+  for every protected folder the traversal reaches. This has actually happened:
+  an agent chasing a path under a not-yet-installed `node_modules` reached for
+  `find / -path /proc -prune -o -type d -name "@mantine" -print` instead of
+  scoping down, and it fired a stack of Photos/Music access prompts with no
+  useful result. A `PreToolUse` hook in `.claude/settings.json` now blocks a
+  `find` rooted at bare `/` before it runs, but the hook is a backstop, not a
+  substitute for judgement — the same hazard applies to any other unscoped
+  system-wide traversal (`grep -r / …`, `mdfind` with no scope, etc.) that the
+  hook doesn't pattern-match. If you don't know where something lives, narrow
+  by directory (the repo root, `~/Library/…`, a specific crate) before
+  reaching for a broad search.
 - **Leave a worktree clean before you stop in it.** Building and running tests
   drifts `Cargo.lock`, and experiment scaffolding lands untracked (`.idea/`,
   a scratch dir, a prototype). A worktree carrying uncommitted changes or

--- a/crates/veld-daemon/ui/src/shared/notify.ts
+++ b/crates/veld-daemon/ui/src/shared/notify.ts
@@ -210,7 +210,9 @@ export interface TerminalNotifyOptions {
 }
 
 export function notifyTerminal(opts: TerminalNotifyOptions): void {
+  const id = `veld-terminal-notify-${Math.random().toString(36).slice(2)}`;
   notifications.show({
+    id,
     title: opts.title,
     // The toast's whole surface is clickable, but that is only discoverable if
     // it says so — a visible "click to focus" hint on its own line.
@@ -221,7 +223,13 @@ export function notifyTerminal(opts: TerminalNotifyOptions): void {
       createElement("span", { className: "term-notify-focus" }, "Click to focus"),
     ),
     color: "teal",
-    onClick: opts.onClick,
+    // Hide on click rather than relying on Mantine's default (which leaves the
+    // toast up until its own timeout) — the click already did the thing the
+    // toast was offering, so lingering is stale, not informative.
+    onClick: () => {
+      notifications.hide(id);
+      opts.onClick();
+    },
     autoClose: 8000,
   });
 }

--- a/veld.json
+++ b/veld.json
@@ -41,15 +41,18 @@
     // `claude` or `codex` is known to veld — they are names in this file, the
     // same way `npx browser-sync` below is.
     //
-    // The two agents demonstrate the **two shapes** a resumable pane can take,
-    // which is why both are here rather than one:
+    // These panes demonstrate the **two shapes** a resumable pane can take:
     //
-    //   claude — accepts an id veld chose, so each pane owns its own
-    //            conversation and two panes never collide.
+    //   claude / claude-sonnet / pi — each accepts an id veld chose, so every
+    //            pane owns its own conversation and two panes never collide.
     //   codex  — mints its own id and cannot be told one, so the pane carries
     //            no token and leans on the tool's own "most recent session".
     //
-    // Both are offered in **auto mode only**. There used to be a second Claude
+    // `claude` and `claude-sonnet` are the same pane pinned to different
+    // models (Opus, Sonnet) — the model that's pinned is what the label
+    // names, so a resumed session can never drift out from under its label.
+    //
+    // All are offered in **auto mode only**. There used to be a second Claude
     // pane running `--dangerously-skip-permissions`; it is gone on purpose, so
     // that the panes this repo hands a contributor are the ones that still stop
     // and ask. Run the unsandboxed variant from a plain terminal if you want it.
@@ -57,8 +60,8 @@
       {
         "id": "claude",
         "type": "terminal",
-        "label": "Claude - auto",
-        "description": "Claude Code in this worktree, in auto permission mode",
+        "label": "Claude Opus",
+        "description": "Claude Code (Opus) in this worktree, in auto permission mode",
         "icon": "robot",
         "requires_bin": ["claude"],
         // This moved in both directions, so read it as both. Against the pane
@@ -70,25 +73,66 @@
         // `auto` gates is the CLI's business and is not documented here; check
         // `claude --help` for the current set rather than trusting this comment.
         //
+        // `--model opus` is pinned rather than left to the CLI's own default,
+        // because the label says "Opus" — an unpinned model would drift out
+        // from under a label that stopped being true.
+        //
         // `--session-id` creates the conversation under an id veld chose, which
         // is what makes the `resume` below able to name it after a reboot.
         "argv": [
           "claude",
           "--permission-mode",
           "auto",
+          "--model",
+          "opus",
           "--session-id",
           "${veld.pane.token}"
         ],
-        // Repeated on resume: the pane's label promises auto mode, and a
-        // resumed session that quietly came back in a different one would make
-        // that label a lie for the rest of the conversation.
+        // Repeated on resume: the pane's label promises auto mode on Opus, and
+        // a resumed session that quietly came back in a different mode or
+        // model would make that label a lie for the rest of the conversation.
         "resume": {
           "argv": [
             "claude",
             "--resume",
             "${veld.pane.token}",
             "--permission-mode",
-            "auto"
+            "auto",
+            "--model",
+            "opus"
+          ]
+        },
+        "auto_resume": true
+      },
+      {
+        // Same shape as `claude` above, pinned to Sonnet instead of Opus —
+        // a distinct pane rather than a variant of the other, because the
+        // token is per-pane: two panes means two independent conversations
+        // that can both be open at once.
+        "id": "claude-sonnet",
+        "type": "terminal",
+        "label": "Claude Sonnet",
+        "description": "Claude Code (Sonnet) in this worktree, in auto permission mode",
+        "icon": "robot",
+        "requires_bin": ["claude"],
+        "argv": [
+          "claude",
+          "--permission-mode",
+          "auto",
+          "--model",
+          "sonnet",
+          "--session-id",
+          "${veld.pane.token}"
+        ],
+        "resume": {
+          "argv": [
+            "claude",
+            "--resume",
+            "${veld.pane.token}",
+            "--permission-mode",
+            "auto",
+            "--model",
+            "sonnet"
           ]
         },
         "auto_resume": true


### PR DESCRIPTION
## Summary

- Terminal "click to focus" toast now closes immediately on click instead of lingering until its 8s `autoClose` timeout. The toast is given an id and `notifications.hide(id)` runs in the same `onClick` handler that focuses the pane.
- Adds a "Super light" review tier to the `/ship` skill's kickoff questionnaire — a single sonnet agent reading the diff once for correctness, no staged angles or verify pass — for fixes even smaller than the existing Light tier's own trivia-clause floor.
- Adds a `PreToolUse` hook (`.claude/settings.json`) blocking a Bash `find` rooted at bare `/`, plus an AGENTS.md convention naming the hazard, after an agent's `find /` triggered repeated macOS TCC Photos/Music permission prompts while investigating a `node_modules` path.

## Root cause (toast fix)

`notifyTerminal` passed `onClick: opts.onClick` straight through to Mantine's `notifications.show()`. Mantine doesn't close a notification on click by default — only on its `autoClose` timer (or an explicit `hide()`) — so the toast stayed on screen for up to 8s after the click already did the thing it offered.

## Review

Ran the new **Super light** tier: one sonnet pass reviewed the notify.ts diff for correctness (Math.random usage, Mantine hide-from-own-onClick semantics, autoClose/hover-pause regressions, TypeScript shape). No findings.

## Test evidence

- `tsc --noEmit` in `crates/veld-daemon/ui`: clean.
- `./node_modules/.bin/biome lint src` (the real signal — see note below): exit 0, matches `main`'s current green "Management UI v2 (TypeScript)" CI job.
- Pipe-tested and live-fired the new find-guard hook against 6 cases (bare `/`, `find .`, a real path, chained after `&&`, an unrelated command, flags before `/`) — all correct.

**Note on a detour:** `npm run lint` in this environment is intercepted by a local shell tool (`rtk`) that misparses Biome's plain-text reporter as ESLint JSON and always reports a fake exit 1, regardless of the real result — cost some time chasing a phantom "6221 warnings" failure before finding the local `biome` binary directly gives the true (passing) signal. Not a repo issue; noting it here in case it looks like an unaddressed CI concern.

## Scope note

The stack also carries an unrelated, already-committed `veld.json` change (from `385c333`, prior to this session) adding a Sonnet-pinned Claude pane — pushing it along per the maintainer's request rather than splitting it out.

## Merge policy

Bypass-merge on green CI, no test checkpoint, per explicit instruction.