### PR TITLE
fix(update): don't run GitHub's error page as the install script

### DIFF
--- a/crates/veld-core/src/setup.rs
+++ b/crates/veld-core/src/setup.rs
@@ -1573,19 +1573,56 @@ pub async fn check_update() -> Result<Option<String>, anyhow::Error> {
         .context("failed to build HTTP client")?;
 
     let url = format!("https://api.github.com/repos/{GITHUB_REPO}/releases/latest");
-    let resp = client
-        .get(&url)
-        .header("Accept", "application/vnd.github+json")
-        .send()
-        .await
-        .context("failed to fetch latest release from GitHub")?;
 
-    if !resp.status().is_success() {
+    // Retried on the same terms as the install script download, and for the same
+    // reason rather than for symmetry: this is the *first* GitHub call `veld update`
+    // makes, and on the app-driven path Veld Desktop has already quit by the time it
+    // runs — so a single transient 503 here ends the update with the user's app
+    // closed and nothing installed. The download's retry would never be reached.
+    //
+    // Silent, unlike the download's: the other caller is the passive "a newer
+    // version is available" nudge in `main.rs`, which runs on ordinary commands
+    // under a 5s `tokio::time::timeout`. Narrating a retry there would put two
+    // lines of GitHub weather on every `veld` invocation during an outage. That
+    // timeout also means the nudge simply gives up mid-retry, which is the right
+    // outcome for a best-effort check and the reason the extra attempts cost it
+    // nothing — but the two are now coupled, so do not shorten either alone.
+    let mut attempt = 0u32;
+    let resp = loop {
+        attempt += 1;
+        let last = attempt >= INSTALL_SCRIPT_ATTEMPTS;
+
+        let resp = match client
+            .get(&url)
+            .header("Accept", "application/vnd.github+json")
+            .send()
+            .await
+        {
+            Ok(resp) => resp,
+            Err(_) if !last => {
+                tokio::time::sleep(INSTALL_SCRIPT_RETRY_DELAY).await;
+                continue;
+            }
+            Err(e) => {
+                return Err(
+                    anyhow::Error::new(e).context("failed to fetch latest release from GitHub")
+                );
+            }
+        };
+
+        let status = resp.status();
+        if status.is_success() {
+            break resp;
+        }
+        if is_transient_status(status) && !last {
+            tokio::time::sleep(INSTALL_SCRIPT_RETRY_DELAY).await;
+            continue;
+        }
         anyhow::bail!(
-            "GitHub API returned status {} when checking for updates",
-            resp.status()
+            "GitHub API returned status {status} when checking for updates{}",
+            github_outage_hint(status, resp.headers())
         );
-    }
+    };
 
     let body: serde_json::Value = resp
         .json()
@@ -1759,10 +1796,253 @@ fn install_script_override_from(raw: Option<std::ffi::OsString>) -> Option<PathB
     (path.is_absolute() && path.is_file()).then_some(path)
 }
 
+/// The install script could not be fetched, so **nothing ran**.
+///
+/// A distinct type rather than a plain `anyhow!`, for one reason: the caller
+/// follows a failed update with "re-run with `veld update --verbose` to see the
+/// installer's own output", and on this path there is no installer output to see.
+/// A hint that points at a log that does not exist costs the reader the one
+/// minute they had to spend on the real cause. `is_install_script_unavailable`
+/// is how the caller asks.
+///
+/// The message is pre-formatted, not composed from parts, because the surfacing
+/// site prints with `{e}` and the wording differs per failure — a status, a
+/// transport error, a body that was not a script.
+#[derive(Debug)]
+pub struct InstallScriptUnavailable(String);
+
+impl std::fmt::Display for InstallScriptUnavailable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for InstallScriptUnavailable {}
+
+/// Did this failure happen *before* the install script ran?
+///
+/// Checks the whole chain, so a caller that adds its own context on the way up
+/// does not hide the answer.
+pub fn is_install_script_unavailable(e: &anyhow::Error) -> bool {
+    e.chain().any(|c| c.is::<InstallScriptUnavailable>())
+}
+
+/// A "this is probably not you" hint for a status that means the far end is
+/// rate-limiting or broken, ready to append to an error message.
+///
+/// Every network fetch an update makes — the release lookup and the install
+/// script — ends at GitHub, so a GitHub incident arrives here as a bare HTTP
+/// status with no explanation attached. The first thing anyone does with an
+/// unexplained `429` is go looking for what they broke locally; naming the
+/// status page spends one line to save that.
+///
+/// Returns `""` rather than an `Option` so a call site can interpolate it
+/// unconditionally.
+///
+/// Takes the headers, not just the status, for one reason: GitHub's REST API
+/// answers an exhausted **unauthenticated** rate limit — 60 requests an hour, and
+/// `veld update` spends one on every run — with `403 Forbidden` as readily as with
+/// `429`, distinguished only by `x-ratelimit-remaining: 0`. On status alone that
+/// case reads as "Forbidden" with no explanation, which is the most misleading
+/// answer of the set: it invites the reader to go looking for a permission problem
+/// that does not exist.
+fn github_outage_hint(
+    status: reqwest::StatusCode,
+    headers: &reqwest::header::HeaderMap,
+) -> &'static str {
+    const RATE_LIMITED: &str = " — GitHub is rate-limiting this network, or is degraded; check \
+                                https://www.githubstatus.com/ and try again in a few minutes";
+
+    let exhausted = headers
+        .get("x-ratelimit-remaining")
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.trim() == "0");
+
+    if status == reqwest::StatusCode::TOO_MANY_REQUESTS
+        || (status == reqwest::StatusCode::FORBIDDEN && exhausted)
+    {
+        RATE_LIMITED
+    } else if status.is_server_error() {
+        " — GitHub is failing requests; check https://www.githubstatus.com/ and \
+         try again in a few minutes"
+    } else {
+        ""
+    }
+}
+
+/// Statuses worth trying again, matching the set `curl --retry` treats as
+/// transient (408, 429, 5xx) — the same judgement `install.sh` gets from that
+/// flag, made here for the one download that does not go through curl.
+fn is_transient_status(status: reqwest::StatusCode) -> bool {
+    status == reqwest::StatusCode::TOO_MANY_REQUESTS
+        || status == reqwest::StatusCode::REQUEST_TIMEOUT
+        || status.is_server_error()
+}
+
+/// How many times a transient failure downloading the install script is tried,
+/// and how long between tries.
+///
+/// Three attempts two seconds apart, not an exponential climb into the minutes:
+/// somebody is watching a progress line while this runs, and an incident that
+/// outlasts a short backoff is not one a longer backoff would have survived
+/// either. The retry is here for the single-request blip; the error message is
+/// what handles the rest.
+///
+/// A server-sent `Retry-After` is deliberately **ignored**, which is the one place
+/// this half and `install.sh`'s `curl --retry` differ on purpose. curl prefers that
+/// header to its own `--retry-delay` and does not cap it, so a rate-limiting CDN
+/// answering `Retry-After: 600` can stall an install for half an hour — which is
+/// why the flags there carry `--retry-max-time`. A flat delay has no such header to
+/// obey, so there is nothing to cap.
+const INSTALL_SCRIPT_ATTEMPTS: u32 = 3;
+const INSTALL_SCRIPT_RETRY_DELAY: Duration = Duration::from_secs(2);
+
+/// Does this look like `install.sh` rather than something a proxy, a CDN or a
+/// captive portal wrote?
+///
+/// **Why a guard on the body at all**, given the status check in
+/// `download_install_script`: this text is handed to `bash -c`, so anything that
+/// reaches it *runs*. The failure that motivated both halves was a real 429 from
+/// `raw.githubusercontent.com` during a GitHub incident — two lines of prose,
+/// executed, producing `429:: command not found`, a syntax error on the
+/// parenthesis in GitHub's terms-of-service URL, and a final report of "install
+/// script exited with code 2". The status check catches that one. This catches
+/// the case a status code cannot: an interception layer that serves its own page
+/// with `200 OK`.
+///
+/// Deliberately weak — a shebang, and the one variable every caller of this
+/// script sets — because a tight fingerprint would be a second contract to keep
+/// in step with a file published from `main` that this crate cannot see.
+///
+/// `the_repo_install_script_passes_the_shape_gate` pins it against this checkout's
+/// script, and **that guarantee runs one way only.** This predicate ships inside
+/// released binaries; the script is fetched from `main`. So a commit that renames
+/// `VELD_VERSION` in `install.sh` *and* updates this predicate together is green in
+/// CI and breaks `veld update` for every CLI already installed, which is reading
+/// the new script with the old predicate. Nothing can catch that from here — the
+/// only safe move is to treat the marker as a published contract and not rename it.
+fn looks_like_install_script(body: &str) -> bool {
+    body.starts_with("#!") && body.contains("VELD_VERSION")
+}
+
+/// Fetch the install script, retrying transient failures, and refuse to return
+/// anything that is not a shell script.
+///
+/// The caller runs what this returns, so every early exit here is a `bail!`: an
+/// error the user reads is always better than a body `bash` interprets.
+async fn download_install_script(
+    client: &reqwest::Client,
+    url: &str,
+) -> Result<String, anyhow::Error> {
+    let mut attempt = 0u32;
+    loop {
+        attempt += 1;
+        // Computed before the request, so a config of one attempt takes the
+        // give-up branch rather than looping: the retry paths below are only
+        // reachable while another attempt is actually left.
+        let last = attempt >= INSTALL_SCRIPT_ATTEMPTS;
+
+        let retry = |reason: String| async move {
+            eprintln!(
+                "  {reason}; retrying in {}s ({}/{INSTALL_SCRIPT_ATTEMPTS})",
+                INSTALL_SCRIPT_RETRY_DELAY.as_secs(),
+                attempt + 1
+            );
+            tokio::time::sleep(INSTALL_SCRIPT_RETRY_DELAY).await;
+        };
+
+        // A transport failure (DNS, TLS, connect, timeout) is retried on the same
+        // terms as a transient status. During an incident both happen, and which
+        // one a given request gets is luck.
+        let resp = match client.get(url).send().await {
+            Ok(resp) => resp,
+            Err(e) if !last => {
+                retry(format!("Could not reach {url} ({e})")).await;
+                continue;
+            }
+            // The transport error is interpolated rather than attached as a
+            // `context`, because the one place this is printed formats with `{e}`
+            // and would drop a cause chain — "failed to download" without the
+            // "why" is the message this whole change exists to stop shipping.
+            Err(e) => {
+                return Err(InstallScriptUnavailable(format!(
+                    "failed to download the install script from {url}: {e}"
+                ))
+                .into());
+            }
+        };
+
+        let status = resp.status();
+        if !status.is_success() {
+            if is_transient_status(status) && !last {
+                retry(format!("{url} returned HTTP {}", status.as_u16())).await;
+                continue;
+            }
+            return Err(InstallScriptUnavailable(format!(
+                "failed to download the install script: {url} returned HTTP {status}{}",
+                github_outage_hint(status, resp.headers())
+            ))
+            .into());
+        }
+
+        // Retried on the same terms as the `send()` above, for the same reason: a
+        // connection reset part-way through the body, or the client timeout firing
+        // during the read, is the same transient transport failure — it just
+        // happens after the status line rather than before it. Treating only one of
+        // the two as transient would be a distinction the network does not make.
+        let body = match resp.text().await {
+            Ok(body) => body,
+            Err(e) if !last => {
+                retry(format!(
+                    "Could not read the install script from {url} ({e})"
+                ))
+                .await;
+                continue;
+            }
+            Err(e) => {
+                return Err(InstallScriptUnavailable(format!(
+                    "failed to read the install script from {url}: {e}"
+                ))
+                .into());
+            }
+        };
+
+        if !looks_like_install_script(&body) {
+            // The first line, not the length alone: on the failure this was
+            // written for it is literally `429: Too Many Requests`, which
+            // explains the whole thing in one glance.
+            let first: String = body
+                .lines()
+                .next()
+                .unwrap_or("")
+                .trim()
+                .chars()
+                .take(120)
+                .collect();
+            return Err(InstallScriptUnavailable(format!(
+                "{url} did not return the install script ({} bytes, starting {first:?})",
+                body.len()
+            ))
+            .into());
+        }
+
+        return Ok(body);
+    }
+}
+
 /// Download and run the install script with the given version pinned.
 ///
 /// `log`, when given, receives the script's stdout and stderr instead of this
 /// process's.
