### PR TITLE
fix(ui): don't flag the in-flight worktree as a name collision

### DIFF
--- a/crates/veld-daemon/ui/src/components/dialogs.tsx
+++ b/crates/veld-daemon/ui/src/components/dialogs.tsx
@@ -28,6 +28,7 @@ import {
   deriveAlias,
   deriveBranch,
   deriveDisplayName,
+  takenExcluding,
 } from "../shared/worktreeName";
 import { randomMarker } from "../shared/markerPick";
 
@@ -273,33 +274,58 @@ export function NewWorktreeDialog(props: {
   const displayName = deriveDisplayName(name);
   const derivedBranch = deriveBranch(name);
   const branch = branchEdit ?? derivedBranch;
-  const collides = aliasCollides(alias, props.takenAliases);
+  /** The alias this dialog has submitted and is waiting on. While a create is
+   *  in flight the 5s `refresh()` poll can already surface the checkout it is
+   *  creating (the daemon registers the row before its response returns), so
+   *  `takenAliases` starts containing exactly the alias being made and the
+   *  courtesy check below lights up against the dialog's *own* creation — a
+   *  slow `git fetch origin` make that a seconds-long, confusing red error on
+   *  a create that then finishes fine. Set at submit, cleared only when the
+   *  create *fails* (the dialog stays open; a poll may then legitimately show
+   *  a sibling that really does collide). On success the dialog closes, so it
+   *  staying set across the reorder/refresh that follow is exactly the window
+   *  it exists to silence. */
+  const [pendingAlias, setPendingAlias] = useState<string | null>(null);
+  const taken = takenExcluding(props.takenAliases, pendingAlias);
+  const collides = aliasCollides(alias, taken);
   // An existing branch is named exactly, not slugged: `deriveBranch` would happily
   // turn `feature/JIRA-12` into `feature/jira-12`, which is a different ref and would
   // fail `git worktree add` with a confusing "invalid reference".
   const branchRequired = !createBranch;
   const ready = alias !== "" && branch !== "" && !collides;
 
-  const { busy, error, submit } = useSubmit(() =>
-    props.onCreate({
-      branch,
-      create_branch: createBranch,
-      // Always explicit, never left to the daemon's branch-derived default: the name
-      // is the primary field, so a checkout must end up called what the dialog said
-      // it would be. It also means a collision is a 409 that created nothing rather
-      // than a silent `-2` suffix.
-      alias,
-      // What the rail will show. Sent even when it happens to equal the alias:
-      // "the name is what you typed" is one rule, and a dialog that silently
-      // stops storing it once you type something already slug-shaped is two.
-      display_name: displayName,
-      // Always sent when a list resolved, so the checkout wears what the dialog
-      // showed. Empty only while the fetch is in flight, where the daemon's own
-      // assignment is the honest fallback.
-      emoji: chosen.emoji || undefined,
-      marker_color: chosen.color || undefined,
-    }),
-  );
+  const { busy, error, submit } = useSubmit(() => {
+    // Captured at submit, before the daemon's response: this is the alias the
+    // in-flight create is about to make, and it must not read as a collision
+    // when the poll catches up with the daemon mid-request.
+    setPendingAlias(alias);
+    return props
+      .onCreate({
+        branch,
+        create_branch: createBranch,
+        // Always explicit, never left to the daemon's branch-derived default: the name
+        // is the primary field, so a checkout must end up called what the dialog said
+        // it would be. It also means a collision is a 409 that created nothing rather
+        // than a silent `-2` suffix.
+        alias,
+        // What the rail will show. Sent even when it happens to equal the alias:
+        // "the name is what you typed" is one rule, and a dialog that silently
+        // stops storing it once you type something already slug-shaped is two.
+        display_name: displayName,
+        // Always sent when a list resolved, so the checkout wears what the dialog
+        // showed. Empty only while the fetch is in flight, where the daemon's own
+        // assignment is the honest fallback.
+        emoji: chosen.emoji || undefined,
+        marker_color: chosen.color || undefined,
+      })
+      .catch((e) => {
+        // The create is no longer in flight. The dialog stays open on failure,
+        // so the courtesy check must be truthful again: if the daemon's own
+        // refresh now lists a sibling, that is a real collision worth saying.
+        setPendingAlias(null);
+        throw e;
+      });
+  });
 
   return (
     <Modal title="New worktree" onClose={props.onClose}>

--- a/crates/veld-daemon/ui/src/shared/worktreeName.test.ts
+++ b/crates/veld-daemon/ui/src/shared/worktreeName.test.ts
@@ -7,6 +7,7 @@ import {
   deriveAlias,
   deriveBranch,
   deriveDisplayName,
+  takenExcluding,
   worktreeLabel,
 } from "./worktreeName";
 
@@ -198,5 +199,21 @@ describe("aliasCollides", () => {
     // Empty means "nothing to create"; reporting a collision on top of that would
     // put a confusing error under an empty field.
     expect(aliasCollides("", ["", "main"])).toBe(false);
+  });
+});
+
+describe("takenExcluding", () => {
+  it("is a no-op without a pending alias", () => {
+    const taken = ["main", "chk"];
+    expect(takenExcluding(taken, null)).toBe(taken);
+  });
+
+  it("drops only the pending alias, slug-compared", () => {
+    // `main_2` and `main-2` are one name to the router, so a pending `main-2`
+    // silences the sibling `main_2` the dialog's own create is about to make.
+    expect(takenExcluding(["main", "main_2"], "main-2")).toEqual(["main"]);
+    // A pending alias never masks an unrelated, real collision.
+    expect(takenExcluding(["main", "chk"], "main")).toEqual(["chk"]);
+    expect(takenExcluding(["main", "chk"], "")).toEqual(["main", "chk"]);
   });
 });

--- a/crates/veld-daemon/ui/src/shared/worktreeName.ts
+++ b/crates/veld-daemon/ui/src/shared/worktreeName.ts
@@ -238,3 +238,19 @@ export function aliasCollides(alias: string, taken: string[]): boolean {
   if (slug === "") return false;
   return taken.some((t) => storedSlug(t) === slug);
 }
+
+/**
+ * `taken` with `pending` removed (slug-compared) — the aliases that are truly
+ * taken *now*, ignoring one the caller is itself in the middle of creating.
+ *
+ * The New worktree dialog relies on this: while its create request is in flight,
+ * the 5s poll can already surface the checkout the daemon is registering, so
+ * `taken` starts containing exactly the alias being made and the courtesy check
+ * would light up against the dialog's *own* creation. `pending` is the alias
+ * submitted, and it is the only alias that may be mid-flight — the dialog is the
+ * sole creator, and a concurrent create from elsewhere is still a real collision.
+ */
+export function takenExcluding(taken: string[], pending: string | null): string[] {
+  if (!pending) return taken;
+  return taken.filter((t) => !aliasCollides(pending, [t]));
+}


### PR DESCRIPTION
## What

The New worktree dialog's courtesy collision check started lighting up against its **own** pending creation.

While a create request is in flight, the 5s `refresh()` poll can already surface the checkout the daemon is registering (the row is written to the DB before the HTTP response returns). On a slow create — typically a `git fetch origin` — `takenAliases` briefly includes exactly the alias being made, so the dialog showed `This repo already has a checkout with that name` on a create that then finished fine.

## Fix

Track the submitted alias and exclude it (slug-compared, via a new `takenExcluding` helper beside `aliasCollides`) from the collision check while the create is in flight. It is cleared **only on failure** — the dialog stays open on failure, where a poll may legitimately show a real sibling; on success the dialog closes, so keeping it set across the reorder/refresh that follow is exactly the window it exists to silence.

## Tests

Added `takenExcluding` unit tests. `just test-ui` + `just lint-ui` green locally.