### PR TITLE
feat(ide): indicate resumable and auto-resumable panes in the chooser

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -195,7 +195,11 @@ Three rules that make it worth the spend rather than theatre:
 
 - Match surrounding code: naming, comment density, error handling, idioms.
 - Honour the AGENTS.md key conventions (daemon `PATH`, brand on every HTML
-  surface, `{var}` vs `${var}`, `command` vs `start_server` semantics).
+  surface, `{var}` vs `${var}`, `command` vs `start_server` semantics, and —
+  for any `crates/veld-daemon/ui` change — reaching for a Mantine primitive
+  before hand-rolling DOM+CSS for anything the library already provides; check
+  [mantine.dev/llms.txt](https://mantine.dev/llms.txt) when unsure whether one
+  exists).
 - Build, then `rustup update stable` (CI uses floating stable — drift blocks it),
   `cargo clippy --workspace --all-targets`, `cargo fmt --all`, and run the tests
   as you go. For a JS/TS change, run the Biome `lint` + `typecheck`/`test` in the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -377,6 +377,24 @@ run, while a plain terminal in the same app works perfectly.
   for a symbol across the UI will report zero hits while the only production consumer
   sits in that file. Found when a review agent concluded a function had no callers.
   Use `rg -a` (or `grep -a`) for anything that greps the UI tree.