+///
+/// **What authenticates the script it runs: TLS, and nothing else.** There is no
+/// checksum, no signature, and no pinned commit on `veld.oss.life.li/get`, whose
+/// 302 is followed to whatever host it names — while the script this fetches does
+/// verify every release asset it goes on to download against `checksums.txt`. That
+/// asymmetry predates this function's current shape and is not narrowed by
+/// `looks_like_install_script`, which is a corruption check, not an authenticity
+/// one. Written down because the guard reads like more than it is, and the next
+/// person to add a check here should know which one is actually missing.
 async fn run_install_script(
     version: &str,
     extra_env: &[(String, String)],
@@ -1787,14 +2067,7 @@ async fn run_install_script(
                 .build()
                 .context("failed to build HTTP client")?;
 
-            client
-                .get(&install_url)
-                .send()
-                .await
-                .context("failed to download install script")?
-                .text()
-                .await
-                .context("failed to read install script")?
+            download_install_script(&client, &install_url).await?
         }
     };
 
@@ -2936,10 +3209,233 @@ mod tests {
     use std::time::Duration;
 
     use super::{
-        first_existing_file, init_lua_loads_veld_spoon, install_script_override_from,
-        linux_desktop_candidates, parse_launchctl_pid, parse_launchctl_program,
-        parse_systemd_exec_start, parse_systemd_main_pid, pids_running_from, remove_spoon_files,
+        download_install_script, first_existing_file, github_outage_hint,
+        init_lua_loads_veld_spoon, install_script_override_from, is_install_script_unavailable,
+        is_transient_status, linux_desktop_candidates, looks_like_install_script,
+        parse_launchctl_pid, parse_launchctl_program, parse_systemd_exec_start,
+        parse_systemd_main_pid, pids_running_from, remove_spoon_files,
     };
+
+    /// Byte-for-byte what `raw.githubusercontent.com` served during the GitHub
+    /// incident of 2026-08-17, which `veld update` handed to `bash -c`. The first
+    /// line became `429:: command not found`; the parenthesis on the second became
+    /// a syntax error; the user was told "install script exited with code 2".
+    const GITHUB_429_BODY: &str = "429: Too Many Requests\nFor more on scraping GitHub and how it \
+                                   may affect your rights, please review our Terms of Service \
+                                   (https://docs.github.com/en/site-policy/github-terms/github-terms-of-service).\n";
+
+    /// The published install script is what production runs, and
+    /// `looks_like_install_script` is the gate in front of it. If a refactor ever
+    /// renames `VELD_VERSION` or drops the shebang, the gate starts rejecting the
+    /// real thing and *every* `veld update` fails with "did not return the install
+    /// script" — a self-inflicted outage that no other test in this repo would
+    /// catch, because the CLI-side contract test checks the variables the script
+    /// *reads*, not the bytes this predicate looks at.
+    #[test]
+    fn the_repo_install_script_passes_the_shape_gate() {
+        assert!(looks_like_install_script(include_str!(
+            "../../../install.sh"
+        )));
+    }
+
+    /// The whole point: an error body is not a script, so it never reaches bash.
+    #[test]
+    fn an_error_body_is_not_mistaken_for_the_install_script() {
+        assert!(!looks_like_install_script(GITHUB_429_BODY));
+        // A `200 OK` page from a captive portal or a corporate proxy — the case a
+        // status check cannot see, which is why the gate exists as well as the check.
+        assert!(!looks_like_install_script(
+            "<!doctype html><title>Sign in to continue</title>"
+        ));
+        // A shell script that is not *this* shell script — and read the reason it
+        // fails, not the shape of it: the **only** thing asserted here is that the
+        // marker is absent. `"#!/bin/sh\nrm -rf / # VELD_VERSION\n"` passes the
+        // gate. That is not a hole being tolerated, it is what the gate is: an
+        // anti-corruption check on a body fetched over TLS, never an authenticity
+        // check. Nothing here authenticates the script — see the note on
+        // `run_install_script`.
+        assert!(!looks_like_install_script("#!/bin/sh\nrm -rf /\n"));
+        assert!(!looks_like_install_script(""));
+    }
+
+    /// The retry set, matching what `install.sh` gets from `curl --retry`. Asserted
+    /// because the two halves of the installer picking different transient sets is
+    /// exactly the kind of drift nobody notices until an incident.
+    #[test]
+    fn transient_statuses_match_curls_retry_set() {
+        for code in [408, 429, 500, 502, 503, 504] {
+            assert!(
+                is_transient_status(reqwest::StatusCode::from_u16(code).unwrap()),
+                "HTTP {code} should be retried"
+            );
+        }
+        for code in [400, 401, 403, 404, 410] {
+            assert!(
+                !is_transient_status(reqwest::StatusCode::from_u16(code).unwrap()),
+                "HTTP {code} should not be retried"
+            );
+        }
+    }
+
+    /// The hint is the difference between "I broke my machine" and "GitHub is
+    /// having a day", so it has to appear on the statuses an incident produces and
+    /// stay off the ones it does not.
+    #[test]
+    fn the_outage_hint_names_the_status_page_only_when_it_helps() {
+        let none = reqwest::header::HeaderMap::new();
+        for code in [429, 500, 502, 503] {
+            let hint = github_outage_hint(reqwest::StatusCode::from_u16(code).unwrap(), &none);
+            assert!(
+                hint.contains("githubstatus.com"),
+                "HTTP {code} should point at the status page, got {hint:?}"
+            );
+        }
+        // A plain 403 or 404 is an answer, not weather.
+        for code in [403, 404] {
+            assert!(
+                github_outage_hint(reqwest::StatusCode::from_u16(code).unwrap(), &none).is_empty(),
+                "HTTP {code} is not an outage"
+            );
+        }
+    }
+
+    /// GitHub spends an exhausted unauthenticated rate limit as `403`, not only as
+    /// `429`. Without the header check that lands as an unexplained "Forbidden",
+    /// which sends the reader hunting for a permission problem they do not have.
+    #[test]
+    fn an_exhausted_rate_limit_is_recognised_on_a_403() {
+        let mut exhausted = reqwest::header::HeaderMap::new();
+        exhausted.insert("x-ratelimit-remaining", "0".parse().unwrap());
+
+        assert!(
+            github_outage_hint(reqwest::StatusCode::FORBIDDEN, &exhausted)
+                .contains("githubstatus.com")
+        );
+
+        // …and a 403 with budget left is a genuine refusal, which must stay
+        // unexplained rather than be blamed on GitHub's weather.
+        let mut plenty = reqwest::header::HeaderMap::new();
+        plenty.insert("x-ratelimit-remaining", "57".parse().unwrap());
+        assert!(github_outage_hint(reqwest::StatusCode::FORBIDDEN, &plenty).is_empty());
+    }
+
+    /// Serve `responses` in order, one per connection, and return the address.
+    ///
+    /// A hand-rolled listener rather than a mock-HTTP dev-dependency: the assertion
+    /// needs a *transient* status followed by a good body, which is three lines of
+    /// canned bytes, and `veld-core` carries no dev-dependencies today.
+    async fn serve_in_order(responses: Vec<String>) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            for body in responses {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    return;
+                };
+                // Read the request line and headers so the client does not see a
+                // reset before it has finished writing.
+                let mut buf = [0u8; 4096];
+                let _ = tokio::io::AsyncReadExt::read(&mut stream, &mut buf).await;
+                let _ = tokio::io::AsyncWriteExt::write_all(&mut stream, body.as_bytes()).await;
+                let _ = tokio::io::AsyncWriteExt::shutdown(&mut stream).await;
+            }
+        });
+        format!("http://{addr}/get")
+    }
+
+    fn http_response(status: &str, body: &str) -> String {
+        format!(
+            "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        )
+    }
+
+    const FAKE_SCRIPT: &str = "#!/usr/bin/env bash\necho \"${VELD_VERSION:-}\"\n";
+
+    /// A 429 is reported, not returned — the regression this change is about.
+    ///
+    /// Re-introduce it by deleting the status check in `download_install_script`
+    /// and this test starts returning GitHub's prose as a script to run.
+    #[tokio::test]
+    async fn a_rate_limited_download_fails_instead_of_returning_prose() {
+        let url = serve_in_order(vec![
+            http_response("429 Too Many Requests", GITHUB_429_BODY),
+            http_response("429 Too Many Requests", GITHUB_429_BODY),
+            http_response("429 Too Many Requests", GITHUB_429_BODY),
+        ])
+        .await;
+        let client = reqwest::Client::builder().build().unwrap();
+
+        let err = download_install_script(&client, &url).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("429"), "{msg}");
+        assert!(msg.contains("githubstatus.com"), "{msg}");
+        // And the caller must be able to tell that nothing ran, so it does not
+        // send the reader to an installer log that was never written.
+        assert!(is_install_script_unavailable(&err));
+        assert!(is_install_script_unavailable(
+            &err.context("while updating veld")
+        ));
+    }
+
+    /// A `200 OK` body that is not a script is refused too, because the status is
+    /// not what makes it safe to run.
+    #[tokio::test]
+    async fn a_two_hundred_that_is_not_a_script_is_refused() {
+        let url = serve_in_order(vec![http_response(
+            "200 OK",
+            "<!doctype html><title>Wi-Fi login</title>",
+        )])
+        .await;
+        let client = reqwest::Client::builder().build().unwrap();
+
+        let err = download_install_script(&client, &url).await.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("did not return the install script"),
+            "{err}"
+        );
+        assert!(is_install_script_unavailable(&err));
+    }
+
+    /// The blip case the retry exists for: one transient failure, then the script.
+    #[tokio::test]
+    async fn a_transient_failure_is_retried_and_the_script_still_arrives() {
+        let url = serve_in_order(vec![
+            http_response("503 Service Unavailable", "upstream is sad"),
+            http_response("200 OK", FAKE_SCRIPT),
+        ])
+        .await;
+        let client = reqwest::Client::builder().build().unwrap();
+
+        let body = download_install_script(&client, &url).await.unwrap();
+        assert_eq!(body, FAKE_SCRIPT);
+    }
+
+    /// A permanent status is *not* retried — a 404 answers the question, and
+    /// re-asking it three times only makes the failure slower.
+    #[tokio::test]
+    async fn a_permanent_status_is_not_retried() {
+        // One response only: a second attempt would find the listener gone and
+        // fail with a transport error instead of the status, so the assertion on
+        // the message is also the assertion that no second attempt happened.
+        let url = serve_in_order(vec![http_response("404 Not Found", "nope")]).await;
+        let client = reqwest::Client::builder().build().unwrap();
+
+        let err = download_install_script(&client, &url).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("404"), "{msg}");
+        assert!(!msg.contains("githubstatus.com"), "{msg}");
+    }
+
+    /// An unrelated error must not read as "the script never ran", or the hint
+    /// disappears from the failures it was written for.
+    #[test]
+    fn an_unrelated_failure_is_not_an_unavailable_script() {
+        assert!(!is_install_script_unavailable(&anyhow::anyhow!(
+            "install script exited with code 1"
+        )));
+    }
 
     /// This user, in the fixture below.
     const ME: u32 = 501;

