### PR TITLE
feat(ide): confirm before fast-forwarding a dirty main checkout

### DIFF
--- a/crates/veld-daemon/src/desktop.rs
+++ b/crates/veld-daemon/src/desktop.rs
@@ -41,6 +41,7 @@ pub fn routes() -> Router {
         .route("/api/repos", get(list_repos).delete(remove_repo))
         .route("/api/repos/refresh", post(refresh_repos))
         .route("/api/repos/update-main", post(update_main))
+        .route("/api/repos/revert-root", post(revert_repo_root))
         .route("/api/repos/import", post(import_repo))
         .route("/api/worktrees", post(create_worktree))
         .route(
@@ -1675,6 +1676,43 @@ struct UpdateMainBody {
     root: String,
 }
 
+/// Resolve the main checkout's branch — what the IDE means by "main" even
+/// when the project calls it something else — and refuse to touch the repo
+/// root unless it is actually checked out on that branch.
+///
+/// Shared by [`update_main`] and [`revert_repo_root`]: a revert that discards
+/// uncommitted work only for the fast-forward that follows to refuse anyway
+/// for an unrelated reason (wrong branch) destroys work for nothing, so both
+/// callers apply the same gate before doing anything destructive. A detached
+/// HEAD fails `symbolic-ref` and lands here too.
+async fn checked_default_branch(db: &Db, repo_root: &FsPath) -> Result<String, ApiError> {
+    let default_branch = db
+        .list_worktrees(repo_root)
+        .map_err(db_err)?
+        .into_iter()
+        .find(|w| w.is_main)
+        .map(|w| w.branch)
+        .ok_or_else(|| err(StatusCode::CONFLICT, "cannot determine the default branch"))?;
+    let head_branch = git(repo_root, &["symbolic-ref", "--short", "HEAD"])
+        .await
+        .map_err(|e| {
+            err(
+                StatusCode::CONFLICT,
+                format!("repo root is not on a branch: {e}"),
+            )
+        })?;
+    if head_branch != default_branch {
+        return Err(err(
+            StatusCode::CONFLICT,
+            format!(
+                "repo root is on \"{head_branch}\", not \"{default_branch}\" — \
+                 switch it to update {default_branch}"
+            ),
+        ));
+    }
+    Ok(default_branch)
+}
+
 /// Bring the repo's main checkout up to date with `origin/<default>`: fetch,
 /// then fast-forward-only.
 ///
@@ -1702,35 +1740,7 @@ async fn update_main(Json(body): Json<UpdateMainBody>) -> Result<Json<RepoView>,
         .ok_or_else(|| err(StatusCode::NOT_FOUND, "repo not imported"))?;
     let repo_root = PathBuf::from(&repo.root);
 
-    // The default branch is the main checkout's branch — what the IDE means by
-    // "main" even when the project calls it something else.
-    let default_branch = db
-        .list_worktrees(&repo_root)
-        .map_err(db_err)?
-        .into_iter()
-        .find(|w| w.is_main)
-        .map(|w| w.branch)
-        .ok_or_else(|| err(StatusCode::CONFLICT, "cannot determine the default branch"))?;
-
-    // Fast-forwarding only moves the checkout's *current* branch, so it must be
-    // the default. A detached HEAD fails `symbolic-ref` and lands here too.
-    let head_branch = git(&repo_root, &["symbolic-ref", "--short", "HEAD"])
-        .await
-        .map_err(|e| {
-            err(
-                StatusCode::CONFLICT,
-                format!("repo root is not on a branch: {e}"),
-            )
-        })?;
-    if head_branch != default_branch {
-        return Err(err(
-            StatusCode::CONFLICT,
-            format!(
-                "repo root is on \"{head_branch}\", not \"{default_branch}\" — \
-                 switch it to update {default_branch}"
-            ),
-        ));
-    }
+    let default_branch = checked_default_branch(&db, &repo_root).await?;
     // Empty porcelain output is a clean tree; anything else is uncommitted work
     // that a fast-forward would fight. Reuses the shared `git_status` helper the
     // worktree delete flow uses (one spelling of `status --porcelain`, not two).
@@ -1775,6 +1785,50 @@ async fn update_main(Json(body): Json<UpdateMainBody>) -> Result<Json<RepoView>,
         })?;
     let git = repo_git_status(&db, &repo_root).await;
     Ok(Json(repo_view(&db, repo, true, Some(git)).await?))