+- **Reach for a Mantine primitive before hand-rolling DOM+CSS for anything the
+  library already provides.** This UI is `React+Mantine`, and a hand-rolled
+  equivalent of `Tooltip`/`Button`/`Menu`/`Modal`/`ActionIcon` quietly forks the
+  app's interaction model from everything built with the real one. A resumable-pane
+  badge shipped wrong twice before landing on this: first a `title` handed straight
+  to the Tabler icon component, which renders as an inner SVG `<title>` that only
+  opens on the painted stroke — nearly un-hoverable on a 13px outline glyph — then
+  a `title` on the wrapping `<span>`, which worked but is the slow ~1s browser-chrome
+  tooltip nothing else in the app uses. `Extensions.tsx`'s own badges and
+  `theme.ts`'s global `Tooltip: { defaultProps: { openDelay: 400 } }` already say
+  "Mantine's `Tooltip`, not the browser's" — reachable the whole time, and correct
+  and fast on the first try. Same reasoning for any other interactive or visual
+  primitive Mantine already ships; hand-roll only when there's a concrete reason it
+  doesn't fit, and say what that reason is. When unsure whether Mantine already has
+  it, check **[llms.txt](https://mantine.dev/llms.txt)** — an index of every
+  component/hook/guide page as a fetchable Markdown file
+  (`https://mantine.dev/llms/core-tooltip.md`, `-button`, `-menu`, …) — before
+  reaching for raw HTML/CSS.
 - **Never let a dev build touch the production database — and use the dev-DB
   recipes.** The installed veld's state lives in one file per user
   (`<data_dir>/veld/veld.db`). A binary that opens it and applies a migration makes

--- a/crates/veld-daemon/ui/src/panes/PaneArea.tsx
+++ b/crates/veld-daemon/ui/src/panes/PaneArea.tsx
@@ -49,12 +49,14 @@
  * (`PlaceList.tsx`).
  */
 
-import { ActionIcon, Button, Menu, Modal, Text } from "@mantine/core";
+import { ActionIcon, Button, Menu, Modal, Text, Tooltip } from "@mantine/core";
 import {
   IconActivityHeartbeat,
   IconArrowsExchange,
+  IconBolt,
   IconBookmark,
   IconExternalLink,
+  IconHistory,
   IconLayoutColumns,
   IconLogs,
   IconPlus,
@@ -1643,6 +1645,49 @@ function PaneButton(props: { spec: PaneSpec; onPick: (spec: PaneSpec) => void })
     >
       <span className="pane-card-main">
         {paneIcon(spec.icon, 15)} {spec.label}
+        {/* This is what teaches a contributor that a pane is worth keeping open:
+            `resume`/`auto_resume` are config fields most people would never open
+            `veld.json` to discover otherwise. Auto gets its own glyph rather than
+            sharing one with a qualifier, because the two are genuinely different
+            promises — the Codex pane below is resumable but never auto, and the
+            distinction is exactly what a glance at the chooser should surface. */}
+        {spec.auto_resume ? (
+          <Tooltip
+            label="Resumes its last session automatically — no click needed"
+            withArrow
+            openDelay={200}
+          >
+            {/* `title=""` blocks inheritance of the card button's own `title` —
+                without it, hovering the badge fires the fast Mantine tooltip
+                *and*, after the browser's native delay, the button's title
+                (the pane's description), stacked over the same spot. `tabIndex`
+                makes the badge focusable, which is what lets Mantine's Tooltip
+                show it on keyboard focus too, not only on mouse hover. */}
+            <span
+              className="pane-resume-badge auto"
+              title=""
+              tabIndex={0}
+              aria-label="Resumes its last session automatically — no click needed"
+            >
+              <IconBolt size={13} />
+            </span>
+          </Tooltip>
+        ) : spec.can_resume ? (
+          <Tooltip
+            label="Can resume its last session — offered as a choice, not automatic"
+            withArrow
+            openDelay={200}
+          >
+            <span
+              className="pane-resume-badge"
+              title=""
+              tabIndex={0}
+              aria-label="Can resume its last session — offered as a choice, not automatic"
+            >
+              <IconHistory size={13} />
+            </span>
+          </Tooltip>
+        ) : null}
       </span>
       {/* Every card carries its second line, not only a chosen one: the description
           is what tells four agent panes apart, and giving it to one of them is how

--- a/crates/veld-daemon/ui/src/styles.css
+++ b/crates/veld-daemon/ui/src/styles.css
@@ -1939,6 +1939,20 @@ body[data-theme="light"] .swatch-cell > .swatch-dot {
   flex: none;
 }
 
+/* Teaches resumability without a second line of text: subdued for "offered as a
+   choice", tinted `--info` for "happens without a click" — the two are different
+   promises (Codex is resumable but never auto), so they get different glyphs
+   rather than one glyph and a qualifier. */
+.pane-resume-badge {
+  display: inline-flex;
+  flex: none;
+  color: var(--muted);
+}
+
+.pane-resume-badge.auto {
+  color: var(--info);
+}
+
 /* The description, on every card. Clamped rather than truncated to one line: two
    lines of "Claude Code in this worktree, in auto permission mode" is the sentence,
    and an ellipsis after four words tells you nothing. */


### PR DESCRIPTION
## Summary

The pane chooser's "Work in a terminal" cards already had everything needed to tell a resumable pane apart from a plain one — `PaneSpec.can_resume`/`auto_resume`, computed by the daemon from a pane's `ide.panes` config (`resume`/`auto_resume` fields) — but nothing in the UI surfaced it. A contributor had no way to learn a pane resumes, or resumes *automatically*, without opening `veld.json`.

Adds a small badge next to each card's label:
- 🔵 bolt icon — `auto_resume: true` — "resumes its last session automatically, no click needed"
- ⚪ history icon — `can_resume: true`, `auto_resume: false` — "can resume, offered as a choice"
- nothing — neither declared (plain `Terminal`, `Git log`, …)

Against this repo's own `veld.json`: Claude Opus/Sonnet and Pi get the bolt, Codex gets the history icon (declares `resume` but `auto_resume: false` on purpose, per its own comment), Terminal/Git log get neither.

No config or schema changes — `can_resume`/`auto_resume` already existed on `PaneSpec` and have been used elsewhere in this file (the running pane's own Resume button) for a while. This is presentation-only.

## Root cause / classification

Core, not customization (universal-primitive test): this renders data the daemon already computes from the project's own config, with no provider API involved.

## Also in this PR

A documentation-only addition, prompted by how the badge's tooltip was built: **`AGENTS.md`** gets a new Key Convention — reach for a Mantine primitive (`Tooltip`, `Button`, `Menu`, …) before hand-rolling DOM+CSS for anything the library already provides, with [mantine.dev/llms.txt](https://mantine.dev/llms.txt) named as the way to check whether one exists. `.claude/skills/ship/SKILL.md`'s Step 2 now points at it. Recorded because the tooltip shipped wrong twice before landing on Mantine's own `Tooltip` (see the review-fix commit and the AGENTS.md bullet itself for the concrete failure modes).

## Review

Super-light tier (small, self-contained diff, no stakes-override paths touched): one sonnet pass over the full diff found two real issues, both fixed before this PR:
- 🟠 the badge's `<span>` had no `title` of its own, so it inherited the card button's native `title` — hovering the badge would fire the fast Mantine tooltip *and*, after the browser's native delay, the button's own tooltip stacked on top. Fixed with `title=""` on the badge.
- 🟡 the badge's tooltip was mouse-hover-only (a non-focusable `<span>`), unlike every other `Tooltip` in this codebase (`Extensions.tsx`'s badges wrap actual `Button`/`ActionIcon` controls). Fixed with `tabIndex={0}` + `aria-label` so it's reachable and announced on keyboard focus too.

## Test plan

- [x] `crates/veld-daemon/ui`: `npm run typecheck`, `npm run lint` (Biome, exit 0 — only pre-existing warnings, no new errors), `npm test` (855 tests, all green) — run before and after the review fixes
- [x] `just lint` (full repo: clippy, fmt, all JS/TS surfaces) — green
- [x] `just test` (full repo) — running, will confirm green before marking ready
- [x] Hand-driven in a local `veld start --preset dev-headless` run against this repo's own `veld.json`: confirmed the bolt/history badges render on the right cards and the Mantine tooltip opens fast on hover

## Docs / promotion

- No config/CLI surface changed, so no README/schema/config-doc updates apply.
- Marketing site: not updated — this is IDE polish, not a headline capability.
- Feature promotion (`ide.news`): not added — the badge teaches in place every time the chooser opens, which is the opposite of the "would otherwise never notice" case promotions exist for.