### PR TITLE
feat(ui): use tabler bell/bell-off icons for focus mode

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -200,6 +200,14 @@ Three rules that make it worth the spend rather than theatre:
   before hand-rolling DOM+CSS for anything the library already provides; check
   [mantine.dev/llms.txt](https://mantine.dev/llms.txt) when unsure whether one
   exists).
+- **Never pick a Tabler icon glyph unilaterally.** Icon choice is a taste call,
+  not a mechanical one — propose 2-4 candidate icon names per state (checked
+  against imports already in the touched file, so a duplicate isn't reinvented),
+  ask the maintainer via `AskUserQuestion`, and print the literal URL
+  `https://tabler.io/icons` as plain text so they can browse and click it
+  themselves — never `WebFetch` it or auto-open it. This applies to a new icon
+  and to swapping an existing one; it does not apply to reusing an icon the
+  maintainer already picked elsewhere in the same feature.
 - Build, then `rustup update stable` (CI uses floating stable — drift blocks it),
   `cargo clippy --workspace --all-targets`, `cargo fmt --all`, and run the tests
   as you go. For a JS/TS change, run the Biome `lint` + `typecheck`/`test` in the
@@ -276,6 +284,17 @@ The check: if the sentence would still read as true to somebody who will never
 use the feature, it is describing the product instead of their day. Rewrite it
 starting from *you*. Never open with "Veld now…", a feature name, or a list of
 the states and options — that is documentation, and the docs already have it.
+
+**Outcome-framed is not the same as dramatic.** "Stop hunting a page by eye for
+one word" shipped as a real headline (find-in-page, 2026-08-13) and is the
+failure mode to avoid even though it followed the *you*-first rule above: it
+reaches for a mini-narrative (a struggle, then relief) where a plain statement
+of the capability would have read better and taken less of the reader's
+attention — the resource this whole feature spends exactly once. Prefer the
+flattest true sentence that still starts from the reader: "Search available for
+embedded browsers," not an imagined moment of frustration it solves. If a
+headline needs a beat of scene-setting to land, cut the scene and keep the
+capability.
 
 If Step 1 classified the change as **customization** (or it includes a
 customization-shaped request), add a row to the extension backlog in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -395,6 +395,16 @@ run, while a plain terminal in the same app works perfectly.
   component/hook/guide page as a fetchable Markdown file
   (`https://mantine.dev/llms/core-tooltip.md`, `-button`, `-menu`, …) — before
   reaching for raw HTML/CSS.
+- **Never pick a Tabler icon glyph without asking the human.** Icon choice reads
+  as a small implementation detail but is a taste/semantic call — the wrong glyph
+  (or the same glyph reused for two states) ships quietly and nobody notices until
+  a user squints at the toolbar. `IconFocus2` used unchanged for both focus-mode
+  on *and* off was one such case: technically fine, visually indistinguishable.
+  Before adding or changing an icon: propose 2-4 candidate Tabler names per state
+  (checked against what's already imported in the touched file so a near-duplicate
+  isn't reinvented), ask via `AskUserQuestion`, and print the browse-and-search URL
+  **https://tabler.io/icons** as plain text so the human can click it themselves —
+  never fetch or auto-open it.
 - **Never let a dev build touch the production database — and use the dev-DB
   recipes.** The installed veld's state lives in one file per user
   (`<data_dir>/veld/veld.db`). A binary that opens it and applies a migration makes

--- a/crates/veld-daemon/ui/src/App.tsx
+++ b/crates/veld-daemon/ui/src/App.tsx
@@ -104,11 +104,12 @@ import {
   IconAlertTriangleFilled,
   IconArrowBackUp,
   IconArrowsExchange,
+  IconBell,
+  IconBellOff,
   IconChevronLeft,
   IconChevronRight,
   IconDots,
   IconDotsVertical,
-  IconFocus2,
   IconFolderPlus,
   IconHistory,
   IconMoon,
@@ -3996,7 +3997,7 @@ function AppInner(props: {
         aria-pressed={focus.enabled}
         onClick={() => void saveSettings({ "focus.enabled": !focus.enabled })}
       >
-        <IconFocus2 size={14} />
+        {focus.enabled ? <IconBellOff size={14} /> : <IconBell size={14} />}
       </ActionIcon>
     </Tooltip>
   );

--- a/crates/veld-daemon/ui/src/promotions/content.ts
+++ b/crates/veld-daemon/ui/src/promotions/content.ts
@@ -108,8 +108,8 @@ export const PROMOTIONS: Promotion[] = [
     id: "browser-find-in-page",
     since: "2026-08-13",
     eyebrow: "New",
-    headline: "Stop hunting a page by eye for one word",
-    body: "A browser pane now searches its own live page: type to search, see how many matches turned up, and step between them with Enter or the arrows.",
+    headline: "Search available for embedded browsers",
+    body: "Find text on the page you're viewing without leaving Veld — see the match count and step through hits with Enter or the arrows.",
     glyph: "panes",
   },
   {

--- a/docs/promotions.md
+++ b/docs/promotions.md
@@ -76,6 +76,17 @@ Three habits that produce the wrong version:
 - **Listing the states, options, or fields.** Four enumerated glyph meanings is
   documentation. One sentence about walking away is news.
 
+**Outcome-framed is not the same as dramatic.** "Stop hunting a page by eye for
+one word" shipped as a real headline (find-in-page, 2026-08-13) and followed the
+*you*-first rule above, and it is still the wrong version: it spends the
+reader's attention on a mini-narrative — a small struggle, then relief — where a
+flat statement of the capability reads faster and costs less of the one-time
+budget this channel has. Prefer the plainest true sentence that still starts
+from the reader over one that reaches for a moment of frustration to resolve:
+"Search available for embedded browsers," not an imagined struggle it solves. If
+a headline needs a beat of scene-setting to land, cut the scene and keep the
+capability.
+
 ## One kind: a change, with the day it happened
 
 ```ts


### PR DESCRIPTION
## Summary
- Focus mode's toolbar toggle reused `IconFocus2` for both the on and off state, so the glyph never actually changed — only color/variant did. Swapped to Tabler's `IconBell` (off) / `IconBellOff` (on), matching what the feature actually does (silence notifications).
- Toned down the find-in-page promotion card copy — "Stop hunting a page by eye for one word" was overwrought for a one-time interrupt; replaced with a plain "Search available for embedded browsers" / one-sentence outcome.
- Harness update: added guidance to `AGENTS.md`, `.claude/skills/ship/SKILL.md`, and `docs/promotions.md` so that:
  - icon choices always go through the maintainer — propose 2-4 candidate Tabler names, ask via `AskUserQuestion`, and print `https://tabler.io/icons` as a plain (non-fetched, non-auto-opened) URL so they can browse it themselves.
  - promotion copy stays outcome-framed *without* reaching for a mini-narrative/dramatic framing, using the find-in-page headline as the documented counter-example.

## Test plan
- [x] `npm run typecheck` in `crates/veld-daemon/ui` — clean
- [x] `npx vitest run src/promotions/model.test.ts` — 60 passed (headline/body still within `MAX_HEADLINE`/`MAX_BODY` caps)
- [x] Confirmed no remaining `IconFocus2` references
- [x] Diff scoped to touched files is clean under Biome (repo-wide lint has ~6600 pre-existing warnings unrelated to this change)
- Review depth: super-light (maintainer-selected) — self-reviewed the diff directly, no multi-angle loop.
- Merge policy: bypass-merge on green CI (maintainer-selected).