+}
+
+/// Discard the repo root's uncommitted changes so [`update_main`] can
+/// fast-forward it.
+///
+/// The "revert changes" half of the top bar's dirty confirm — the same trade
+/// [`revert_worktree`] makes for a worktree, but reached by repo root rather
+/// than worktree id, since that endpoint refuses on the main checkout on
+/// purpose. Shares [`update_main`]'s branch and live-run gates: reverting is
+/// destructive, so it must refuse under exactly the conditions that would make
+/// the fast-forward it exists to unblock refuse anyway — otherwise a dirty
+/// repo root on the wrong branch would lose its uncommitted work for nothing.
+async fn revert_repo_root(Json(body): Json<UpdateMainBody>) -> Result<Json<StatusView>, ApiError> {
+    let db = open_desktop_db()?;
+    let repo = db
+        .get_repo(FsPath::new(&body.root))
+        .map_err(db_err)?
+        .ok_or_else(|| err(StatusCode::NOT_FOUND, "repo not imported"))?;
+    let repo_root = PathBuf::from(&repo.root);
+    // Refuse before doing anything destructive if the fast-forward this revert
+    // exists to unblock would refuse anyway (wrong branch): discarding real,
+    // uncommitted work only to hit an unrelated refusal a moment later is a
+    // pure loss, not progress. See `checked_default_branch`.
+    checked_default_branch(&db, &repo_root).await?;
+    let live = db.live_run_names(&repo_root).map_err(db_err)?;
+    if !live.is_empty() {
+        return Err(err(
+            StatusCode::CONFLICT,
+            format!(
+                "a run is live in the repo root ({}) — stop it before reverting",
+                live.join(", ")
+            ),
+        ));
+    }
+    revert_git_changes(&repo_root)
+        .await
+        .map_err(|e| err(StatusCode::UNPROCESSABLE_ENTITY, e))?;
+    let files = git_status(&repo_root)
+        .await
+        .map_err(|e| err(StatusCode::UNPROCESSABLE_ENTITY, e))?;
+    Ok(Json(StatusView {
+        dirty: !files.is_empty(),
+        files,
+    }))
 }
 
 #[derive(Deserialize)]
