### PR TITLE
feat(desktop): find in page for embedded browser panes

### DIFF
--- a/crates/veld-daemon/ui/src/App.tsx
+++ b/crates/veld-daemon/ui/src/App.tsx
@@ -2843,10 +2843,13 @@ function AppInner(props: {
 
   // A focused native view swallows every keystroke, so the shell forwards the
   // palette accelerator back to us (it also moves focus to the page, or the
-  // palette would open with the keyboard still pointed at the view).
+  // palette would open with the keyboard still pointed at the view). The
+  // per-pane "find" accelerator is not handled here — `BrowserPane` itself
+  // subscribes and filters on its own `viewId`, since only one pane's find bar
+  // should open.
   useEffect(
     () =>
-      onBrowserAccelerator((accelerator) => {
+      onBrowserAccelerator(({ accelerator }) => {
         if (accelerator === "palette") setDialog({ kind: "search" });
       }),
     [],

--- a/crates/veld-daemon/ui/src/panes/BrowserPane.tsx
+++ b/crates/veld-daemon/ui/src/panes/BrowserPane.tsx
@@ -22,6 +22,8 @@ import {
   IconBookmark,
   IconBug,
   IconCheck,
+  IconChevronDown,
+  IconChevronUp,
   IconClockExclamation,
   IconCode,
   IconDeviceMobile,
@@ -36,6 +38,7 @@ import {
   IconRefresh,
   IconRestore,
   IconRotateClockwise,
+  IconSearch,
   IconShieldLock,
   IconSun,
   IconSunMoon,
@@ -105,9 +108,14 @@ import {
   browserDevTools,
   browserStatus,
   clearBrowserSession,
+  findNext,
+  findPrevious,
+  findSupported,
   mountBrowser,
   navigateBrowser,
+  onBrowserAccelerator,
   onBrowserPointer,
+  onFindResult,
   onPermissionRequest,
   onPermissionSettings,
   originOf,
@@ -121,6 +129,8 @@ import {
   setBrowserResizing,
   setBrowserZoom,
   setPermission,
+  startFind,
+  stopFind,
   subscribeBrowser,
   unmountBrowser,
   type PermissionPrompt,
@@ -305,6 +315,13 @@ export function BrowserPane(props: {
     const unsubscribe = subscribeBrowser(id, bump);
     return () => {
       unsubscribe();
+      // The find bar is this component's own state, and unmounting here is a
+      // detach, not a close — the view (and Chromium's highlights on it) lives
+      // on. Without this, switching away from a pane mid-search leaves
+      // highlights painted on a page with no bar and no React state left to
+      // clear them from; returning to the tab shows a plain closed pane over a
+      // still-highlighted page.
+      stopFind(id);
       // Detach only — the view lives on; `pruneBrowsers` in App.tsx is what
       // closes one for good.
       unmountBrowser(id);
@@ -524,6 +541,143 @@ export function BrowserPane(props: {
   const [confirmClear, setConfirmClear] = useState<BrowserProfile | "all" | null>(
     null,
   );
+
+  // ---- Find in page --------------------------------------------------------
+  //
+  // A bar in flow between the chrome and the slot, exactly like the permission
+  // prompt above and for the same reason: a native view paints over DOM
+  // whatever the z-index says, so an overlay is not an option here — shrinking
+  // the slot is, and its `ResizeObserver` republishes the view's box the same
+  // way it does for every other row this pane inserts above it.
+  //
+  // Electron only. An `<iframe>` cannot read cross-origin content to search it
+  // (`contentWindow` throws for the pane's whole reason to exist — a page that
+  // refuses to be framed elsewhere), so the button and the `Ctrl/⌘+F` bind are
+  // both gated on `canFind` and there is nothing here to disable-and-explain.
+  //
+  // `findSupported`, not just `!iframeBackend`: the app shell and this bundle
+  // update independently, so an app older than this feature has no `find` on
+  // its bridge at all. Gating on the backend alone would still render an open,
+  // typeable bar that silently does nothing — worse than no bar.
+  const canFind = !iframeBackend && findSupported;
+  const [findOpen, setFindOpen] = useState(false);
+  const [findQuery, setFindQuery] = useState("");
+  const [findResult, setFindResult] = useState<{
+    matches: number;
+    activeMatchOrdinal: number;
+  } | null>(null);
+  /**
+   * `null` is overloaded on `findResult` for two different things — "have not
+   * asked" and "asked, no answer yet" — and the count/prev/next below need to
+   * tell them apart from a third: "asked, and the page really has none." This
+   * flag is that third state. Without it, clearing `findResult` the instant a
+   * new query starts (so a stale count from the *previous* query does not
+   * linger) reads, until the reply lands, as an equally confident "No
+   * results" for the *current* one — flashing that on every keystroke of a
+   * page that has matches, which is worse than the stale count it replaced.
+   */
+  const [findPending, setFindPending] = useState(false);
+  const findInputRef = useRef<HTMLInputElement>(null);
+
+  const closeFind = () => {
+    stopFind(id);
+    setFindOpen(false);
+    setFindQuery("");
+    setFindResult(null);
+    setFindPending(false);
+  };
+
+  // `Ctrl/⌘+F` while this pane's native view has keyboard focus: the shell
+  // cannot forward it as a normal keystroke (a focused `WebContentsView`
+  // swallows every key), so it comes back as an accelerator naming which pane
+  // asked — filtered here rather than in `App.tsx`, since only the one pane the
+  // key was pressed in should open its bar.
+  useEffect(() => {
+    if (!canFind) return;
+    return onBrowserAccelerator((payload) => {
+      if (payload.accelerator !== "find" || payload.viewId !== id) return;
+      setFindOpen(true);
+      // A repeat `Ctrl/⌘+F` after clicking back into the page is the common
+      // case a real find bar handles by refocusing — but the bar is already
+      // open here, so `setFindOpen(true)` is a no-op React bails out of, and
+      // the mount-triggered focus effect below (keyed on `findOpen`) never
+      // reruns. Focus directly for that case; a no-op when the bar isn't
+      // mounted yet, which the effect below still covers on first open.
+      findInputRef.current?.focus();
+    });
+  }, [id, canFind]);
+
+  // The match count, from the page's own search — never derived here, since
+  // only Chromium knows what its highlighter actually found. Clears the
+  // pending flag: this reply is the answer the last `startFind` was waiting on
+  // (main-process forwards only Chromium's `finalUpdate` reply per request, so
+  // there is exactly one of these per query, not an intermediate scoping tick).
+  useEffect(() => {
+    return onFindResult((payload) => {
+      if (payload.viewId !== id) return;
+      setFindResult({ matches: payload.matches, activeMatchOrdinal: payload.activeMatchOrdinal });
+      setFindPending(false);
+    });
+  }, [id]);
+
+  // Live search-as-you-type, the same as a real browser's find bar. An empty
+  // query clears the highlights rather than searching for nothing, which would
+  // otherwise flash "No results" on every keystroke while the field is blank.
+  //
+  // For a non-empty query, `findResult` is cleared but `findPending` is set
+  // instead of also showing "No results": the previous query's count must not
+  // linger (a stale "3 of 5"), but flashing a confident zero on *every*
+  // keystroke of a page that has matches — while genuinely waiting on the
+  // reply — is a worse, more visible bug than the stale count it would replace.
+  useEffect(() => {
+    if (!findOpen) return;
+    if (findQuery === "") {
+      setFindResult(null);
+      setFindPending(false);
+      stopFind(id);
+      return;
+    }
+    setFindResult(null);
+    setFindPending(true);
+    startFind(id, findQuery);
+  }, [id, findOpen, findQuery]);
+
+  useEffect(() => {
+    if (findOpen) findInputRef.current?.focus();
+  }, [findOpen]);
+
+  // A stale match count surviving a navigation is a wrong answer, not a stale
+  // render — the query no longer describes the page underneath it, so closing
+  // the bar (rather than leaving "3 of 5" up for a page with none of them) is
+  // the only honest move. `findOpenRef` (not `findOpen` in the dependency
+  // array) is deliberate: opening the bar must not immediately close it.
+  //
+  // Keyed on `state.loading`'s rising edge, not on `state.url` directly — the
+  // permission prompt below draws the same lesson from the same trap
+  // (`promptOrigin`: "a fragment change cannot cross an origin"), just with a
+  // different fix for a different question. `state.url` is pushed on
+  // `did-navigate-in-page` too, which fires for a single-page app's own
+  // `history.pushState`/hash change with no real navigation underneath it, so
+  // closing the bar on every one of those would be firing on the wrong signal.
+  // Origin (that fix) is the wrong substitute here, though: a real same-origin
+  // navigation — an ordinary link to another page on the same site — must
+  // still close the bar, and origin-keying would miss exactly that. What
+  // actually distinguishes the two is whether a network load happened at all:
+  // `did-start-loading` — the one thing that flips `loading` to `true` — never
+  // fires for an in-page navigation, since there is nothing to load.
+  const findOpenRef = useRef(false);
+  findOpenRef.current = findOpen;
+  const wasLoadingRef = useRef(state.loading);
+  useEffect(() => {
+    const startedLoading = state.loading && !wasLoadingRef.current;
+    wasLoadingRef.current = state.loading;
+    if (!startedLoading || !findOpenRef.current) return;
+    stopFind(id);
+    setFindOpen(false);
+    setFindQuery("");
+    setFindResult(null);
+  }, [id, state.loading]);
+
   // Read by the unmount cleanup, which must not re-subscribe on every prompt.
   const promptRef = useRef<PermissionPrompt | null>(null);
   promptRef.current = prompt;
@@ -937,6 +1091,27 @@ export function BrowserPane(props: {
             {canStop ? <IconX size={14} /> : <IconRefresh size={14} />}
           </ActionIcon>
         </Tooltip>
+
+        {/* Find in page: Electron only, for the same reason the bar itself is —
+            an iframe cannot search cross-origin content it cannot read — and
+            also gated on `findSupported`, so an app shell older than this
+            feature (the two update independently) doesn't show a button that
+            opens a bar with no way to ever report a real count. Hidden rather
+            than disabled-with-tooltip, like the permission shield below: there
+            is nothing to explain past "this needs a newer desktop app". */}
+        {canFind && (
+          <Tooltip {...TIP} label="Find in page">
+            <ActionIcon
+              size="sm"
+              variant={findOpen ? "light" : "subtle"}
+              color={findOpen ? "blue" : "gray"}
+              aria-label="Find in page"
+              onClick={() => (findOpen ? closeFind() : setFindOpen(true))}
+            >
+              <IconSearch size={14} />
+            </ActionIcon>
+          </Tooltip>
+        )}
 
         {/* Site settings, where a browser puts them: at the head of the address
             bar, about the site the address bar is showing. Hidden in the browser
@@ -1933,6 +2108,77 @@ export function BrowserPane(props: {
           >
             Clear
           </Button>
+        </div>
+      )}
+
+      {/* Same row-in-flow trick as the two prompts above: it shrinks the slot
+          instead of painting over it, which is the only way a DOM element gets
+          to coexist with a native view that ignores z-index. */}
+      {findOpen && canFind && (
+        <div className="browser-find" role="search" aria-label="Find in page">
+          <IconSearch size={14} className="browser-find-icon" aria-hidden />
+          {/* A plain input, not Mantine's `TextInput`, to match the address bar two
+              rows up (`.browser-address`) — same pill height, monospace and focus
+              treatment. `TextInput`'s own wrapper and default sizing would need
+              overriding to match it anyway, and two different input styles this
+              close together would read as two toolbars, not one. */}
+          <input
+            ref={findInputRef}
+            className="browser-find-input"
+            value={findQuery}
+            spellCheck={false}
+            autoCapitalize="off"
+            autoCorrect="off"
+            placeholder="Find in page"
+            aria-label="Find in page"
+            onChange={(e) => setFindQuery(e.currentTarget.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                if (e.shiftKey) findPrevious(id, findQuery);
+                else findNext(id, findQuery);
+              } else if (e.key === "Escape") {
+                e.preventDefault();
+                closeFind();
+              }
+            }}
+          />
+          <span className="browser-find-count faint">
+            {findQuery === "" || findPending
+              ? ""
+              : findResult && findResult.matches > 0
+                ? `${findResult.activeMatchOrdinal} of ${findResult.matches}`
+                : "No results"}
+          </span>
+          <ActionIcon
+            size="sm"
+            variant="subtle"
+            color="gray"
+            aria-label="Previous match"
+            disabled={!findResult?.matches}
+            onClick={() => findPrevious(id, findQuery)}
+          >
+            <IconChevronUp size={14} />
+          </ActionIcon>
+          <ActionIcon
+            size="sm"
+            variant="subtle"
+            color="gray"
+            aria-label="Next match"
+            disabled={!findResult?.matches}
+            onClick={() => findNext(id, findQuery)}
+          >
+            <IconChevronDown size={14} />
+          </ActionIcon>
+          <ActionIcon
+            size="sm"
+            variant="subtle"
+            color="gray"
+            aria-label="Close find bar"
+            onClick={closeFind}
+          >
+            <IconX size={14} />
+          </ActionIcon>
         </div>
       )}
 

--- a/crates/veld-daemon/ui/src/panes/browserHost.ts
+++ b/crates/veld-daemon/ui/src/panes/browserHost.ts
@@ -153,6 +153,17 @@ interface DesktopBrowserApi {
     viewId: string,
     command: "back" | "forward" | "reload" | "stop" | "focus",
   ): Promise<void>;
+  /** Optional: arrived after the bridge did (see the note above the permission
+   *  helpers) — an older shell serving a newer bundle just has no find bar. */
+  find?(viewId: string, action: "start" | "next" | "previous" | "stop", text: string): Promise<void>;
+  onFindResult?(
+    fn: (payload: {
+      viewId: string;
+      requestId: number;
+      matches: number;
+      activeMatchOrdinal: number;
+    }) => void,
+  ): () => void;
   emulate(viewId: string, emulation: PaneEmulation | null): Promise<void>;
   /** Optional here, and in every permission method below: these arrived after
    *  the bridge did, and an older shell will not have them. See the note above
@@ -173,7 +184,7 @@ interface DesktopBrowserApi {
   onOpenRequest(
     fn: (payload: { viewId: string; url: string; profile: BrowserProfile }) => void,
   ): () => void;
-  onAccelerator(fn: (payload: { accelerator: string }) => void): () => void;
+  onAccelerator(fn: (payload: { viewId: string; accelerator: string }) => void): () => void;
   onPointer(
     fn: (payload: { viewId: string; type: string; x: number; y: number }) => void,
   ): () => void;
@@ -976,6 +987,64 @@ export function reloadBrowser(id: string): void {
 }
 
 /**
+ * Whether this shell's bridge actually has `find` — not just whether it's
+ * Electron. The two halves of Veld Desktop update independently (see the note
+ * above the permission helpers below), so a bundle newer than the app it's
+ * running in is a real pairing, not a hypothetical one. Without this, `find`'s
+ * being `?`-optional only stops the *call* from throwing; the button and the
+ * bar would still render, open, and sit there silently doing nothing — a
+ * find bar with no way to ever show a real count is worse than no find bar,
+ * the same reasoning that gates the permission shield icon on `site.origin`
+ * actually arriving rather than on the backend alone.
+ */
+export const findSupported: boolean = typeof desktop?.find === "function";
+
+/**
+ * Find-in-page for one pane's find bar. Electron only: an `<iframe>` cannot read
+ * cross-origin content to search it (`contentWindow` throws), so these are
+ * no-ops under the iframe backend and `BrowserPane` hides the find bar entirely
+ * there (`iframeBackend`).
+ *
+ * Operates on the pane's real `WebContents` regardless of whether the view is
+ * currently painted live or is hidden behind a frozen still while suspended —
+ * there is no "frozen" copy of the page to search, only a paint substitute; see
+ * `veld:browser:find` in `desktop/src/browserViews.js`.
+ *
+ * Errors are swallowed rather than surfaced through `reportFailure`: a failed
+ * find is not a reason to blank the pane with a load error.
+ */
+export function startFind(id: string, text: string): void {
+  if (!desktop) return;
+  void desktop.find?.(id, "start", text).catch(() => {});
+}
+
+export function findNext(id: string, text: string): void {
+  if (!desktop) return;
+  void desktop.find?.(id, "next", text).catch(() => {});
+}
+
+export function findPrevious(id: string, text: string): void {
+  if (!desktop) return;
+  void desktop.find?.(id, "previous", text).catch(() => {});
+}
+
+export function stopFind(id: string): void {
+  if (!desktop) return;
+  void desktop.find?.(id, "stop", "").catch(() => {});
+}
+
+export function onFindResult(
+  fn: (payload: {
+    viewId: string;
+    requestId: number;
+    matches: number;
+    activeMatchOrdinal: number;
+  }) => void,
+): () => void {
+  return desktop?.onFindResult ? desktop.onFindResult(fn) : () => {};
+}
+
+/**
  * Clear one session slot's cookies and storage, then reload any pane using it.
  *
  * Addressed by slot rather than by pane, so a session with no pane open can still
@@ -1500,8 +1569,10 @@ export function onBrowserOpenRequest(
   return desktop ? desktop.onOpenRequest(fn) : () => {};
 }
 
-export function onBrowserAccelerator(fn: (accelerator: string) => void): () => void {
-  return desktop ? desktop.onAccelerator((p) => fn(p.accelerator)) : () => {};
+export function onBrowserAccelerator(
+  fn: (payload: { viewId: string; accelerator: string }) => void,
+): () => void {
+  return desktop ? desktop.onAccelerator(fn) : () => {};
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/veld-daemon/ui/src/promotions/content.ts
+++ b/crates/veld-daemon/ui/src/promotions/content.ts
@@ -104,4 +104,12 @@ export const PROMOTIONS: Promotion[] = [
     body: "When somebody changes how your project runs, their note reaches you once — marked with the project's name, and kept in What's new if you close it.",
     glyph: "inbox",
   },
+  {
+    id: "browser-find-in-page",
+    since: "2026-08-13",
+    eyebrow: "New",
+    headline: "Stop hunting a page by eye for one word",
+    body: "A browser pane now searches its own live page: type to search, see how many matches turned up, and step between them with Enter or the arrows.",
+    glyph: "panes",
+  },
 ];

--- a/crates/veld-daemon/ui/src/styles.css
+++ b/crates/veld-daemon/ui/src/styles.css
@@ -2294,6 +2294,51 @@ body[data-theme="light"] .swatch-cell > .swatch-dot {
   font-weight: 600;
 }
 
+/* ---- Find in page (panes/BrowserPane.tsx) --------------------------------- */
+
+/* Same shape as `.permission-prompt`: an in-flow row between the chrome and the
+   slot, not an overlay — a native view paints over DOM regardless of z-index,
+   so shrinking the slot is the only way this coexists with the live page. */
+.browser-find {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 9px;
+  border-bottom: 1px solid var(--border);
+  background: var(--panel2);
+}
+
+.browser-find-icon {
+  color: var(--muted);
+  flex: none;
+}
+
+.browser-find-input {
+  flex: 1;
+  min-width: 64px;
+  height: 22px;
+  padding: 0 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg);
+  color: var(--text);
+  font-family: "JetBrains Mono Variable", ui-monospace, monospace;
+  font-size: 11px;
+  outline: none;
+}
+
+.browser-find-input:focus {
+  border-color: var(--accent);
+}
+
+.browser-find-count {
+  flex: none;
+  min-width: 64px;
+  font-size: 11px;
+  text-align: right;
+}
+
 /* The box a live view occupies. Under Electron the content is a native
    WebContentsView positioned over this element — it is NOT a child, and it
    ignores z-index — so nothing may be layered on top of it. `position:

--- a/desktop/src/browserViews.js
+++ b/desktop/src/browserViews.js
@@ -476,6 +476,28 @@ function attachListeners(window, viewId, entry) {
     push({ kind: "crash", code: null, text: String(details.reason), url: "" });
   });
 
+  // Chromium's own answer to `findInPage`/`stopFindInPage` below — the match
+  // count and which one is active. This always reflects the live page: a
+  // suspended pane's frozen still is only ever a paint substitute (`applyVisibility`
+  // in the renderer), never a substitute source for what gets searched.
+  //
+  // One request can raise several of these as Chromium scopes a long page, and
+  // only the one with `finalUpdate` is the authoritative tally — an earlier one
+  // can under-report (a fresh search reporting 0 matches before it has scanned
+  // far enough), which the pane would otherwise show as "No results" for a
+  // query that has some, for a moment. Forwarding only the final one is what a
+  // real production find-bar implementation does (electron-in-page-search
+  // gates on the same field before emitting).
+  wc.on("found-in-page", (_e, result) => {
+    if (!result.finalUpdate) return;
+    send(window, "veld:browser:find-result", {
+      viewId,
+      requestId: result.requestId,
+      matches: result.matches,
+      activeMatchOrdinal: result.activeMatchOrdinal,
+    });
+  });
+
   // A `target=_blank` (or `window.open`) inside a pane becomes another browser
   // *tab in the same dock*, carrying the same profile — so the popup keeps the
   // session it was opened from. The renderer decides where the tab goes; if it
@@ -503,17 +525,37 @@ function attachListeners(window, viewId, entry) {
 
   // While a native view has keyboard focus the renderer sees no keys at all, so
   // the app's own accelerators are dead the moment you click into a preview.
-  // Only the command palette's binding is intercepted and forwarded:
-  // `Ctrl/⌘+Shift+P` is the app's documented one, and unlike `⌘K` it is not
-  // something the previewed page is likely to want for itself.
+  // Two bindings are intercepted and forwarded: `Ctrl/⌘+Shift+P` for the command
+  // palette, and `Ctrl/⌘+F` for the pane's own find bar — both are the app's
+  // documented shortcuts. `⇧P` is safely outside anything a previewed page
+  // wants for itself; `F` is a real, accepted trade-off rather than a free
+  // one — a dev-server preview with its own find (a docs site, an embedded
+  // Monaco/CodeMirror editor) loses that binding entirely, since this fires
+  // ahead of the page's own key handlers and there is no escape hatch. This is
+  // the same trade a real browser tab already makes: Chrome's own find bar
+  // owns `Ctrl/⌘+F` unconditionally too, so a page cannot claim it there
+  // either — this pane behaving the same way is consistent with that, not a
+  // new risk this diff introduces.
   wc.on("before-input-event", (event, input) => {
-    if (input.type !== "keyDown" || !input.shift) return;
+    if (input.type !== "keyDown") return;
+    if (
+      (input.control || input.meta) &&
+      !input.shift &&
+      !input.alt &&
+      input.key.toLowerCase() === "f"
+    ) {
+      event.preventDefault();
+      // Move the keyboard back to the page first: forwarding the accelerator
+      // alone would open the bar while every keystroke still went to the view,
+      // so the input would be there and unusable.
+      window.webContents.focus();
+      send(window, "veld:browser:accelerator", { viewId, accelerator: "find" });
+      return;
+    }
+    if (!input.shift) return;
     if (!(input.control || input.meta)) return;
     if (input.key.toLowerCase() !== "p") return;
     event.preventDefault();
-    // Move the keyboard back to the page first: forwarding the accelerator
-    // alone would open the palette while every keystroke still went to the
-    // view, so the input would be there and unusable.
     window.webContents.focus();
     send(window, "veld:browser:accelerator", { viewId, accelerator: "palette" });
   });
@@ -1558,6 +1600,54 @@ function registerBrowserViewIpc(resolveWindow, opts = {}) {
       default:
         break;
     }
+  });
+
+  /**
+   * Find-in-page, driven by the pane's own find bar.
+   *
+   * `action` is "start" (a fresh search — the page's own current text, not
+   * whatever a previous query matched), "next"/"previous" (step to another match
+   * of the same text) or "stop" (clear the highlights). This always calls
+   * through to the real `WebContents` — there is no "frozen" mode for a pane's
+   * page content, only a paint substitute the renderer shows while a view is
+   * hidden, so a search issued against a suspended pane still finds the page's
+   * actual, current text and the highlights are there the moment it is shown
+   * again.
+   */
+  ipcMain.handle("veld:browser:find", (event, args) => {
+    const found = lookup(event, args?.viewId);
+    if (!found) return;
+    const wc = found.entry.view.webContents;
+    if (wc.isDestroyed()) return;
+    if (args?.action === "stop") {
+      wc.stopFindInPage("clearSelection");
+      return;
+    }
+    const text = typeof args?.text === "string" ? args.text : "";
+    if (!text) {
+      wc.stopFindInPage("clearSelection");
+      return;
+    }
+    // One options object per branch rather than a bare call for "start": a
+    // field added later (a match-case toggle, say) then has three explicit
+    // places to land instead of one bare call that's easy to miss. An
+    // unrecognized action is a safe no-op, matching `command`'s own
+    // explicit-whitelist switch above rather than guessing at what "start" means.
+    let options;
+    switch (args?.action) {
+      case "start":
+        options = {};
+        break;
+      case "next":
+        options = { forward: true, findNext: true };
+        break;
+      case "previous":
+        options = { forward: false, findNext: true };
+        break;
+      default:
+        return;
+    }
+    wc.findInPage(text, options);
   });
 
   /**

--- a/desktop/src/preload.js
+++ b/desktop/src/preload.js
@@ -288,6 +288,13 @@ contextBridge.exposeInMainWorld("veldDesktop", {
     onOpenRequest: (fn) => on("veld:browser:open-request", fn),
     /** An app accelerator a focused view would otherwise have swallowed. */
     onAccelerator: (fn) => on("veld:browser:accelerator", fn),
+    /** Find-in-page. "start" begins a fresh search, "next"/"previous" step
+     *  through the same one, "stop" clears the highlights. Always the live page,
+     *  never whatever still is currently painted over a suspended view. */
+    find: (viewId, action, text) =>
+      ipcRenderer.invoke("veld:browser:find", { viewId, action, text }),
+    /** Match count and which one is active, pushed after every `find` call. */
+    onFindResult: (fn) => on("veld:browser:find-result", fn),
 
     /** The selected worktree's `ide.permissions`, plus the origins veld serves for
      *  its run — the policy every pane in this window is answered against. Pushed


### PR DESCRIPTION
## Summary

Adds an in-browser "find in page" feature to Veld Desktop's embedded browser panes.

- **Ctrl/⌘+F** (while a pane's native view has focus) or the new magnifier **toolbar button** opens a find bar between the address bar and the page.
- The bar searches the pane's real, live `WebContents` via Electron's `findInPage`/`stopFindInPage`/`found-in-page` — never whatever frozen still is currently painted over a suspended/backgrounded view (the browser pane already suspends the native view and shows a captured still when it's not the active one; search always targets the live page underneath).
- Shows a match count ("2 of 5" / "No results"), next/previous chevrons, Enter/Shift+Enter to step, Escape or the × to close.
- The bar is an **in-flow row**, not an overlay — same trick the pre-existing permission-prompt row already uses, since a native `WebContentsView` paints over DOM regardless of z-index. It shrinks the pane's slot instead of covering it, reusing the existing `ResizeObserver` → geometry-sync → `setBounds` pipeline with no new plumbing for the resize itself.

## Root cause / design

The maintainer's brief specifically called out that the browser pane's content is a native, possibly-suspended view, and asked for a bar that resizes the content rather than overlaying it. The existing permission-prompt row already established that exact in-flow-row pattern for the same structural reason, so this reuses it rather than inventing a new mechanism.

## Rejected alternative

Considered (and rejected) letting the find feature degrade to a partial in-page JS implementation under the non-Electron `<iframe>` backend. A cross-origin iframe can't be searched programmatically (`contentWindow` throws), so the feature is Electron-only — consistent with every other pane feature that needs the native view (device emulation, sessions, DevTools).

## Version-skew handling

Veld Desktop's app shell and its `/ide` bundle update independently. A new `findSupported` check (`typeof desktop?.find === "function"`) gates the button/bar/shortcut on the bridge actually having `find`, not just on "Electron vs iframe" — an older shell would otherwise render an open, typeable bar that silently does nothing.

## Review

Ran the repo's autonomous multi-angle review loop at **light** depth. Two spawned named background agents never returned usable output (only idle pings) — their angles (counterfactual, missing-corners) were covered manually instead, including independently verifying Electron's confusingly-documented `findNext` semantics against the official docs and two real production find-in-page libraries. Angles 2 (persona) and 3 (assumptions) ran cleanly and surfaced 8 real findings, 7 fixed in this PR:

- 🟠 the bar's auto-close-on-navigation was keyed on a field that also updates on SPA `pushState`/hash changes — rekeyed on a real-navigation signal (`did-start-loading`'s rising edge).
- 🟡 unmounting (tab switch) didn't stop an open search, leaving live highlights on the page with no bar left to clear them.
- 🟡 `found-in-page` streams multiple replies per request; forwarding only Chromium's `finalUpdate` reply (matching a real production library's approach) avoids a transient "No results" flash.
- 🟡 the `Ctrl/⌘+F` interception didn't exclude Alt (`Ctrl+Alt+F`/Windows AltGr+F was swallowed).
- 🟡 the `findSupported` version-skew gate above.
- Plus a couple of maintainability fixes (one shared `findInPage` options object instead of an odd-one-out bare call; explicit action whitelist instead of a silent fallback).

A fix-delta round then re-verified all 8 fixes and caught a real regression in one of my own fixes (clearing the match count on every keystroke flashed a false "No results" on pages that do have matches) — fixed with a `findPending` state that distinguishes "waiting for the reply" from "confirmed zero matches."

**Deferred, both with reason:**
- A window-level `Ctrl/⌘+F` fallback for when no pane's native view has OS focus (e.g. cursor left in the address bar) — real gap, but routing a global keydown to "the active browser pane" needs the dock's tab-selection model, which is bigger than this diff.
- `requestId`-based staleness filtering for an out-of-order `found-in-page` reply — a narrow, self-correcting race once the `finalUpdate`-only forwarding and `findPending` fixes landed; not worth the extra IPC-response plumbing at this point.

## Docs

No config fields, CLI flags, or schema changes — the documentation checklist doesn't apply. Checked whether this belongs on the marketing website: it doesn't describe pane-level features at all today (no mention of device emulation, sessions, or permissions either), so I didn't add it there.

Added one promotions entry (`crates/veld-daemon/ui/src/promotions/content.ts`) — a previously-dead `Ctrl/⌘+F` inside a browser pane now works, which fits the bar for "alters how someone works and they wouldn't otherwise find."

## Test plan

- [x] `npm run typecheck` / `npm run lint` / `npm test` green in `crates/veld-daemon/ui` (855/855 tests)
- [x] `npm run lint` / `npm test` green in `desktop` (113/113 tests)
- [x] Hands-on checkpoint: maintainer drove the feature in the running dev stack before the review loop — magnifier button, `Ctrl/⌘+F`, live match count, resize-not-overlay, next/prev, close-on-navigate, and no interference with the existing `⌘⇧P` command palette.