### PR TITLE
fix(desktop): stop losing a window's actual size on near-max resize

### DIFF
--- a/crates/veld-daemon/ui/src/styles.css
+++ b/crates/veld-daemon/ui/src/styles.css
@@ -244,14 +244,14 @@ select:focus {
  * buttons sit off the bar's own controls. The inset is what clears those
  * buttons: `windows.js` puts the leftmost at x=13, and three 14px lights on
  * macOS 26's 23px pitch end at 73px (see `TRAFFIC_LIGHT_SIZE` for where those
- * two numbers were measured). 90 leaves 17px after them — more than the 13px
+ * two numbers were measured). 100 leaves 27px after them — more than the 13px
  * they get on their left and clearly more than the 9px between the bar's own
  * controls, so the OS buttons read as their own group rather than as the first
  * item of ours. That is the lights' metric, not the bar's: retuning the bar's
  * padding or gap is not a reason to move this. */
 .topbar.electron {
   height: 40px;
-  padding-left: 90px; /* traffic-light inset */
+  padding-left: 100px; /* traffic-light inset */
   -webkit-app-region: drag;
 }
 .topbar.electron > * {

--- a/desktop/src/windows.js
+++ b/desktop/src/windows.js
@@ -373,6 +373,24 @@ let persistTimer = null;
  * — the one field in the state file that survives having no windows.
  */
 let lastMainBounds = null;
+/**
+ * The bounds to persist for a window: always its live rect, never
+ * `getNormalBounds()`.
+ *
+ * The latter looked like the right call — a window remembered while
+ * maximised should restore to the size it had before, not to a literal
+ * full-screen rect — until it was measured against a real resize: dragging a
+ * window's edges to fill its display flips `isMaximized()` true on this
+ * platform exactly the same as clicking the maximize control does, so
+ * `getNormalBounds()` cannot tell "the user maximised this" from "the user
+ * dragged it to nearly this size" apart — both land on the pre-drag restore
+ * rect, which is stale in the second case. There is no reliable signal here
+ * to recover the graceful-unmaximize behaviour with, so the simpler, correct
+ * rule wins: what you see is what gets restored.
+ */
+function capturedBounds(win) {
+  return win.getBounds();
+}
 function persistWindows() {
   // A quit closes every window one by one, and each `closed` would shrink the
   // recorded set — the last write winning would be "one window", which is what
@@ -388,15 +406,14 @@ function persistWindows() {
     // point some windows are already destroyed and would be filtered out of the
     // very list the next launch reopens.
     if (!deps || quitting) return;
-    // The last live main window's normal bounds, captured *while it is still
+    // The last live main window's bounds, captured *while it is still
     // alive* — the fallback bounds a fresh main window opens at. Captured here
     // rather than in `close` so it is current by the time the last window is
     // being torn down: when `closed` empties the set this has already been
     // updated by the resizes that led up to it, and writing it is what lets a
-    // macOS red-X close followed by a reopen recall the size. Normal bounds, so
-    // a window remembered while maximised restores to the size it had before.
+    // macOS red-X close followed by a reopen recall the size.
     const main = allRecords().find((r) => r.kind === "main" && !r.win.isDestroyed());
-    if (main) lastMainBounds = safeBounds(main.win.getNormalBounds());
+    if (main) lastMainBounds = safeBounds(capturedBounds(main.win));
     try {
       const records = allRecords()
         .filter((r) => !r.win.isDestroyed())
@@ -406,10 +423,9 @@ function persistWindows() {
           origin: r.origin,
           worktreeId: r.worktreeId,
           repoRoot: r.repoRoot,
-          // Normal bounds, not `getBounds()`: a window remembered while
-          // maximised or full-screen restores as a window with no way back to
-          // the size it had before.
-          bounds: safeBounds(r.win.getNormalBounds()),
+          // See `capturedBounds` for why this is the live rect, never
+          // `getNormalBounds()`.
+          bounds: safeBounds(capturedBounds(r.win)),
         }));
       fs.mkdirSync(path.dirname(deps.stateFile), { recursive: true });
       // Write-then-rename, because a torn file is worse than a stale one: a
@@ -617,7 +633,11 @@ function openWindow(options = {}) {
           titleBarStyle: "hiddenInset",
           trafficLightPosition: {
             x: 13,
-            y: Math.round((deps.topbarHeight - deps.trafficLightSize) / 2),
+            // The centred value reads 2px low against the bar's own controls
+            // on the current build; nudged up rather than folded into the
+            // centring math, which is a separately-verified measurement (see
+            // `TRAFFIC_LIGHT_SIZE` in `main.js`).
+            y: Math.round((deps.topbarHeight - deps.trafficLightSize) / 2) - 2,
           },
         }),
     backgroundColor: "#0d0e10",


### PR DESCRIPTION
## What / why

Resizing the Electron main window to near-full or truly-full screen (dragging, not clicking the maximize control) got mis-persisted — on quit + relaunch the window came back at an older, smaller size.

## Root cause

Confirmed via live instrumentation on macOS: a manual resize that fills (or nearly fills) the display's work area flips `BrowserWindow.isMaximized()` true exactly the same as an explicit maximize does. `getNormalBounds()` then returns whatever restore rect it had cached *before* the drag — stale — because there's no reliable signal to tell "the user maximised this" apart from "the user dragged it to nearly/exactly this size."

The original design (persist `getNormalBounds()` so a maximised window restores "gracefully" to its pre-maximize size) can't be built correctly on top of that signal, since both gestures are indistinguishable to it.

## Fix

`capturedBounds()` in `desktop/src/windows.js` now always persists the live rect (`getBounds()`), never `getNormalBounds()`. Simpler and correct: what you see is what gets restored.

## Also in this PR

Two small, already-verified-live cosmetic fixes to the same file/area, bundled because they touch the same window-chrome code:
- macOS traffic-light buttons nudged up 2px (`trafficLightPosition.y`) — they read slightly low against the topbar's own controls.
- Topbar's traffic-light inset (`padding-left`) widened 90→100px for more breathing room between the lights and the mode switch.

## Test evidence

- `cd desktop && npm test` — 113/113 pass.
- `biome lint` on touched files — 0 errors (only pre-existing style warnings repo-wide, unrelated).
- Root-caused and verified live against a running `veld start --preset dev` Electron instance: read `BrowserWindow.getBounds()`/`getNormalBounds()`/`isMaximized()` via temporary instrumentation while manually resizing, confirmed the stale-restore-rect mechanism, then confirmed the fix persists the correct size and the state file (`~/Library/Application Support/veld/windows.json`) round-trips through a restart with the actual dragged size. Maintainer additionally hand-verified the traffic-light/spacing tweaks in the same running build.

## Review

Ran the "super light" pass per this repo's review workflow (one agent, diff-only correctness read) — no findings.

## Docs

Purely internal bug fix + cosmetic pixel tweaks; no new config, flags, or user-visible capability, so no documentation-checklist or promotions-channel updates apply.