### PR TITLE
fix(ui): stop extension badge text hard-cropping mid-word

### DIFF
--- a/crates/veld-daemon/ui/src/styles.css
+++ b/crates/veld-daemon/ui/src/styles.css
@@ -364,11 +364,15 @@ body[data-fullscreen="true"] .topbar.electron {
    no `overflow`, so without a width bound the badge either collapses its
    shrinkable siblings or pushes the row past the window. Excluded from an
    icon-only badge, which has no long text to clip and wants to be square rather
-   than however wide 22ch of nothing renders as. */
-.topbar .ext-badge:not(.ext-badge-icon) {
-  max-width: 22ch;
-}
+   than however wide 30ch of nothing renders as.
+ *
+ * The bound lives on the label span, not the button: putting it on the button
+   capped the whole box — icon, gap and text together — so the text was clipped
+   by the button's overflow before its own ellipsis ever ran, cutting a word in
+   half with no `…`. On the label the icon and gap render at full size and only
+   the text shrinks, so the ellipsis that already existed here actually shows. */
 .topbar .ext-badge:not(.ext-badge-icon) .mantine-Button-label {
+  max-width: 30ch;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
## What

Extension badges in the topbar (PR status, CI checks, etc.) were showing text hard-cropped mid-word with no ellipsis — e.g. "PR #300 · checks runn".

## Root cause

`max-width: 22ch` was applied to the whole `.ext-badge` button (icon + gap + text together), while the ellipsis machinery (`overflow:hidden; text-overflow:ellipsis; white-space:nowrap; min-width:0`) lived on the inner `.mantine-Button-label` span. The button's own box constrained total width before the label's ellipsis ever got a clean shrink target, so text was clipped by the button's overflow rather than eliding gracefully.

## Fix

Moved the `max-width` bound off the button and onto `.mantine-Button-label` itself, merging it into the existing ellipsis rule. Icon + gap now render full-size; only the text shrinks and its `…` shows correctly. Bumped the bound from 22ch to 30ch per visual testing (icon-only badges remain unaffected via the existing `:not(.ext-badge-icon)` exclusion).

## Test evidence

- Hand-verified in a running `veld` dev environment: badge with a long PR/CI label now truncates with a visible ellipsis instead of a mid-word crop.
- `just build-ui` clean.
- Reviewed by a read-only subagent for correctness (moving the constraint to the label, no other `.ext-badge`/button-level width rule left behind, no icon/label overlap risk) — no findings.

## Scope

Single file, single CSS rule move: `crates/veld-daemon/ui/src/styles.css`. No config/flag/behavior surface change, so no docs checklist items apply.