@@ -3407,6 +3461,7 @@ mod tests {
             for (method, uri, body) in [
                 ("POST", "/api/repos/refresh", ""),
                 ("POST", "/api/repos/import", r#"{"path":"/tmp"}"#),
+                ("POST", "/api/repos/revert-root", r#"{"root":"/tmp"}"#),
                 ("DELETE", "/api/repos", r#"{"root":"/tmp"}"#),
                 (
                     "POST",
@@ -3617,5 +3672,52 @@ mod tests {
             age < 600,
             "commit B was just made, so the newest missing commit should be recent (age {age}s)"
         );
+    }
+
+    /// `checked_default_branch` must refuse a repo root that isn't on the
+    /// registered default branch, and must do so *before* the caller does
+    /// anything destructive — `revert_repo_root` relies on this running ahead
+    /// of `revert_git_changes` so a wrong-branch repo root never has its
+    /// uncommitted work discarded for a fast-forward that was going to refuse
+    /// anyway.
+    #[tokio::test]
+    async fn checked_default_branch_refuses_a_repo_root_on_the_wrong_branch() {
+        fn git(cwd: &std::path::Path, args: &[&str]) {
+            let out = std::process::Command::new("git")
+                .arg("-C")
+                .arg(cwd)
+                .args(args)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let work = dir.path().join("work");
+        std::fs::create_dir_all(&work).unwrap();
+        git(&work, &["init", "-b", "main"]);
+        git(&work, &["config", "user.email", "t@t"]);
+        git(&work, &["config", "user.name", "t"]);
+        std::fs::write(work.join("a.txt"), "a").unwrap();
+        git(&work, &["add", "a.txt"]);
+        git(&work, &["commit", "-m", "A"]);
+
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = veld_core::db::Db::open_at(&db_dir.path().join("veld.db")).unwrap();
+        db.upsert_repo(&work, "test").unwrap();
+        sync_repo_worktrees(&db, &work).await.unwrap();
+
+        // On "main" (the registered default branch): the gate passes.
+        assert_eq!(checked_default_branch(&db, &work).await.unwrap(), "main");
+
+        // Switched to a feature branch: the gate must refuse rather than let a
+        // caller proceed to something destructive.
+        git(&work, &["checkout", "-qb", "feature"]);
+        let refusal = checked_default_branch(&db, &work).await.unwrap_err();
+        assert_eq!(refusal.0, StatusCode::CONFLICT);
     }
 }

--- a/crates/veld-daemon/ui/src/App.tsx
+++ b/crates/veld-daemon/ui/src/App.tsx
@@ -226,6 +226,7 @@ import {
   RemoveRepoDialog,
   RenameWorktreeDialog,
   TrashWorktreeDialog,
+  UpdateMainDirtyDialog,
 } from "./components/dialogs";
 
 import {
@@ -1873,6 +1874,12 @@ function AppInner(props: {
      * state; the dialog turns it into a choice (discard vs revert first).
      */
     | { kind: "confirm-delete"; worktree: Worktree; status: WorktreeGitStatus }
+    /**
+     * The top bar's "update main" hit a dirty repo root. `status` is the
+     * fetched dirty state; the dialog turns it into a choice (revert first, or
+     * cancel) instead of the daemon's refusal landing as a bare toast.
+     */
+    | { kind: "update-main-dirty"; root: string; status: WorktreeGitStatus }
     | { kind: "marker"; worktree: Worktree }
     /** `worktree` set means "create it, then move this one into it". */
     | { kind: "new-lane"; worktree?: Worktree }
@@ -4193,14 +4200,11 @@ function AppInner(props: {
     );
   }
 
-  /**
-   * The one-click "update main": fetch + fast-forward the main checkout, then
-   * re-read the repo so the staleness badge clears in the same breath. The
-   * daemon refuses a dirty tree, a root not on the default branch, or a root
-   * with a live run — the error is the "why" a greyed button cannot say.
-   */
-  const updateMain = async () => {
-    if (!repo || updatingMain) return;
+  /** Fetch + fast-forward the main checkout, then re-read the repo so the
+   *  staleness badge clears in the same breath. Shared by the direct click
+   *  and the dirty-confirm dialog's "revert, then update" button. */
+  const doUpdateMain = async () => {
+    if (!repo) return;
     setUpdatingMain(true);
     try {
       await api.updateMain(repo.root);
@@ -4211,6 +4215,31 @@ function AppInner(props: {
     } finally {
       setUpdatingMain(false);
     }
+  };
+
+  /**
+   * The one-click "update main". Mirrors the trash flow: check the repo
+   * root's dirty state up front (same `git status` the daemon's own refusal
+   * would otherwise surface a moment later as a bare toast) and, if dirty,
+   * turn it into a choice — revert first, or cancel — instead of failing
+   * blind. A clean tree skips straight to the fast-forward as before.
+   */
+  const updateMain = async () => {
+    if (!repo || updatingMain) return;
+    const main = worktrees.find((w) => w.is_main);
+    if (main) {
+      try {
+        const status = await api.worktreeGitStatus(main.id);
+        if (status.dirty) {
+          setDialog({ kind: "update-main-dirty", root: repo.root, status });
+          return;
+        }
+      } catch {
+        // Status unavailable (git error, checkout gone): fall through and let
+        // the daemon's own dirty check surface the refusal, as before.
+      }
+    }
+    await doUpdateMain();
   };
 
   return (
@@ -4621,6 +4650,17 @@ function AppInner(props: {
           onRevertThenDelete={async () => {
             await api.revertWorktree(dialog.worktree.id);
             await enqueueDelete(dialog.worktree);
+            closeDialog();
+          }}
+        />
+      )}
+      {dialog.kind === "update-main-dirty" && (
+        <UpdateMainDirtyDialog
+          status={dialog.status}
+          onClose={closeDialog}
+          onRevertThenUpdate={async () => {
+            await api.revertRepoRoot(dialog.root);
+            await doUpdateMain();
             closeDialog();
           }}
         />

--- a/crates/veld-daemon/ui/src/api.ts
+++ b/crates/veld-daemon/ui/src/api.ts
@@ -1026,6 +1026,16 @@ export const api = {
       body: JSON.stringify({ root }),
     }),
   /**
+   * Discard the repo root's uncommitted changes so `updateMain` can
+   * fast-forward it: tracked files reset to HEAD, untracked files removed.
+   * Returns the post-revert status. Destructive — the UI must ask first.
+   */
+  revertRepoRoot: (root: string) =>
+    request<WorktreeGitStatus>("/api/repos/revert-root", {
+      method: "POST",
+      body: JSON.stringify({ root }),
+    }),
+  /**
    * Create a worktree.
    *
    * `emoji`/`marker_color` are the create dialog's marker pick. Sent with the create

--- a/crates/veld-daemon/ui/src/components/dialogs.tsx
+++ b/crates/veld-daemon/ui/src/components/dialogs.tsx
@@ -913,6 +913,71 @@ export function ConfirmDeleteWorktreeDialog(props: {
 }
 
 /**
+ * Warn before fast-forwarding main over a dirty repo root.
+ *
+ * `merge --ff-only` refuses on uncommitted changes the same way
+ * `git worktree remove` does, so this mirrors the trash flow's dirty confirm:
+ * show what is in the way and let the user revert first instead of hitting
+ * the daemon's refusal blind. There is no "update anyway" — reverting is the
+ * only path that makes the fast-forward possible, unlike the trash flow's
+ * discard-and-proceed option.
+ */
+export function UpdateMainDirtyDialog(props: {
+  status: WorktreeGitStatus;
+  onClose: () => void;
+  /** Revert the repo root's changes, then fetch and fast-forward main. */
+  onRevertThenUpdate: () => Promise<void>;
+}) {
+  const revert = useSubmit(props.onRevertThenUpdate);
+  const count = props.status.files.length;
+  return (
+    <Modal title="Update main" onClose={props.onClose}>
+      <Stack gap="md">
+        <Alert color="yellow" variant="light" p="sm">
+          <Text size="sm" fw={600}>
+            The main checkout has {count} uncommitted change
+            {count === 1 ? "" : "s"} a fast-forward would refuse on.
+          </Text>
+          <Text size="xs" c="dimmed" mt={2}>
+            These files are not saved to git yet.
+          </Text>
+          <div style={{ marginTop: 8 }}>
+            <DirtyFileList files={props.status.files} />
+          </div>
+        </Alert>
+        <Text size="sm" c="dimmed">
+          Revert these changes and update main, or cancel and handle them
+          yourself first.
+        </Text>
+        <Group>
+          <Tooltip
+            label="Reverts these changes (reset to the last commit, remove untracked files), then fetches and fast-forwards main. This cannot be undone."
+            multiline
+            w={260}
+          >
+            <Button
+              color="yellow"
+              variant="light"
+              loading={revert.busy}
+              onClick={(e) => {
+                e.preventDefault();
+                void revert.submit(e);
+              }}
+            >
+              Revert changes, then update main
+            </Button>
+          </Tooltip>
+          <Button variant="default" onClick={props.onClose}>
+            Cancel
+          </Button>
+        </Group>
+        <ErrorText error={revert.error} />
+      </Stack>
+    </Modal>
+  );
+}
+
+/**
  * Edit a worktree's name and alias. Purely editing — trashing/deletion has its
  * own dialog ([`TrashWorktreeDialog`]), so a rename action can never
  * accidentally read as a delete, and the trash flow is never buried under a


### PR DESCRIPTION
## Summary

The topbar's "Update main" button (fetch + fast-forward the repo's main
checkout) already refused a dirty repo root — but only with a generic toast
("the repo root has uncommitted changes — commit or stash them first"), same
as any other refusal. This mirrors the existing trash flow's dirty-worktree
confirm instead: before calling update-main, the frontend checks the main
checkout's git status (reusing the trash flow's `GET /api/worktrees/{id}/status`),
and if dirty, opens a modal listing the blocking files (`DirtyFileList`, same
component the trash dialog uses) with two choices: **Cancel**, or **Revert
changes, then update main**. A clean tree is unaffected — same fast path as
before.

## What changed

- **Backend**: new `POST /api/repos/revert-root`, scoped to the repo root
  rather than a worktree id, because the existing `revert_worktree` handler
  explicitly refuses on the main checkout (`is_main`) by design. Reuses the
  same `revert_git_changes`/`git_status` helpers the per-worktree revert and
  status endpoints already use.
- **Frontend**: `updateMain` split into `doUpdateMain` (the actual fetch+ff
  call, unchanged) and `updateMain` (new proactive dirty check that opens a
  dialog instead of calling straight through when dirty). New
  `UpdateMainDirtyDialog` component, mirroring `ConfirmDeleteWorktreeDialog`'s
  shape.

## Root cause fixed during review

Review (first-person, after three background review agents idled without
ever delivering a report — a known failure mode) caught a real bug before it
shipped: the new `revert_repo_root` endpoint had no check that the repo root
was actually on the default branch, unlike its sibling `update_main`. A dirty
repo root sitting on the *wrong* branch would pass the frontend's dirty
check, show the "revert & update" dialog, have its uncommitted work destroyed
by the revert, and then still have the fast-forward refuse anyway (wrong
branch) — a pure, irreversible loss with zero benefit, since `update_main`
checks branch *before* it checks dirtiness.

Fixed by extracting `checked_default_branch` (the branch-resolution +
mismatch-refusal logic `update_main` already had) into a helper shared by
both handlers, and running it first in `revert_repo_root`, before the
live-run check and before anything destructive. Added a regression test,
`checked_default_branch_refuses_a_repo_root_on_the_wrong_branch`, against a
real git repo + real DB fixture.

## Rejected alternative

Considered gating the *frontend's* proactive dirty-check on branch state
instead (skip the dialog if not on the default branch, let update-main's
existing toast handle it) rather than fixing it server-side. Rejected: the
backend is the one source of truth for "which branch counts as main," and a
client-side duplicate of that check would drift from `update_main`'s own
logic the same way the bug in this PR did — the two must share one gate.

## Test evidence

- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt --all --check` — clean
- `cargo test -p veld-daemon` (desktop:: module) — 33 passed, including the
  new regression test and the existing CSRF-403 table (extended with the new
  route)
- `npm run typecheck` / biome lint (crates/veld-daemon/ui) — clean (0 errors;
  pre-existing project-wide warnings only, untouched by this diff)
- `npm test` (crates/veld-daemon/ui) — 844 passed
- Hands-on: ran `just dev-daemon` + `just dev-ui`, imported a real repo,
  dirtied the main checkout, confirmed the modal lists the file and both
  Cancel and Revert-and-update work — maintainer confirmed working before
  this PR was opened.

## Docs

No config fields, CLI flags, or schema changed — purely a UX safety net on an
existing button. Website/promotions: no update — this isn't a new capability,
existing feature got safer; promotions are never for a fix.

## Review

Ran the repo's autonomous multi-angle review loop, stakes-elevated (new
mutating daemon HTTP endpoint touching the working tree) despite the
maintainer's light-depth request — §3.3 of docs/agentic-review.md makes that
override non-downgradable. See commit for the fix; ledger is gitignored
(`notes/review/`).