--- a/crates/veld-core/src/setup.rs
+++ b/crates/veld-core/src/setup.rs
@@ -3362,8 +3362,11 @@ mod tests {
     /// accepted by nobody and answered by nobody. Without this a regression would
     /// hang the suite instead of failing it.
     ///
-    /// These tests sleep the real `INSTALL_SCRIPT_RETRY_DELAY` — about 6s across the
-    /// three of them. `#[tokio::test(start_paused = true)]` would erase that, and is
+    /// Two of the four tests using this sleep the real `INSTALL_SCRIPT_RETRY_DELAY`
+    /// — 4s in `a_rate_limited_download_fails_instead_of_returning_prose` and 2s in
+    /// `a_transient_failure_is_retried_and_the_script_still_arrives`; the other two
+    /// return before any retry and cost nothing.
+    /// `#[tokio::test(start_paused = true)]` would erase those 6s, and is
     /// deliberately not used: paused time also drives reqwest's own timeout, so the
     /// guard above would fire the instant the client waited on a socket. A slow test
     /// that cannot hang beats a fast one that can.

--- a/crates/veld-core/src/setup.rs
+++ b/crates/veld-core/src/setup.rs
@@ -1574,55 +1574,38 @@ pub async fn check_update() -> Result<Option<String>, anyhow::Error> {
 
     let url = format!("https://api.github.com/repos/{GITHUB_REPO}/releases/latest");
 
-    // Retried on the same terms as the install script download, and for the same
-    // reason rather than for symmetry: this is the *first* GitHub call `veld update`
-    // makes, and on the app-driven path Veld Desktop has already quit by the time it
-    // runs — so a single transient 503 here ends the update with the user's app
-    // closed and nothing installed. The download's retry would never be reached.
+    // **One attempt, deliberately — do not add a retry here.** It was tried and
+    // reverted, because the caller that dominates this function is not the one it
+    // looks like. `maybe_show_update_banner` in `main.rs` calls it on every
+    // `veld start|stop|restart|status|stats|urls|action|logs`, and it stamps
+    // `KV_UPDATE_LAST_CHECK` only after a *successful* fetch — so during a GitHub
+    // outage the check is re-attempted on every one of those commands, including the
+    // `veld action` the IDE invokes. Three attempts two seconds apart measures ~4s,
+    // which slips *under* that call site's 5s timeout and therefore gets paid in
+    // full, every command, for the length of the outage. One request costs a round
+    // trip.
     //
-    // Silent, unlike the download's: the other caller is the passive "a newer
-    // version is available" nudge in `main.rs`, which runs on ordinary commands
-    // under a 5s `tokio::time::timeout`. Narrating a retry there would put two
-    // lines of GitHub weather on every `veld` invocation during an outage. That
-    // timeout also means the nudge simply gives up mid-retry, which is the right
-    // outcome for a best-effort check and the reason the extra attempts cost it
-    // nothing — but the two are now coupled, so do not shorten either alone.
-    let mut attempt = 0u32;
-    let resp = loop {
-        attempt += 1;
-        let last = attempt >= INSTALL_SCRIPT_ATTEMPTS;
+    // The other caller loses little: `veld update` with no version pinned, where a
+    // transient failure costs one re-run and now says so. And the case that would
+    // actually hurt — the Veld Desktop handoff, app already quit — never reaches
+    // here at all: the app always passes `--target-version`
+    // (`desktop/src/updatePolicy.js`) and `resolve_target` in `update.rs` skips this
+    // call whenever a target is given, to keep the window off a second rate-limited
+    // source. `download_install_script`'s retry is the one on that path.
+    let resp = client
+        .get(&url)
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+        .context("failed to fetch latest release from GitHub")?;
 
-        let resp = match client
-            .get(&url)
-            .header("Accept", "application/vnd.github+json")
-            .send()
-            .await
-        {
-            Ok(resp) => resp,
-            Err(_) if !last => {
-                tokio::time::sleep(INSTALL_SCRIPT_RETRY_DELAY).await;
-                continue;
-            }
-            Err(e) => {
-                return Err(
-                    anyhow::Error::new(e).context("failed to fetch latest release from GitHub")
-                );
-            }
-        };
-
-        let status = resp.status();
-        if status.is_success() {
-            break resp;
-        }
-        if is_transient_status(status) && !last {
-            tokio::time::sleep(INSTALL_SCRIPT_RETRY_DELAY).await;
-            continue;
-        }
+    if !resp.status().is_success() {
         anyhow::bail!(
-            "GitHub API returned status {status} when checking for updates{}",
-            github_outage_hint(status, resp.headers())
+            "GitHub API returned status {} when checking for updates{}",
+            resp.status(),
+            github_outage_hint(resp.status(), resp.headers())
         );
-    };
+    }
 
     let body: serde_json::Value = resp
         .json()
@@ -1870,9 +1853,15 @@ fn github_outage_hint(
     }
 }
 
-/// Statuses worth trying again, matching the set `curl --retry` treats as
-/// transient (408, 429, 5xx) — the same judgement `install.sh` gets from that
-/// flag, made here for the one download that does not go through curl.
+/// Statuses worth trying again: 408, 429, and **any** 5xx.
+///
+/// A deliberate superset of `curl --retry`'s set, which is the enumeration
+/// 500/502/503/504 rather than a range — measured on curl 8.7.1, a `501` and a
+/// Cloudflare `521` are both retried here and neither is retried by `install.sh`.
+/// Kept wider on purpose: this is the one download that does not go through curl,
+/// and a gateway in front of the CDN answering 52x is the same blip as a 503. The
+/// test below pins the divergence rather than the intersection, so nobody
+/// "restores parity" by narrowing it back.
 fn is_transient_status(status: reqwest::StatusCode) -> bool {
     status == reqwest::StatusCode::TOO_MANY_REQUESTS
         || status == reqwest::StatusCode::REQUEST_TIMEOUT
@@ -3206,10 +3195,12 @@ fn hang_up_terminal_holders(veld_dir: &Path) {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
     use super::{
-        download_install_script, first_existing_file, github_outage_hint,
+        INSTALL_SCRIPT_ATTEMPTS, download_install_script, first_existing_file, github_outage_hint,
         init_lua_loads_veld_spoon, install_script_override_from, is_install_script_unavailable,
         is_transient_status, linux_desktop_candidates, looks_like_install_script,
         parse_launchctl_pid, parse_launchctl_program, parse_systemd_exec_start,
@@ -3248,22 +3239,34 @@ mod tests {
             "<!doctype html><title>Sign in to continue</title>"
         ));
         // A shell script that is not *this* shell script — and read the reason it
-        // fails, not the shape of it: the **only** thing asserted here is that the
-        // marker is absent. `"#!/bin/sh\nrm -rf / # VELD_VERSION\n"` passes the
-        // gate. That is not a hole being tolerated, it is what the gate is: an
-        // anti-corruption check on a body fetched over TLS, never an authenticity
-        // check. Nothing here authenticates the script — see the note on
-        // `run_install_script`.
+        // fails, not the shape of it: the **only** thing rejected here is the absent
+        // marker.
         assert!(!looks_like_install_script("#!/bin/sh\nrm -rf /\n"));
+        // Which is why the exception is asserted next to it rather than described:
+        // add the marker as a comment and the same hostile script passes. That is
+        // not a hole being tolerated, it is what the gate *is* — an anti-corruption
+        // check on a body already fetched over TLS, never an authenticity check.
+        // Nothing here authenticates the script; see the note on
+        // `run_install_script` for what is actually missing. This assertion exists
+        // so nobody can read the line above as more than it is.
+        assert!(looks_like_install_script(
+            "#!/bin/sh\nrm -rf / # VELD_VERSION\n"
+        ));
         assert!(!looks_like_install_script(""));
     }
 
-    /// The retry set, matching what `install.sh` gets from `curl --retry`. Asserted
-    /// because the two halves of the installer picking different transient sets is
-    /// exactly the kind of drift nobody notices until an incident.
+    /// The retry set. Asserted because the two halves of the installer picking
+    /// different transient sets is exactly the kind of drift nobody notices until an
+    /// incident — and because the divergence that *is* intended has to be written
+    /// down somewhere a change would trip over.
+    ///
+    /// 501 and 521 are the intended divergence: `curl --retry` takes an enumeration
+    /// (500/502/503/504), this takes the whole 5xx range, so those two are retried
+    /// here and not by `install.sh`. Verified against curl 8.7.1, which gave up on
+    /// both in 0.02s.
     #[test]
-    fn transient_statuses_match_curls_retry_set() {
-        for code in [408, 429, 500, 502, 503, 504] {
+    fn transient_statuses_are_a_deliberate_superset_of_curls_retry_set() {
+        for code in [408, 429, 500, 501, 502, 503, 504, 521] {
             assert!(
                 is_transient_status(reqwest::StatusCode::from_u16(code).unwrap()),
                 "HTTP {code} should be retried"
@@ -3319,19 +3322,28 @@ mod tests {
         assert!(github_outage_hint(reqwest::StatusCode::FORBIDDEN, &plenty).is_empty());
     }
 
-    /// Serve `responses` in order, one per connection, and return the address.
+    /// Serve `responses` in order, one per connection. Returns the URL and a live
+    /// count of connections accepted.
     ///
     /// A hand-rolled listener rather than a mock-HTTP dev-dependency: the assertion
     /// needs a *transient* status followed by a good body, which is three lines of
     /// canned bytes, and `veld-core` carries no dev-dependencies today.
-    async fn serve_in_order(responses: Vec<String>) -> String {
+    ///
+    /// The counter is what lets "this was not retried" be *asserted* rather than
+    /// inferred from an error message — inference was wrong here, because a second
+    /// attempt against a dead listener produces a transport error that this code
+    /// also retries, so the message alone cannot tell one attempt from three.
+    async fn serve_in_order(responses: Vec<String>) -> (String, Arc<AtomicUsize>) {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
+        let seen = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&seen);
         tokio::spawn(async move {
             for body in responses {
                 let Ok((mut stream, _)) = listener.accept().await else {
                     return;
                 };
+                counter.fetch_add(1, Ordering::SeqCst);
                 // Read the request line and headers so the client does not see a
                 // reset before it has finished writing.
                 let mut buf = [0u8; 4096];
@@ -3340,7 +3352,26 @@ mod tests {
                 let _ = tokio::io::AsyncWriteExt::shutdown(&mut stream).await;
             }
         });
-        format!("http://{addr}/get")
+        (format!("http://{addr}/get"), seen)
+    }
+
+    /// A client for these tests, with a timeout.
+    ///
+    /// The timeout is not tidiness: once the canned responses run out the listener
+    /// task ends, and a connection that lands in the kernel's backlog first is
+    /// accepted by nobody and answered by nobody. Without this a regression would
+    /// hang the suite instead of failing it.
+    ///
+    /// These tests sleep the real `INSTALL_SCRIPT_RETRY_DELAY` — about 6s across the
+    /// three of them. `#[tokio::test(start_paused = true)]` would erase that, and is
+    /// deliberately not used: paused time also drives reqwest's own timeout, so the
+    /// guard above would fire the instant the client waited on a socket. A slow test
+    /// that cannot hang beats a fast one that can.
+    fn test_client() -> reqwest::Client {
+        reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()
+            .unwrap()
     }
 
     fn http_response(status: &str, body: &str) -> String {
@@ -3358,15 +3389,20 @@ mod tests {
     /// and this test starts returning GitHub's prose as a script to run.
     #[tokio::test]
     async fn a_rate_limited_download_fails_instead_of_returning_prose() {
-        let url = serve_in_order(vec![
+        let (url, seen) = serve_in_order(vec![
             http_response("429 Too Many Requests", GITHUB_429_BODY),
             http_response("429 Too Many Requests", GITHUB_429_BODY),
             http_response("429 Too Many Requests", GITHUB_429_BODY),
         ])
         .await;
-        let client = reqwest::Client::builder().build().unwrap();
 
-        let err = download_install_script(&client, &url).await.unwrap_err();
+        let err = download_install_script(&test_client(), &url)
+            .await
+            .unwrap_err();
+        assert_eq!(
+            seen.load(Ordering::SeqCst),
+            INSTALL_SCRIPT_ATTEMPTS as usize
+        );
         let msg = err.to_string();
         assert!(msg.contains("429"), "{msg}");
         assert!(msg.contains("githubstatus.com"), "{msg}");
@@ -3382,14 +3418,17 @@ mod tests {
     /// not what makes it safe to run.
     #[tokio::test]
     async fn a_two_hundred_that_is_not_a_script_is_refused() {
-        let url = serve_in_order(vec![http_response(
+        let (url, seen) = serve_in_order(vec![http_response(
             "200 OK",
             "<!doctype html><title>Wi-Fi login</title>",
         )])
         .await;
-        let client = reqwest::Client::builder().build().unwrap();
 
-        let err = download_install_script(&client, &url).await.unwrap_err();
+        let err = download_install_script(&test_client(), &url)
+            .await
+            .unwrap_err();
+        // Not retried either: a served page is an answer, not a blip.
+        assert_eq!(seen.load(Ordering::SeqCst), 1);
         assert!(
             err.to_string()
                 .contains("did not return the install script"),
@@ -3401,31 +3440,33 @@ mod tests {
     /// The blip case the retry exists for: one transient failure, then the script.
     #[tokio::test]
     async fn a_transient_failure_is_retried_and_the_script_still_arrives() {
-        let url = serve_in_order(vec![
+        let (url, seen) = serve_in_order(vec![
             http_response("503 Service Unavailable", "upstream is sad"),
             http_response("200 OK", FAKE_SCRIPT),
         ])
         .await;
-        let client = reqwest::Client::builder().build().unwrap();
 
-        let body = download_install_script(&client, &url).await.unwrap();
+        let body = download_install_script(&test_client(), &url).await.unwrap();
         assert_eq!(body, FAKE_SCRIPT);
+        assert_eq!(seen.load(Ordering::SeqCst), 2);
     }
 
     /// A permanent status is *not* retried — a 404 answers the question, and
     /// re-asking it three times only makes the failure slower.
     #[tokio::test]
     async fn a_permanent_status_is_not_retried() {
-        // One response only: a second attempt would find the listener gone and
-        // fail with a transport error instead of the status, so the assertion on
-        // the message is also the assertion that no second attempt happened.
-        let url = serve_in_order(vec![http_response("404 Not Found", "nope")]).await;
-        let client = reqwest::Client::builder().build().unwrap();
+        let (url, seen) = serve_in_order(vec![http_response("404 Not Found", "nope")]).await;
 
-        let err = download_install_script(&client, &url).await.unwrap_err();
+        let err = download_install_script(&test_client(), &url)
+            .await
+            .unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("404"), "{msg}");
         assert!(!msg.contains("githubstatus.com"), "{msg}");
+        // The assertion that carries this test: exactly one request was made. The
+        // message alone could not say so — a second attempt would hit a dead
+        // listener, and a transport error is retried too.
+        assert_eq!(seen.load(Ordering::SeqCst), 1);
     }
 
     /// An unrelated error must not read as "the script never ran", or the hint

--- a/crates/veld/src/commands/desktop.rs
+++ b/crates/veld/src/commands/desktop.rs
@@ -88,6 +88,12 @@ pub async fn install(
         // "install script exited with code 1" is true and useless. The script
         // already said why — into the log, where on the handoff path nobody was
         // going to look — so lift that line into the message the user gets.
+        // …unless the script never ran, in which case that log belongs to a
+        // *previous* run: the download happens before the log file is truncated, so
+        // lifting its last line prefixes this failure with an unrelated stale
+        // reason — "checksum verification failed for … (HTTP 429 …)". The error is
+        // the whole story on that path, and nothing else wrote to the log.
+        Err(e) if veld_core::setup::is_install_script_unavailable(&e) => Err(format!("{e}")),
         Err(e) => Err(match opts.log.as_deref().and_then(last_diagnostic) {
             Some(reason) => format!("{reason} ({e})"),
             None => format!("{e}"),

--- a/crates/veld/src/commands/update.rs
+++ b/crates/veld/src/commands/update.rs
@@ -991,7 +991,11 @@ async fn perform(
                 }
                 Err(e) => {
                     output::print_error(&format!("Update failed: {e}"), false);
-                    if !verbose {
+                    // Not printed when the script never ran: there is no
+                    // "installer's own output" to go and look at, and the error
+                    // above is already the whole story. This is the case a GitHub
+                    // incident produces, so it is the one most people meet.
+                    if !verbose && !veld_core::setup::is_install_script_unavailable(&e) {
                         println!(
                             "  {}",
                             output::dim(
@@ -1293,9 +1297,18 @@ async fn run_desktop_step(
             // information is on disk either way, because the app hands this
             // process an fd on that log, but nobody reads a log they were not
             // told about.
-            let detail = veld_core::setup::desktop_update_log_path()
-                .as_deref()
-                .and_then(super::desktop::last_diagnostic);
+            //
+            // Not when the script never ran, though: the download precedes the log
+            // truncation, so on that path the "last complaint" is a leftover from an
+            // earlier run and would attach a stale, wrong reason to a message that is
+            // already complete. Same guard as `veld desktop update`.
+            let detail = if veld_core::setup::is_install_script_unavailable(&e) {
+                None
+            } else {
+                veld_core::setup::desktop_update_log_path()
+                    .as_deref()
+                    .and_then(super::desktop::last_diagnostic)
+            };
             let e = match detail {
                 Some(reason) => format!("{reason} ({e})"),
                 None => format!("{e}"),

--- a/install.sh
+++ b/install.sh
@@ -109,6 +109,28 @@ say() {
 # than the caller, because it is the half holding the socket.
 CURL_PROGRESS="--progress-bar"
 
+# Every download here is a GitHub URL, and GitHub has incidents: `429 Too Many
+# Requests` on raw.githubusercontent, a 503 on a release asset. Both are gone by
+# the next request, and without this a blip in the middle of an install aborts a
+# run that had already closed the app and stopped nothing else.
+#
+# `--retry` alone, not `--retry-all-errors`: curl's own transient set (a timeout,
+# HTTP 408/429/500/502/503/504) is exactly the right one here, whereas retrying
+# *any* error would spend six seconds re-asking for a 404 that will stay a 404 —
+# an old release with no app archive is a supported case, not a blip.
+#
+# `--retry-max-time` is not belt-and-braces on `--retry-delay`, it is the only
+# thing bounding the wait: **curl obeys a server-sent `Retry-After` in preference
+# to `--retry-delay`, and `--max-time` does not cap it.** Measured against a local
+# listener on curl 8.7.1 — a `429` carrying `Retry-After: 25` took 75s, not the 6s
+# the delay implies, and a `Retry-After: 600` was still sleeping past two minutes.
+# That header is exactly what a rate-limiting CDN sends, so without a cap the
+# incident case turns a failed install into a half-hour stall with the app already
+# quit. 30s: room for the ordinary three 2s waits and for retrying a large archive
+# that died part-way, while a large `Retry-After` now fails fast instead of
+# sleeping through it.
+CURL_RETRY="--retry 3 --retry-delay 2 --retry-max-time 30"
+
 # --- Detect platform ---
 
 detect_os() {
@@ -178,12 +200,29 @@ if [ -n "${VELD_VERSION:-}" ]; then
   TAG="v${VERSION}"
 else
   say "Fetching latest release..."
-  TAG="$(curl -fsSL -H "Accept: application/json" "https://api.github.com/repos/${REPO}/releases/latest" | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)"
+  # `if ! TAG=…` rather than a bare assignment, and the construct is the whole
+  # point: under `set -euo pipefail` a failing command substitution aborts the
+  # script *inside* the assignment, so the `[ -z "$VERSION" ]` check below was
+  # unreachable on every path that actually fails — a 429, a 503, a DNS error.
+  # The user got curl's one-line stderr and a silent exit. `if !` suspends
+  # `errexit` for this command, which is what lets the error message run.
+  #
+  # `-f` plus `pipefail` also means a 200 whose body has no `tag_name` lands here
+  # (grep exits 1), so the message below covers "did not answer" and "answered
+  # with something unparseable" alike.
+  if ! TAG="$(curl -fsSL $CURL_RETRY -H "Accept: application/json" "https://api.github.com/repos/${REPO}/releases/latest" | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)"; then
+    TAG=""
+  fi
   VERSION="${TAG#v}"
 fi
 
 if [ -z "$VERSION" ]; then
-  echo "Error: could not determine version"
+  # Named rather than left as a bare "could not determine": `-f` means an empty
+  # TAG is almost always an HTTP failure, and during a GitHub incident that is
+  # what everybody hits at once. Anyone whose network is fine reads past it.
+  echo "Error: could not determine the latest version from the GitHub API."
+  echo "  If GitHub is having an incident (https://www.githubstatus.com/), try again later."
+  echo "  Otherwise pin a version: VELD_VERSION=x.y.z"
   exit 1
 fi
 
@@ -256,7 +295,7 @@ trap 'exit 143' TERM
 
 say "Downloading checksums..."
 HAVE_CHECKSUMS=""
-if curl -fSL -o "${TMP_DIR}/checksums.txt" "$CHECKSUMS_URL" 2>/dev/null; then
+if curl -fSL $CURL_RETRY -o "${TMP_DIR}/checksums.txt" "$CHECKSUMS_URL" 2>/dev/null; then
   HAVE_CHECKSUMS="1"
 else
   echo "Warning: checksums.txt not available, skipping verification"
@@ -566,7 +605,7 @@ install_desktop_app() {
   fi
 
   say "Downloading ${url}..."
-  if ! curl -fSL $CURL_PROGRESS -o "${TMP_DIR}/${zip}" "$url"; then
+  if ! curl -fSL $CURL_PROGRESS $CURL_RETRY -o "${TMP_DIR}/${zip}" "$url"; then
     echo "Warning: could not download ${zip}, skipping the app"
     return 1
   fi
@@ -660,7 +699,7 @@ fi
 # --- Download and extract ---
 
 say "Downloading ${URL}..."
-curl -fSL $CURL_PROGRESS -o "${TMP_DIR}/${TARBALL}" "$URL"
+curl -fSL $CURL_PROGRESS $CURL_RETRY -o "${TMP_DIR}/${TARBALL}" "$URL"
 
 verify_checksum "${TMP_DIR}/${TARBALL}" "$TARBALL" || exit 1
 

--- a/install.sh
+++ b/install.sh
@@ -130,12 +130,22 @@ CURL_PROGRESS="--progress-bar"
 # That header is exactly what a rate-limiting CDN sends, so without a cap an
 # incident turns a failed install into a half-hour stall with the app already quit.
 #
-# 30s, and the reason it does not have to cover the ~113 MB app archive: that timer
-# is reset once, before the *first* attempt, and includes transfer time — so a cap
-# only ever protects retries that happen early. It costs nothing anyway, because
-# every failure curl will retry is a status line, which arrives just as fast for a
-# 113 MB asset as for a 2 KB one; the slow-then-fail case is a dead transfer, and
-# that is exit 18/56, outside the retry set with or without a cap.
+# 30s, and be precise about what that buys and what it spends. The timer is reset
+# once, before the *first* attempt, and **includes transfer time** — so the cap only
+# ever protects retries that begin early.
+#
+# What it spends: a **timeout** is in curl's retry set, and it is by definition the
+# slow failure. This script sets no `--connect-timeout`, so a blackholed SYN (a DROP
+# firewall, a captive network) burns curl's default connect timeout on attempt one
+# and the cap then refuses the rest — one attempt where an uncapped run would make
+# four. That is accepted deliberately: four attempts at curl's default is twenty
+# minutes of an installer looking hung, which is worse than not retrying.
+#
+# What it costs nothing: asset size. The download failures curl retries by *status*
+# are status lines, and those arrive as fast for a 113 MB asset as for a 2 KB one.
+# A transfer that dies part-way is not the exception to that — it is exit 18/56,
+# outside the retry set with or without a cap (measured: one connection, no second
+# attempt).
 CURL_RETRY="--retry 3 --retry-delay 2 --retry-max-time 30"
 
 # --- Detect platform ---
@@ -215,8 +225,9 @@ else
   # `errexit` for this command, which is what lets the error message run.
   #
   # `-f` plus `pipefail` also means a 200 whose body has no `tag_name` lands here
-  # (grep exits 1), so the message below covers "did not answer" and "answered
-  # with something unparseable" alike.
+  # (grep exits 1). That case is why the message below opens cause-neutrally: GitHub
+  # *was* reached, so a first line asserting it was not would be a false statement
+  # about the one case curl said nothing about.
   if ! TAG="$(curl -fsSL $CURL_RETRY -H "Accept: application/json" "https://api.github.com/repos/${REPO}/releases/latest" | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)"; then
     TAG=""
   fi
@@ -224,16 +235,17 @@ else
 fi
 
 if [ -z "$VERSION" ]; then
-  # Named rather than left as a bare "could not determine": `-f` means an empty
-  # TAG is almost always a failure to reach GitHub, and during an incident that is
-  # what everybody hits at once. Anyone whose network is fine reads past it.
+  # A neutral first line and the causes underneath it as possibilities, because
+  # three unrelated failures land here and the script cannot tell which: GitHub
+  # answered an error, nothing answered at all, or something answered `200` with a
+  # body that has no `tag_name`. curl printed its own reason above for the first
+  # two and *nothing* for the third, so the lines below have to stand on their own.
   #
-  # Both causes named, because this line is reached by both and they need opposite
-  # actions. curl retries a DNS failure (measured: four attempts, 3.5s), so a
-  # laptop with no network arrives here too, after a pause, and telling it to wait
-  # for GitHub to recover would be wrong. `curl -sS` has already printed which one
-  # it was on the line above.
-  echo "Error: could not reach the GitHub API to find the latest version."
+  # The offline case is listed because curl retries a DNS failure — measured, four
+  # attempts and 6.1s with the flags above — so a laptop with no network reaches
+  # this after a pause long enough to look like GitHub being slow, and telling it
+  # to wait for GitHub to recover would send it in the wrong direction.
+  echo "Error: could not determine the latest version from the GitHub API."
   echo "  If GitHub is having an incident (https://www.githubstatus.com/), try again later."
   echo "  If this machine is offline or behind a proxy, that is the more likely cause."
   echo "  To skip this lookup entirely, pin a version: VELD_VERSION=x.y.z"

--- a/install.sh
+++ b/install.sh
@@ -130,24 +130,22 @@ CURL_PROGRESS="--progress-bar"
 # That header is exactly what a rate-limiting CDN sends, so without a cap an
 # incident turns a failed install into a half-hour stall with the app already quit.
 #
-# 30s, and be precise about what that buys and what it spends. The timer is reset
-# once, before the *first* attempt, and **includes transfer time** — so the cap only
-# ever protects retries that begin early.
+# 30s, and what that cap does is one sentence: the timer starts before the *first*
+# attempt and includes transfer time, so a retry that would begin more than 30s in
+# does not happen. Measured — a 503 that takes 5s per attempt gets three retries at
+# 30s and none at all at 3s.
 #
-# What it spends: retries of a **timeout**, which is in curl's retry set and is the
-# one retryable failure that is slow by construction — so it is also the one the cap
-# can eat. Measured against a blackholed address with an explicit `--connect-timeout 2`:
-# 4 attempts and 14.4s uncapped, 1 attempt and 8.1s once a cap is in play. Accepted:
-# an installer that gives up on a network that is not answering beats one that looks
-# hung while it tries again. (How long a dead network takes to *become* a timeout is
-# left unstated on purpose — it belongs to the kernel's SYN retries, not to curl, and
-# measuring it here produced neither of the two exit codes one would predict.)
+# For everything this script downloads, that is free. A failure curl retries by
+# *status* is a status line, and one arrives as fast for the 113 MB app archive as
+# for a 2 KB checksums file, so the retries all begin in the first second. The only
+# retryable failure slow enough for the cap to refuse one is a timeout — and how long
+# a dead network takes to become a timeout belongs to the kernel's SYN retries rather
+# than to curl, so it is not worth a number here. An installer that stops asking a
+# network that is not answering is the outcome we want anyway.
 #
-# What it costs nothing: asset size. The download failures curl retries by *status*
-# are status lines, and those arrive as fast for a 113 MB asset as for a 2 KB one.
-# A transfer that dies part-way is not the exception to that — it is exit 18/56,
-# outside the retry set with or without a cap (measured: one connection, no second
-# attempt).
+# Not the exception it looks like: a transfer that dies part-way is exit 18/56, which
+# is outside curl's retry set with or without a cap (measured: one connection, no
+# second attempt).
 CURL_RETRY="--retry 3 --retry-delay 2 --retry-max-time 30"
 
 # --- Detect platform ---

--- a/install.sh
+++ b/install.sh
@@ -134,12 +134,14 @@ CURL_PROGRESS="--progress-bar"
 # once, before the *first* attempt, and **includes transfer time** — so the cap only
 # ever protects retries that begin early.
 #
-# What it spends: a **timeout** is in curl's retry set, and it is by definition the
-# slow failure. This script sets no `--connect-timeout`, so a blackholed SYN (a DROP
-# firewall, a captive network) burns curl's default connect timeout on attempt one
-# and the cap then refuses the rest — one attempt where an uncapped run would make
-# four. That is accepted deliberately: four attempts at curl's default is twenty
-# minutes of an installer looking hung, which is worse than not retrying.
+# What it spends: retries of a **timeout**, which is in curl's retry set and is the
+# one retryable failure that is slow by construction — so it is also the one the cap
+# can eat. Measured against a blackholed address with an explicit `--connect-timeout 2`:
+# 4 attempts and 14.4s uncapped, 1 attempt and 8.1s once a cap is in play. Accepted:
+# an installer that gives up on a network that is not answering beats one that looks
+# hung while it tries again. (How long a dead network takes to *become* a timeout is
+# left unstated on purpose — it belongs to the kernel's SYN retries, not to curl, and
+# measuring it here produced neither of the two exit codes one would predict.)
 #
 # What it costs nothing: asset size. The download failures curl retries by *status*
 # are status lines, and those arrive as fast for a 113 MB asset as for a 2 KB one.

--- a/install.sh
+++ b/install.sh
@@ -114,21 +114,28 @@ CURL_PROGRESS="--progress-bar"
 # the next request, and without this a blip in the middle of an install aborts a
 # run that had already closed the app and stopped nothing else.
 #
-# `--retry` alone, not `--retry-all-errors`: curl's own transient set (a timeout,
-# HTTP 408/429/500/502/503/504) is exactly the right one here, whereas retrying
-# *any* error would spend six seconds re-asking for a 404 that will stay a 404 —
-# an old release with no app archive is a supported case, not a blip.
+# `--retry` alone, not `--retry-all-errors`: curl's own transient set (a timeout, a
+# DNS resolution failure, and HTTP 408/429/500/502/503/504) is the right one here,
+# whereas retrying *any* error would spend six seconds re-asking for a 404 that will
+# stay a 404 — an old release with no app archive is a supported case, not a blip.
+# Note what that set excludes, because it decides what the cap below can cost:
+# connection-refused (exit 7) is not retried, and neither is a transfer that dies
+# part-way (exit 18/56) — measured, one connection, no second attempt.
 #
-# `--retry-max-time` is not belt-and-braces on `--retry-delay`, it is the only
-# thing bounding the wait: **curl obeys a server-sent `Retry-After` in preference
-# to `--retry-delay`, and `--max-time` does not cap it.** Measured against a local
+# `--retry-max-time` is not belt-and-braces on `--retry-delay`, it is the only thing
+# bounding the wait: **curl obeys a server-sent `Retry-After` in preference to
+# `--retry-delay`, and `--max-time` does not cap it.** Measured against a local
 # listener on curl 8.7.1 — a `429` carrying `Retry-After: 25` took 75s, not the 6s
-# the delay implies, and a `Retry-After: 600` was still sleeping past two minutes.
-# That header is exactly what a rate-limiting CDN sends, so without a cap the
-# incident case turns a failed install into a half-hour stall with the app already
-# quit. 30s: room for the ordinary three 2s waits and for retrying a large archive
-# that died part-way, while a large `Retry-After` now fails fast instead of
-# sleeping through it.
+# the delay implies, and `Retry-After: 600` was still sleeping past two minutes.
+# That header is exactly what a rate-limiting CDN sends, so without a cap an
+# incident turns a failed install into a half-hour stall with the app already quit.
+#
+# 30s, and the reason it does not have to cover the ~113 MB app archive: that timer
+# is reset once, before the *first* attempt, and includes transfer time — so a cap
+# only ever protects retries that happen early. It costs nothing anyway, because
+# every failure curl will retry is a status line, which arrives just as fast for a
+# 113 MB asset as for a 2 KB one; the slow-then-fail case is a dead transfer, and
+# that is exit 18/56, outside the retry set with or without a cap.
 CURL_RETRY="--retry 3 --retry-delay 2 --retry-max-time 30"
 
 # --- Detect platform ---
@@ -218,11 +225,18 @@ fi
 
 if [ -z "$VERSION" ]; then
   # Named rather than left as a bare "could not determine": `-f` means an empty
-  # TAG is almost always an HTTP failure, and during a GitHub incident that is
+  # TAG is almost always a failure to reach GitHub, and during an incident that is
   # what everybody hits at once. Anyone whose network is fine reads past it.
-  echo "Error: could not determine the latest version from the GitHub API."
+  #
+  # Both causes named, because this line is reached by both and they need opposite
+  # actions. curl retries a DNS failure (measured: four attempts, 3.5s), so a
+  # laptop with no network arrives here too, after a pause, and telling it to wait
+  # for GitHub to recover would be wrong. `curl -sS` has already printed which one
+  # it was on the line above.
+  echo "Error: could not reach the GitHub API to find the latest version."
   echo "  If GitHub is having an incident (https://www.githubstatus.com/), try again later."
-  echo "  Otherwise pin a version: VELD_VERSION=x.y.z"
+  echo "  If this machine is offline or behind a proxy, that is the more likely cause."
+  echo "  To skip this lookup entirely, pin a version: VELD_VERSION=x.y.z"
   exit 1
 fi
 


### PR DESCRIPTION
## What broke

On 2026-08-17 GitHub had an incident. `veld update` fetches the install script from
`https://veld.oss.life.li/get`, which 302s to
`raw.githubusercontent.com/.../main/install.sh`. raw.githubusercontent answered
**HTTP 429** with two lines of plain-text prose — and we ran them:

```
  [1/3] Installing veld 16.49.0
bash: line 1: 429:: command not found
bash: -c: line 2: syntax error near unexpected token `('
✗ Update failed: install script exited with code 2
  Re-run with `veld update --verbose` to see the installer's own output.
```

`run_install_script` called `.send()` then `.text()` with **no status check** and
handed the body to `bash -c`. The documented human path, `curl -fsSL …/get | bash`,
already had `-f` and failed cleanly — only the Rust fetch executed the error body.
Reproduced live during the incident, byte for byte.

## What changed

**`crates/veld-core/src/setup.rs`** — a new `download_install_script`:

- checks the status before anything is executed;
- retries a transient status (408/429/5xx) or a transport failure three times,
  2s apart, narrating each retry;
- refuses a body that is not a shell script **even on `200 OK`** — the case a
  status code cannot see, e.g. a captive portal or a proxy serving its own page;
- names `githubstatus.com` when GitHub is rate-limiting or failing, including on a
  `403` carrying `x-ratelimit-remaining: 0`, which is how GitHub spends an
  exhausted *unauthenticated* limit (60/hr) as readily as a `429`.

A failure before the script runs is a typed `InstallScriptUnavailable`, which is
load-bearing in two places: `update.rs` stops printing "re-run with `--verbose` to
see the installer's own output" when there is no installer output, and both
`desktop.rs` and `update.rs` stop prefixing the message with `last_diagnostic`'s
"last complaint" — the log is truncated *after* the download, so on this path that
line is a **stale reason from a previous run** ("checksum verification failed …
(HTTP 429 …)").

All three entry points funnel through one function, so all three are covered:
`veld update` (`perform_update`), the Veld Desktop handoff, and `veld desktop update`.

**`install.sh`** — `--retry 3 --retry-delay 2 --retry-max-time 30` on its four
GitHub downloads, and a version-resolve error that can actually be reached.

## Why not the obvious thing

**Why not mirror `install.sh` from `website/nginx.conf` instead of 302-ing to
raw.githubusercontent?** Because during a GitHub incident the *release assets* are
equally unavailable, so serving the script locally converts a clear early failure
into a later, more confusing one. The fix belongs at the point that executes bytes.

**Why `--retry-max-time` is not decoration.** curl prefers a server-sent
`Retry-After` to `--retry-delay`, and `--max-time` does not cap it. Measured on
curl 8.7.1 against a local listener: `Retry-After: 25` → **75s**, `Retry-After: 600`
→ still sleeping past two minutes. That header is exactly what a rate-limiting CDN
sends, so uncapped this would stall an install for half an hour with the app already
quit. With the cap: 0.01s on `Retry-After: 600`, and still a full 6.46s of real
retries when no header is sent.

**Why `--retry`, not `--retry-all-errors`.** curl's transient set is the right one;
retrying *any* error would spend six seconds re-asking for a 404 that stays a 404,
and an old release with no app archive is supported, not a blip.

**Why the shape gate is weak on purpose.** `starts_with("#!") && contains("VELD_VERSION")`
is an anti-corruption check, not an authenticity check, and the tests now assert
that explicitly — a hostile script with the marker appended passes. Nothing
authenticates this script today; see the follow-up below.

**Why `check_update` does *not* retry.** It was added and then reverted. Its
justification was false (the Desktop handoff always passes `--target-version`, so
that path never reaches it), and its real cost was a regression:
`maybe_show_update_banner` runs on every `veld start|stop|restart|status|stats|urls|action|logs`
and stamps its cache only after a **successful** fetch, so ~4s of retries — which
fits under that call site's 5s timeout and is therefore paid in full — would be
re-paid on every such command for the length of an outage, including the
`veld action` the IDE invokes. The header-aware hint stayed.

## Review

Five rounds (the stakes-elevated cap), twelve subagent spawns. Round 1 found six
real defects, **two of them in this change's own new code**. Every round after that
found a defect introduced by the previous round's fix:

- 🔴 the new `install.sh` error message was unreachable — under `set -euo pipefail`
  a failing command substitution aborts *inside* the assignment, so `[ -z "$VERSION" ]`
  never ran. Found independently by two angles. (The pre-existing message it replaced
  was equally unreachable.)
- 🟠 no `--retry-max-time`, above. Also found independently by two angles.
- 🟠 `last_diagnostic` quoting a stale log line as the reason.
- 🔴 the `check_update` retry, reverted rather than re-argued.
- 🟠 ×2 replacement comments stating a mechanism that is false while the code is
  right — including a "the cap costs nothing" claim that ignores that a **timeout**
  is in curl's retry set, and a DNS figure measured with `--retry-delay 1` and quoted
  against flags that use `2`.

- 🔴 ×2 more in the *replacement* text for those comments — one paragraph explaining
  the retry cap was wrong three times running, in different directions: first that the
  cap "costs nothing", then a blackholed-SYN story I had not measured, then two numbers
  quoted as one experiment when they came from runs with different `--connect-timeout`
  values. It is now cut down to a single A/B I re-ran to confirm (a 503 taking 5s per
  attempt: three retries at `--retry-max-time 30`, none at `3`), with the parts I could
  not reproduce removed rather than reworded.

**No code defect has been found since round 1** — rounds 2 through 5 found only
comments claiming more than had been measured. Every finding was verified by
measurement before being fixed, and the regression tests were confirmed to fail when
the guards are removed: with the status check and shape gate neutered,
`download_install_script` returns GitHub's 429 prose as the "script", reproducing the
reported bug exactly.

The loop exited at its round cap with nothing open. The final delta is comment-only
and every claim left in it was measured by me directly, twice, rather than sent to a
sixth round.

## Test evidence

- `cargo clippy --workspace -- -D warnings` clean; `cargo fmt --all --check` clean;
  `cargo test --workspace` 1420 passed.
- `bash -n install.sh` + `shellcheck --severity=warning` clean.
- New tests cover: a rate-limited download failing instead of returning prose, a
  `200` that is not a script being refused, a transient failure retried and the
  script still arriving, a permanent status **not** retried (asserted by counting
  connections, not inferred from a message), the 403-with-exhausted-limit hint, and
  the shape gate pinned against this repo's own `install.sh` so a rename cannot make
  production unreachable.
- Verified live against the incident: 429 → two narrated retries → the actionable
  error.
- `if ! TAG="$(…)"` verified under both `/bin/bash` 3.2.57 (macOS stock, which is
  what `bash -c` resolves under the handoff's `SAFE_PATH`) and bash 5.

## Follow-up (out of scope, deliberately)

**Nothing authenticates `install.sh` itself.** No checksum, no signature, no pinned
commit; the trust root is TLS to `veld.oss.life.li` plus an unpinned 302 — while the
script it fetches verifies every release asset it downloads against `checksums.txt`.
This predates the change and is not narrowed by it, and the asymmetry is now written
into `run_install_script`'s doc comment so it is not invisible. Worth an issue:
publish `install.sh.sha256` at a second origin, or pin the raw URL to a commit SHA
and verify it.

## Docs

Purely a bugfix — no config field, CLI flag, subcommand, or new user-visible
surface — so the documentation checklist does not apply. No website change (no
capability added or renamed). No promotion: the channel is never for a fix.
