### PR TITLE
fix(terminal): repaint the foreground program when a terminal reattaches

### DIFF
--- a/crates/veld-daemon/src/pty.rs
+++ b/crates/veld-daemon/src/pty.rs
@@ -4188,7 +4188,7 @@ async fn resize_session(session: &Session, cols: u16, rows: u16) {
 /// already called on every attach with the client's current size, and when that
 /// size matches what the shell already has — every reattach into an unchanged
 /// pane — the kernel suppresses the `SIGWINCH` and the frame reaches nothing.
-/// See [`wire::REDRAW`] and the holder's `redraw`.
+/// See [`wire::REDRAW`] and the holder's `redraw_nudge`.
 ///
 /// Silently a no-op against a holder from before the frame existed, which is a
 /// session that reattaches exactly as it used to.

--- a/crates/veld-daemon/src/pty.rs
+++ b/crates/veld-daemon/src/pty.rs
@@ -525,6 +525,10 @@ struct Session {
     /// never sends that frame to an older holder that would drop the connection
     /// rather than ignore it.
     busy_supported: bool,
+    /// Whether the holder acts on a [`wire::REDRAW`]. Held for the same reason
+    /// [`Self::busy_supported`] is: an older holder, adopted across an update,
+    /// drops the connection on a daemon-numbered frame it does not know.
+    redraw_supported: bool,
     /// Slot for one in-flight busy query: the handler stores a oneshot sender
     /// here before sending [`wire::QUERY_BUSY`], and [`pump_holder`] completes it
     /// with the [`wire::BUSY`] reply. Serialised by [`Session::busy_lock`], so
@@ -3504,6 +3508,7 @@ fn register(
         released,
         pid: hello.pid,
         busy_supported: hello.supports_busy,
+        redraw_supported: hello.supports_redraw,
         busy_query: Mutex::new(None),
         busy_lock: tokio::sync::Mutex::new(()),
         _slot: slot,
@@ -3980,6 +3985,23 @@ async fn serve_socket(socket: WebSocket, session: Arc<Session>, size: PtySize, r
         return;
     }
 
+    // A resumed shell very likely has a full-screen program on it (a coding
+    // agent, vim, top) that has drawn a screen and will not draw it again on its
+    // own. The replay above just wrote a snapshot of that program's own output
+    // stream over whatever the client's terminal already held, and the program
+    // cannot know — which is the "it comes back mixed up until I drag the pane"
+    // report. Ask it to repaint.
+    //
+    // **After the replay, deliberately.** Frame order on this socket is the order
+    // the client parses in, so a repaint sent first would be overwritten by the
+    // very snapshot it was meant to correct.
+    //
+    // Only on `resumed`: a shell spawned by this attach has printed nothing yet
+    // and has no foreground program to ask.
+    if resumed {
+        redraw_session(&session).await;
+    }
+
     // Input runs in its own task: if it shared this one, a shell that stops
     // reading (`yes` filling the input buffer while flooding output) would
     // block the loop that is supposed to be draining that output — a deadlock
@@ -4132,6 +4154,30 @@ async fn resize_session(session: &Session, cols: u16, rows: u16) {
         .is_err()
     {
         debug!(session = %session.id, "resize dropped: the holder is gone");
+    }
+}
+
+/// Ask the holder to make the foreground program repaint.
+///
+/// Not a resize, and it cannot be done with one: [`resize_session`] above is
+/// already called on every attach with the client's current size, and when that
+/// size matches what the shell already has — every reattach into an unchanged
+/// pane — the kernel suppresses the `SIGWINCH` and the frame reaches nothing.
+/// See [`wire::REDRAW`] and the holder's `redraw`.
+///
+/// Silently a no-op against a holder from before the frame existed, which is a
+/// session that reattaches exactly as it used to.
+async fn redraw_session(session: &Session) {
+    if !session.redraw_supported {
+        return;
+    }
+    if session
+        .to_holder
+        .send((wire::REDRAW, Vec::new()))
+        .await
+        .is_err()
+    {
+        debug!(session = %session.id, "redraw dropped: the holder is gone");
     }
 }
 
@@ -6022,6 +6068,61 @@ mod tests {
                 .await
                 .unwrap();
             read_until(&mut again, "mark=kept").await;
+            end_session(&sid, "test cleanup").await;
+        }
+
+        /// Reattaching at the size the shell already has must still make the
+        /// foreground program repaint.
+        ///
+        /// The whole bug, end to end: a coding agent or a pager owns every cell
+        /// it drew and redraws only when something asks it to. On a reattach
+        /// nothing did — the replay wrote a snapshot of that program's own output
+        /// over whatever the terminal held, and the program never heard about it —
+        /// so the mixture sat there until the user dragged the pane and the
+        /// resize repainted it.
+        ///
+        /// Pinned at the *same* size on purpose. A reattach that changes the size
+        /// was never broken: the kernel signals on a changed `winsize` and the
+        /// program repaints on its own. `90x30` twice is the case that produced
+        /// no signal at all, and it is the overwhelmingly common one — coming back
+        /// to a window nobody moved.
+        ///
+        /// The markers are assembled by `printf` rather than written literally
+        /// because the terminal echoes what is typed into it *and the replay
+        /// replays that echo*: a literal `VELDWINCH` in the command would be
+        /// matched out of the replayed echo of the command itself, and the test
+        /// would pass without any signal ever being delivered.
+        #[tokio::test]
+        async fn a_reattach_at_the_same_size_makes_the_foreground_program_repaint() {
+            let addr = serve().await;
+            let dir = tempfile::tempdir().unwrap();
+            let sid = session_id();
+
+            let mut ws = open(addr, &sid, dir.path(), "&cols=90&rows=30").await;
+            read_control(&mut ws, "ready").await;
+            // Stands in for a full-screen program: something on this terminal that
+            // reacts to SIGWINCH and to nothing else. 28 is SIGWINCH on both Linux
+            // and Darwin, and the numeric form is what every shell accepts.
+            ws.send(WsMessage::Binary(
+                b"trap 'printf \"VELDW%sH\" INC' 28; printf \"VELDR%sY\" EAD\n"
+                    .to_vec()
+                    .into(),
+            ))
+            .await
+            .unwrap();
+            read_until(&mut ws, "VELDREADY").await;
+
+            // Drop the socket the way waking a laptop does — no close frame.
+            drop(ws);
+
+            let mut again = open(addr, &sid, dir.path(), "&cols=90&rows=30").await;
+            assert_eq!(
+                read_control(&mut again, "ready").await["resumed"],
+                true,
+                "the reattach must be a resume; a fresh shell would carry no trap \
+                 and this test would be asserting nothing"
+            );
+            read_until(&mut again, "VELDWINCH").await;
             end_session(&sid, "test cleanup").await;
         }
 

--- a/crates/veld-daemon/src/pty.rs
+++ b/crates/veld-daemon/src/pty.rs
@@ -3994,12 +3994,32 @@ async fn serve_socket(socket: WebSocket, session: Arc<Session>, size: PtySize, r
     // **After the snapshot, necessarily.** The two halves travel on different
     // channels: the request goes out on `to_holder`, and the repaint it provokes
     // comes back as PTY output on `session.output`. Ordering against the *replay
-    // frames* is therefore not the hazard — those are written from this task, and
-    // a repaint issued earlier would simply queue in the broadcast and still be
+    // frames* is therefore not the hazard — those are written from this task, and a
+    // repaint issued earlier would simply queue in the broadcast and still be
     // delivered after `ReplayEnd`. The hazard is ordering against the *snapshot*
-    // taken at the top of this function: a repaint provoked before that would be
-    // recorded into the scrollback and replayed as history, putting a second copy
-    // of the program's screen into the buffer it was meant to correct.
+    // taken at the top of this function: a repaint provoked before it would be in
+    // the very history it was meant to correct.
+    //
+    // **What that ordering does not fix, and this comment must not imply it does.**
+    // The repaint is ordinary PTY output, so `pump_holder` records it into the
+    // scrollback like anything else. Placing it after the snapshot defers the
+    // duplicate by one attach; it does not remove it. Measured, live `vim`
+    // reattached repeatedly at an unchanged size: the replay grows by ~1 KiB — one
+    // full screen — every single time, linearly, so a flapping connection and the
+    // client's own auto-reconnect budget will in the end evict real history from
+    // the 256 KiB ring. That cost is inherent to repainting rather than junk that
+    // could be filtered: the bytes *are* the program's current screen, which is the
+    // whole point of asking for them. Suppressing the recording for a window after
+    // the request would trade it for silently dropping any real output in that
+    // window, and the clean fix is a replay-that-resumes-from-an-offset, which is
+    // its own change. Recorded here so the next reader weighs it rather than
+    // rediscovers it.
+    //
+    // Fires on every resumed attach, including one where `resize_session` above
+    // just delivered a genuine size change and the program has therefore already
+    // repainted — one redundant repaint, deliberately, because gating it would mean
+    // tracking the last size handed to the holder on `Session` purely to save work
+    // on the path that was never broken.
     //
     // Only on `resumed`: a shell spawned by this attach has printed nothing yet
     // and has no foreground program to ask.
@@ -6102,6 +6122,14 @@ mod tests {
         /// no signal at all, and it is the overwhelmingly common one — coming back
         /// to a window nobody moved.
         ///
+        /// The probe traps in the interactive shell rather than running a busy-looping
+        /// job of its own. An earlier version did the latter, to observe the nudge
+        /// mid-flight, and it was the wrong trade twice over: it pinned a core for the
+        /// rest of the test binary whenever an assertion below panicked before the
+        /// cleanup — this session's orphan grace is `detach_grace_hint()`, minutes, not
+        /// the seconds a holder unit test can set — which would then flake every
+        /// timing-sensitive test that followed and bury the original failure.
+        ///
         /// The sizes are reported by `stty size`, and the ready marker is assembled
         /// by `printf`, because the terminal echoes what is typed into it *and the
         /// replay replays that echo*: a literal marker in the command would be
@@ -6115,21 +6143,12 @@ mod tests {
 
             let mut ws = open(addr, &sid, dir.path(), "&cols=90&rows=30").await;
             read_control(&mut ws, "ready").await;
-            // Stands in for a full-screen program: a foreground **job**, in its own
-            // process group, that reacts to SIGWINCH and to nothing else and reports
-            // the size it would have rendered at. Deliberately not a `trap` in the
-            // interactive shell itself — that shell shares the tty's foreground group
-            // with nothing, so it would not exercise the reason the repaint is aimed
-            // at `tcgetpgrp`'s answer rather than the shell, and a shell sitting in
-            // readline only runs its trap once both `ioctl`s have already landed, so
-            // it cannot observe the intermediate size at all.
-            //
-            // It busy-loops because a POSIX shell defers a trap until the foreground
-            // command it is waiting on returns, so a `sleep`-based loop could not see
-            // the nudge either. 28 is SIGWINCH on both Linux and Darwin; the numeric
-            // form is what every shell accepts.
+            // Stands in for a full-screen program: something on this terminal that
+            // reacts to SIGWINCH and to nothing else, and that reports the size it
+            // would have rendered at. 28 is SIGWINCH on both Linux and Darwin, and
+            // the numeric form is what every shell accepts.
             ws.send(WsMessage::Binary(
-                b"sh -c 'trap \"stty size\" 28; printf \"VELDR%sY\" EAD; while :; do :; done'\n"
+                b"trap 'stty size' 28; printf \"VELDR%sY\" EAD\n"
                     .to_vec()
                     .into(),
             ))
@@ -6147,20 +6166,21 @@ mod tests {
                 "the reattach must be a resume; a fresh shell would carry no trap \
                  and this test would be asserting nothing"
             );
-            // `30 90` is the assertion, not "something arrived": the program must be
-            // handed a size it has *not* already rendered at (`29 90`) and then the
-            // real one back. A bare same-size SIGWINCH — the first version of this
-            // fix — delivers neither, and a renderer that diffs its own output would
-            // write nothing at all in response to it.
-            let seen = read_until(&mut again, "30 90").await;
-            let nudged = seen
-                .find("29 90")
-                .expect("the reattach must hand the program a changed size, not just a signal");
-            assert!(
-                nudged < seen.find("30 90").unwrap(),
-                "the nudge must precede the restore, or the pane is left a row short: \
-                 {seen:?}"
-            );
+            // `30 90` — the size the pane actually has. Deliberately *not* also
+            // asserting that the program observed the intermediate `29 90`: whether it
+            // does depends on being scheduled inside `REDRAW_NUDGE`, which the holder
+            // documents as best-effort, and a shell sitting in readline typically runs
+            // its trap only once both `ioctl`s have landed. Asserting it here would be
+            // asserting a scheduling race on five macOS CI legs.
+            //
+            // So the division of labour is: this test owns the *wiring* — a resumed
+            // attach at an unchanged size reaches the holder and comes back at the
+            // right size, which fails if the frame is never sent and fails if the nudge
+            // is never restored — while the holder's own
+            // `a_redraw_changes_the_size_and_restores_it_while_a_same_size_resize_does_nothing`
+            // owns the *semantics*, in a tighter fixture where the sizes observed can
+            // be pinned exactly.
+            read_until(&mut again, "30 90").await;
             end_session(&sid, "test cleanup").await;
         }
 

--- a/crates/veld-daemon/src/pty.rs
+++ b/crates/veld-daemon/src/pty.rs
@@ -3985,16 +3985,21 @@ async fn serve_socket(socket: WebSocket, session: Arc<Session>, size: PtySize, r
         return;
     }
 
-    // A resumed shell very likely has a full-screen program on it (a coding
-    // agent, vim, top) that has drawn a screen and will not draw it again on its
-    // own. The replay above just wrote a snapshot of that program's own output
-    // stream over whatever the client's terminal already held, and the program
-    // cannot know — which is the "it comes back mixed up until I drag the pane"
-    // report. Ask it to repaint.
+    // A resumed shell very likely has a full-screen program on it that has drawn
+    // a screen and will not draw it again on its own. The replay above just wrote
+    // a snapshot of that program's own output stream over whatever the client's
+    // terminal already held, and the program cannot know — which is the "it comes
+    // back mixed up until I drag the pane" report. Ask it to repaint.
     //
-    // **After the replay, deliberately.** Frame order on this socket is the order
-    // the client parses in, so a repaint sent first would be overwritten by the
-    // very snapshot it was meant to correct.
+    // **After the snapshot, necessarily.** The two halves travel on different
+    // channels: the request goes out on `to_holder`, and the repaint it provokes
+    // comes back as PTY output on `session.output`. Ordering against the *replay
+    // frames* is therefore not the hazard — those are written from this task, and
+    // a repaint issued earlier would simply queue in the broadcast and still be
+    // delivered after `ReplayEnd`. The hazard is ordering against the *snapshot*
+    // taken at the top of this function: a repaint provoked before that would be
+    // recorded into the scrollback and replayed as history, putting a second copy
+    // of the program's screen into the buffer it was meant to correct.
     //
     // Only on `resumed`: a shell spawned by this attach has printed nothing yet
     // and has no foreground program to ask.
@@ -4169,6 +4174,16 @@ async fn resize_session(session: &Session, cols: u16, rows: u16) {
 /// session that reattaches exactly as it used to.
 async fn redraw_session(session: &Session) {
     if !session.redraw_supported {
+        // Worth a line: "it still comes back mixed up" otherwise has an adopted
+        // pre-update holder as a silent explanation, indistinguishable from a
+        // program that ignored the repaint.
+        debug!(session = %session.id, "no redraw: this holder predates the frame");
+        return;
+    }
+    // The same gate `query_busy` applies, for the same reason: there is no
+    // foreground program on a finished shell to ask, so the frame would travel
+    // the whole way to be dropped by the holder's own size read.
+    if session.exited().is_some() {
         return;
     }
     if session
@@ -6087,11 +6102,11 @@ mod tests {
         /// no signal at all, and it is the overwhelmingly common one — coming back
         /// to a window nobody moved.
         ///
-        /// The markers are assembled by `printf` rather than written literally
-        /// because the terminal echoes what is typed into it *and the replay
-        /// replays that echo*: a literal `VELDWINCH` in the command would be
-        /// matched out of the replayed echo of the command itself, and the test
-        /// would pass without any signal ever being delivered.
+        /// The sizes are reported by `stty size`, and the ready marker is assembled
+        /// by `printf`, because the terminal echoes what is typed into it *and the
+        /// replay replays that echo*: a literal marker in the command would be
+        /// matched out of the replayed echo of the command itself, and the test would
+        /// pass without anything having been delivered.
         #[tokio::test]
         async fn a_reattach_at_the_same_size_makes_the_foreground_program_repaint() {
             let addr = serve().await;
@@ -6100,11 +6115,21 @@ mod tests {
 
             let mut ws = open(addr, &sid, dir.path(), "&cols=90&rows=30").await;
             read_control(&mut ws, "ready").await;
-            // Stands in for a full-screen program: something on this terminal that
-            // reacts to SIGWINCH and to nothing else. 28 is SIGWINCH on both Linux
-            // and Darwin, and the numeric form is what every shell accepts.
+            // Stands in for a full-screen program: a foreground **job**, in its own
+            // process group, that reacts to SIGWINCH and to nothing else and reports
+            // the size it would have rendered at. Deliberately not a `trap` in the
+            // interactive shell itself — that shell shares the tty's foreground group
+            // with nothing, so it would not exercise the reason the repaint is aimed
+            // at `tcgetpgrp`'s answer rather than the shell, and a shell sitting in
+            // readline only runs its trap once both `ioctl`s have already landed, so
+            // it cannot observe the intermediate size at all.
+            //
+            // It busy-loops because a POSIX shell defers a trap until the foreground
+            // command it is waiting on returns, so a `sleep`-based loop could not see
+            // the nudge either. 28 is SIGWINCH on both Linux and Darwin; the numeric
+            // form is what every shell accepts.
             ws.send(WsMessage::Binary(
-                b"trap 'printf \"VELDW%sH\" INC' 28; printf \"VELDR%sY\" EAD\n"
+                b"sh -c 'trap \"stty size\" 28; printf \"VELDR%sY\" EAD; while :; do :; done'\n"
                     .to_vec()
                     .into(),
             ))
@@ -6122,7 +6147,20 @@ mod tests {
                 "the reattach must be a resume; a fresh shell would carry no trap \
                  and this test would be asserting nothing"
             );
-            read_until(&mut again, "VELDWINCH").await;
+            // `30 90` is the assertion, not "something arrived": the program must be
+            // handed a size it has *not* already rendered at (`29 90`) and then the
+            // real one back. A bare same-size SIGWINCH — the first version of this
+            // fix — delivers neither, and a renderer that diffs its own output would
+            // write nothing at all in response to it.
+            let seen = read_until(&mut again, "30 90").await;
+            let nudged = seen
+                .find("29 90")
+                .expect("the reattach must hand the program a changed size, not just a signal");
+            assert!(
+                nudged < seen.find("30 90").unwrap(),
+                "the nudge must precede the restore, or the pane is left a row short: \
+                 {seen:?}"
+            );
             end_session(&sid, "test cleanup").await;
         }
 

--- a/crates/veld-daemon/src/pty/holder.rs
+++ b/crates/veld-daemon/src/pty/holder.rs
@@ -506,9 +506,11 @@ async fn serve(cfg: &HolderConfig, listener: UnixListener) -> anyhow::Result<()>
                 }
                 Cmd::Frame(seq, frame) => {
                     // A probationary peer that *speaks* has proved itself sooner
-                    // than the window could: only a daemon sends input or a resize,
-                    // and the probes the window exists to survive send nothing at
-                    // all. Promoting here rather than making it wait is what keeps
+                    // than the window could: only a daemon sends input, a resize or
+                    // a redraw, and the probes the window exists to survive send
+                    // nothing at all. (`REDRAW` earns its place here defensively
+                    // rather than because anything reaches it as a first frame
+                    // today — see the drop-exemption list further down.) Promoting here rather than making it wait is what keeps
                     // a takeover prompt — this very frame is then acted on below
                     // instead of being dropped as a displaced peer's, and the
                     // output it missed while waiting was teed to it by the PTY
@@ -613,15 +615,25 @@ async fn serve(cfg: &HolderConfig, listener: UnixListener) -> anyhow::Result<()>
                     // except that it is not a peer worth promoting.
                     else if pending.as_ref().is_some_and(|c| c.generation == seq)
                         && !frame.is_ignorable()
-                        // `REDRAW` here is defensive and, as the lists stand, unreachable:
-                        // the promotion arm above matches the same three kinds and does
-                        // `pending.take()`, so a probationary peer's `REDRAW` has already
-                        // become the writer before control gets here. The listing that is
-                        // actually load-bearing is that one — the daemon sends `REDRAW`
-                        // immediately after an attach, which is exactly when a peer is
-                        // still probationary, and dropping it from up there costs the
-                        // repaint on every adoption with no log to say so. Kept in step
-                        // with it so the two cannot disagree if either is edited.
+                        // `REDRAW` is in both this list and the promotion one above, and in
+                        // *neither* does it change what happens today: no path in
+                        // `serve_socket` reaches its `redraw_session` without having already
+                        // awaited `resize_session`, and both frames ride this one ordered
+                        // channel, so that `RESIZE` promotes a probationary peer before its
+                        // `REDRAW` is ever read. Which is also what makes this arm
+                        // unreachable for a `REDRAW` — promotion took `pending`.
+                        //
+                        // Both entries are insurance against precisely the cleanup this
+                        // module's own docs invite. The `RESIZE` they lean on carries the
+                        // size the pty already has, and `redraw_nudge` argues at length that
+                        // such a resize signals nothing — so somebody will eventually delete
+                        // it as dead work, and on that day a `REDRAW` becomes an adopted
+                        // peer's first frame. With the promotion entry it still works;
+                        // without it the repaint is lost in silence; without either, the
+                        // peer loses its takeover too. The promotion half is pinned by
+                        // `a_peer_whose_only_frame_is_a_redraw_takes_the_session_over_at_once`
+                        // so the insurance cannot be quietly removed; this entry is kept in
+                        // step with it.
                         && !matches!(frame.kind, wire::INPUT | wire::RESIZE | wire::REDRAW)
                     {
                         warn!(

--- a/crates/veld-daemon/src/pty/holder.rs
+++ b/crates/veld-daemon/src/pty/holder.rs
@@ -105,6 +105,22 @@ const OUTPUT_SEND_TIMEOUT: Duration = Duration::from_secs(10);
 /// magnitude longer than a probe's connection lives.
 const TAKEOVER_PROBATION: Duration = Duration::from_secs(1);
 
+/// How long [`redraw`] leaves the terminal one row short before restoring it.
+///
+/// Standard signals coalesce, so two `TIOCSWINSZ` calls with no gap wake a
+/// program once and it reads only the final size — for a renderer that diffs its
+/// own output, an identical frame and nothing written. Measured through the real
+/// daemon against such a renderer: a 0 ms gap redrew 0 frames, 5 ms redrew 2.
+/// This is that floor plus margin for an event loop that is busy rendering, and
+/// it is the whole visible cost of a reattach — one stale bottom row, once.
+///
+/// Bounded, and that is what makes awaiting it in the control loop acceptable
+/// where the output path needs [`OUTPUT_SEND_TIMEOUT`]: the hazard there is a
+/// peer that never reads, i.e. *unbounded* parking, which would take `HANGUP`
+/// handling down with it. This delays the next frame by a fixed 40 ms, once per
+/// resumed attach.
+const REDRAW_NUDGE: Duration = Duration::from_millis(40);
+
 /// How long the holder waits, after handing a daemon the exit code, for that
 /// daemon to close the connection.
 ///
@@ -474,7 +490,7 @@ async fn serve(cfg: &HolderConfig, listener: UnixListener) -> anyhow::Result<()>
                     // writing to it, and its whole contract is that it works
                     // without being anybody's writer.
                     if pending.as_ref().is_some_and(|c| c.generation == seq)
-                        && matches!(frame.kind, wire::INPUT | wire::RESIZE)
+                        && matches!(frame.kind, wire::INPUT | wire::RESIZE | wire::REDRAW)
                     {
                         info!(session = %cfg.session_id, "a second daemon took the session over");
                         conn = pending.take();
@@ -509,7 +525,16 @@ async fn serve(cfg: &HolderConfig, listener: UnixListener) -> anyhow::Result<()>
                                 Some((cols, rows)) => resize(master.as_ref(), cols, rows),
                                 None => warn!("ignoring a malformed resize frame"),
                             },
-                            wire::REDRAW => redraw(master.as_ref()),
+                            wire::REDRAW => {
+                                // Two calls with a gap between them, not one: the
+                                // gap is what makes the change observable (see
+                                // `redraw_nudge`), and the borrow of `master`
+                                // cannot span the await.
+                                if let Some(size) = redraw_nudge(master.as_ref()) {
+                                    tokio::time::sleep(REDRAW_NUDGE).await;
+                                    resize(master.as_ref(), size.cols, size.rows);
+                                }
+                            }
                             wire::QUERY_BUSY => {
                                 // The answer rides the *current* connection's out
                                 // queue; the daemon that asked is the one attached
@@ -561,11 +586,15 @@ async fn serve(cfg: &HolderConfig, listener: UnixListener) -> anyhow::Result<()>
                     // except that it is not a peer worth promoting.
                     else if pending.as_ref().is_some_and(|c| c.generation == seq)
                         && !frame.is_ignorable()
-                        // `REDRAW` belongs beside `INPUT`/`RESIZE` rather than in the
-                        // drop-the-probation bucket, and load-bearingly so: the daemon
-                        // sends it immediately after an attach, which is exactly when a
-                        // peer is still probationary. Left out, the new right thing would
-                        // cost a peer its probation.
+                        // `REDRAW` belongs beside `INPUT`/`RESIZE` here *and* in the
+                        // promotion list above, and load-bearingly so: the daemon sends it
+                        // immediately after an attach, which is exactly when a peer is
+                        // still probationary. Listed only here it would be dropped with no
+                        // log and no repaint, working purely because `resize_session`
+                        // happens to precede it on the same ordered channel and promote
+                        // the peer first — so removing that redundant same-size resize,
+                        // which this module's own docs argue is useless, would silently
+                        // disable the repaint on every adoption.
                         && !matches!(frame.kind, wire::INPUT | wire::RESIZE | wire::REDRAW)
                     {
                         warn!(
@@ -1154,36 +1183,74 @@ fn resize(master: &dyn MasterPty, cols: u16, rows: u16) {
 
 /// Make the foreground program repaint its screen.
 ///
-/// A full-screen program — Claude Code, vim, top — owns every cell it draws and
-/// only redraws when something tells it to. Nothing does, when a browser
-/// reattaches to a shell that never stopped: the replayed scrollback lands on
-/// top of whatever the screen already held, and the program has no idea, so the
-/// mixture stays on screen until the user happens to drag the pane and the
+/// A full-screen program — a coding agent, vim, a pager — owns every cell it
+/// draws and only redraws when something tells it to. Nothing does, when a
+/// browser reattaches to a shell that never stopped: the replayed scrollback
+/// lands on top of whatever the screen already held, and the program has no
+/// idea, so the mixture stays until the user happens to drag the pane and the
 /// resize repaints it. That drag is the whole bug report.
 ///
-/// `SIGWINCH` is what the drag actually delivers, so this delivers it directly.
-/// The one thing that cannot work is re-sending the size: [`resize`] issues
-/// `TIOCSWINSZ` unconditionally, but both Linux and XNU compare the new
-/// `winsize` with the old one and skip the signal when they match — which is
-/// every reattach at an unchanged pane size.
+/// # Why a size change and not a bare `SIGWINCH`
 ///
-/// Signalled to the **foreground** process group, read from the terminal via
-/// `tcgetpgrp`, not to the shell's: an interactive shell puts each job in its
-/// own group, so `killpg(shell_pid, …)` would reach the shell — which ignores
-/// `SIGWINCH` — and never the program actually holding the screen. The
-/// foreground group is also exactly who the kernel signals on a real resize, so
-/// this is the same delivery by the same rule.
-fn redraw(master: &dyn MasterPty) {
-    let Some(fd) = master.as_raw_fd() else {
-        return;
+/// The drag delivers `SIGWINCH`, so sending one directly is the obvious fix, and
+/// it is not enough. A renderer that *diffs* — ink/`log-update`, which is what a
+/// coding agent's TUI is built on, and `ratatui`'s `Terminal::autoresize` — takes
+/// the signal, recomputes its frame from the size it reads, finds it byte-identical
+/// to the frame it last wrote, and writes **nothing**. Measured through the real
+/// daemon against a renderer of that shape: a bare same-size signal produced zero
+/// bytes, while `rows - 1` then `rows` produced two full repaints. Only programs
+/// that repaint unconditionally (vim) are woken by the signal alone, so the bare
+/// version fixes the case nobody reported and misses the case everybody did.
+///
+/// So this changes the size and puts it back — the redraw method `dtach` and
+/// `abduco` settled on for the same reason. Re-sending the *same* size cannot
+/// work either: [`resize`] issues `TIOCSWINSZ` unconditionally, but Linux
+/// (`tty_do_resize`) and XNU (`ttioctl_locked`) compare the new `winsize` with
+/// the old and skip the signal when they match, which is every reattach at an
+/// unchanged pane size.
+///
+/// # Why the gap is load-bearing
+///
+/// [`REDRAW_NUDGE`] is not padding. Standard signals coalesce, so with the two
+/// `ioctl`s back to back the program is woken once and reads only the *final*
+/// size — identical frame, nothing written. Measured, one variable, same probe:
+/// a 0 ms gap redrew **0** frames while 5 ms redrew 2. The value here is that
+/// floor plus margin for an event loop busy rendering.
+///
+/// Signalling is left to the kernel rather than done here with `killpg`. That is
+/// not only simpler: the kernel signals the foreground process group under the
+/// tty lock, holding the group itself, whereas reading a pgid with `tcgetpgrp`
+/// and then signalling that *number* can land on a group that was reaped and its
+/// id reused in between — and it would have been this module's only `killpg` at a
+/// group it neither owns nor reaps, against the rule its own header sets out.
+///
+/// Split across the gap rather than written as one `async fn` because a
+/// `&dyn MasterPty` is not `Send` and this runs inside a spawned task, so the
+/// borrow must not span the await. This half applies the nudge and hands back the
+/// size to restore; the caller sleeps and restores it.
+fn redraw_nudge(master: &dyn MasterPty) -> Option<PtySize> {
+    // The size the pty actually has, read back rather than tracked: the daemon is
+    // free to have resized since, and a remembered value would restore a stale one.
+    let size = match master.get_size() {
+        Ok(size) => size,
+        Err(e) => {
+            debug!("skipping a redraw: the terminal size could not be read: {e}");
+            return None;
+        }
     };
-    // -1 when there is no foreground group yet (or the fd is gone). Nothing is
-    // holding the screen in that case, so there is nothing to repaint.
-    let fg = unsafe { libc::tcgetpgrp(fd) };
-    if fg <= 0 {
-        return;
-    }
-    signal_group(fg, libc::SIGWINCH);
+    // Down a row, not up: a program that draws one row short leaves the bottom
+    // line stale for the length of the gap, while one that draws a row *past* the
+    // screen scrolls the display and moves everything the user was looking at.
+    // `rows` can be 1 (or 0 from a pty nobody sized), and 0 would mean "no
+    // constraint" to a program rather than a smaller screen, so a one-row terminal
+    // nudges the only direction it can.
+    let nudged = if size.rows > 1 {
+        size.rows - 1
+    } else {
+        size.rows + 1
+    };
+    resize(master, size.cols, nudged);
+    Some(size)
 }
 
 /// Duplicate a descriptor, mark it non-blocking, and hand it to tokio's
@@ -1459,25 +1526,35 @@ mod tests {
         );
     }
 
-    /// [`wire::REDRAW`] reaches the foreground program, and a same-size
-    /// [`wire::RESIZE`] does not.
+    /// [`wire::REDRAW`] gives the foreground program a real size *change*, and a
+    /// same-size [`wire::RESIZE`] gives it nothing.
     ///
-    /// Both halves are the point, and the *negative* one is the reason the frame
-    /// exists at all: re-sending the size a shell already has looks like it must
-    /// wake a full-screen program up, and it does nothing, because Linux
-    /// (`tty_do_resize`) and XNU (`ttioctl_locked`) both compare the new
-    /// `winsize` with the old and skip the `SIGWINCH` when they match. Asserting
-    /// only the `REDRAW` half would leave that premise untested — and it is the
-    /// premise that makes a "just resend the resize on reattach" fix, the obvious
-    /// one, silently ineffective.
+    /// Three properties, and each one is a bug that was actually built:
     ///
-    /// The probe busy-loops rather than sleeping between trap checks on purpose:
-    /// a POSIX shell defers a trap until the foreground command it is waiting on
-    /// returns, so a `sleep`-based loop would put up to a whole `sleep` of
-    /// latency between the signal and the `@WINCH@`, and the no-signal half of
-    /// this test would pass by simply not having waited long enough.
+    /// 1. **A same-size resize signals nothing.** The obvious fix — resend the
+    ///    size on reattach — does nothing, because Linux (`tty_do_resize`) and XNU
+    ///    (`ttioctl_locked`) compare the new `winsize` with the old and skip the
+    ///    `SIGWINCH` when they match. Asserting only the REDRAW half would leave
+    ///    that premise untested, and it is the premise that makes the whole frame
+    ///    necessary rather than redundant.
+    /// 2. **REDRAW changes the size, it does not merely signal.** The first version
+    ///    of this delivered a bare `SIGWINCH` via `killpg`, and that is not enough:
+    ///    a renderer that diffs its own output recomputes the same frame from the
+    ///    same size and writes nothing. So the assertion is on the *sizes the
+    ///    program observed* — `rows - 1` and then `rows` — which a bare-signal
+    ///    implementation cannot produce.
+    /// 3. **And it puts the size back.** Nudging without restoring leaves every
+    ///    reattached terminal one row short, which no assertion on "did it repaint"
+    ///    would catch.
+    ///
+    /// The probe reports through `stty size` rather than a literal, so the trap
+    /// body cannot satisfy the assertion by being echoed. It busy-loops instead of
+    /// sleeping because a POSIX shell defers a trap until the foreground command it
+    /// is waiting on returns, and a `sleep`-based loop would put a whole `sleep` of
+    /// latency between signal and output — long enough for property 1 to pass by
+    /// simply not having waited.
     #[tokio::test]
-    async fn a_redraw_signals_the_foreground_program_and_a_same_size_resize_does_not() {
+    async fn a_redraw_changes_the_size_and_restores_it_while_a_same_size_resize_does_nothing() {
         let dir = tempfile::tempdir().unwrap();
         let socket = dir.path().join("w.sock");
         let cfg = HolderConfig {
@@ -1497,7 +1574,7 @@ mod tests {
             argv: Some(vec![
                 "sh".to_owned(),
                 "-c".to_owned(),
-                "trap 'printf @WINCH@' 28; printf @READY@; while :; do :; done".to_owned(),
+                "trap 'stty size' 28; printf \"VELDR%sY\" EAD; while :; do :; done".to_owned(),
             ]),
             env: std::collections::BTreeMap::from([(
                 "PATH".to_owned(),
@@ -1518,12 +1595,12 @@ mod tests {
         let mut pid = 0;
         // Read frames until `needle` shows up in the pty output.
         //
-        // The bound is around the *read*, not only between reads: this probe
-        // busy-loops and prints nothing unasked, so a missing signal means no
-        // frame ever arrives and a deadline checked between whole frames is never
-        // reached — the earlier shape of this helper turned a failure into a
-        // ten-minute hang. Cancelling a `read_frame` mid-frame desyncs the
-        // stream, which is why the timeout is fatal rather than retried.
+        // The bound is around the *read*, not only between reads: this probe prints
+        // nothing unasked, so a missing signal means no frame ever arrives and a
+        // deadline checked between whole frames is never reached — the first shape
+        // of this helper turned a failure into a ten-minute hang. Cancelling a
+        // `read_frame` mid-frame desyncs the stream, which is why the timeout is
+        // fatal rather than retried.
         macro_rules! read_until {
             ($needle:expr) => {{
                 let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
@@ -1552,17 +1629,17 @@ mod tests {
             }};
         }
 
-        read_until!("@READY@");
+        read_until!("VELDREADY");
 
-        // The size the holder already spawned with. Nothing must come back.
+        // Property 1: the size the holder already spawned with. Nothing comes back.
         wire::write_frame(&mut stream, wire::RESIZE, &wire::encode_size(80, 24))
             .await
             .unwrap();
         // Deliberately *not* reading during the wait, so nothing is cancelled: any
         // frame the resize produced queues in the socket and is read below, and the
-        // pty is one ordered stream, so a `@WINCH@` provoked here cannot arrive
-        // after the echo of the marker sent after it.
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        // pty is one ordered stream, so output provoked here cannot arrive after the
+        // echo of a marker sent after it.
+        tokio::time::sleep(REDRAW_NUDGE * 5).await;
         // The line discipline echoes input whether or not the child reads it, which
         // is what makes the marker observable against a probe that never reads stdin.
         wire::write_frame(&mut stream, wire::INPUT, b"MARK\r")
@@ -1570,16 +1647,25 @@ mod tests {
             .unwrap();
         let text = read_until!("MARK");
         assert!(
-            !text.contains("@WINCH@"),
-            "a resize to the size the pty already has must not signal anything — \
-             if this starts passing trivially, the frame under test is unnecessary: \
-             {text:?}"
+            !text.contains("24 80") && !text.contains("23 80"),
+            "a resize to the size the pty already has must not signal anything — if \
+             this starts passing trivially, the frame under test is unnecessary: {text:?}"
         );
 
+        // Properties 2 and 3: a real change, then back.
         wire::write_frame(&mut stream, wire::REDRAW, &[])
             .await
             .unwrap();
-        read_until!("@WINCH@");
+        let text = read_until!("24 80");
+        let nudged = text.find("23 80").expect(
+            "REDRAW must give the program a size it has not already rendered at — a bare \
+             SIGWINCH at the unchanged size leaves a diffing renderer writing nothing",
+        );
+        assert!(
+            nudged < text.find("24 80").unwrap(),
+            "the nudge must come first and the true size last, or every reattached \
+             terminal is left a row short: {text:?}"
+        );
 
         // The probe holds a core; end it rather than leaving it to the grace.
         wire::write_frame(&mut stream, wire::HANGUP, &[])

--- a/crates/veld-daemon/src/pty/holder.rs
+++ b/crates/veld-daemon/src/pty/holder.rs
@@ -111,15 +111,38 @@ const TAKEOVER_PROBATION: Duration = Duration::from_secs(1);
 /// program once and it reads only the final size — for a renderer that diffs its
 /// own output, an identical frame and nothing written. Measured through the real
 /// daemon against such a renderer: a 0 ms gap redrew 0 frames, 5 ms redrew 2.
-/// This is that floor plus margin for an event loop that is busy rendering, and
-/// it is the whole visible cost of a reattach — one stale bottom row, once.
+/// This is that floor with margin, and it is the whole visible cost of a
+/// reattach — one stale bottom row, once, which is imperceptible anywhere in this
+/// range.
+///
+/// **Best-effort, and it cannot be otherwise.** The gap only works if the program
+/// is scheduled and renders inside it, so a machine loaded enough to starve it for
+/// this long collapses back into the 0 ms case: both signals coalesce, the program
+/// reads only the final size, and the repaint silently does not happen. There is
+/// no retry and no verification — the daemon cannot tell a program that ignored
+/// the signal from one that had nothing to redraw. The value is chosen for margin
+/// against scheduler latency rather than because 80 ms is a bound on it, and the
+/// failure mode is the pre-existing one (a screen that needs a manual resize), not
+/// a worse one. Raise it before suspecting anything subtler if the repaint starts
+/// missing under load.
 ///
 /// Bounded, and that is what makes awaiting it in the control loop acceptable
-/// where the output path needs [`OUTPUT_SEND_TIMEOUT`]: the hazard there is a
-/// peer that never reads, i.e. *unbounded* parking, which would take `HANGUP`
-/// handling down with it. This delays the next frame by a fixed 40 ms, once per
-/// resumed attach.
-const REDRAW_NUDGE: Duration = Duration::from_millis(40);
+/// where the output path needs [`OUTPUT_SEND_TIMEOUT`]: the hazard there is a peer
+/// that never reads, i.e. *unbounded* parking, which would take `HANGUP` handling
+/// down with it. This is a fixed 40 ms, once per resumed attach.
+///
+/// It parks the whole `select!` for that window, not just the next daemon frame —
+/// the PTY-read branch included, so the repaint the nudge provokes waits in the
+/// kernel buffer until the restore is done. That is harmless at this size and is
+/// worth knowing before adding a second blocking step nearby.
+///
+/// Parking is also what makes the window *safe* rather than merely tolerable: a
+/// client resize arriving mid-nudge cannot race the restore, because it queues on
+/// `to_holder` and is applied strictly after it. Measured — a resize sent inside
+/// the window left the pty at the client's size, not the restored one. Moving this
+/// sleep off the control loop would turn that into a real race and could leave a
+/// terminal permanently one row short.
+const REDRAW_NUDGE: Duration = Duration::from_millis(80);
 
 /// How long the holder waits, after handing a daemon the exit code, for that
 /// daemon to close the connection.
@@ -1241,9 +1264,12 @@ fn redraw_nudge(master: &dyn MasterPty) -> Option<PtySize> {
     // Down a row, not up: a program that draws one row short leaves the bottom
     // line stale for the length of the gap, while one that draws a row *past* the
     // screen scrolls the display and moves everything the user was looking at.
-    // `rows` can be 1 (or 0 from a pty nobody sized), and 0 would mean "no
-    // constraint" to a program rather than a smaller screen, so a one-row terminal
-    // nudges the only direction it can.
+    //
+    // The `else` is for a one-row terminal, which can only be nudged upwards. It is
+    // deliberately not claimed to cover `rows == 0`: that is unreachable — the spawn
+    // size and every `resize` run through `clamp_dimension`, which maps 0 to the
+    // default — and it would not work if it were, because the restore below goes
+    // through that same clamp and would set 24 rows rather than putting 0 back.
     let nudged = if size.rows > 1 {
         size.rows - 1
     } else {
@@ -2000,6 +2026,54 @@ mod tests {
         })
         .await;
         assert!(closed.is_ok(), "the displaced connection must be dropped");
+    }
+
+    /// A peer whose **only** frame is a `REDRAW` gets the session at once, the same
+    /// as one that sends `INPUT` or `RESIZE`.
+    ///
+    /// This is the promotion list at the top of the `Cmd::Frame` arm, and it needs a
+    /// test of its own because the code works without it. The daemon sends a
+    /// same-size `RESIZE` immediately before every `REDRAW` (`resize_session` then
+    /// `redraw_session` in `serve_socket`), and that `RESIZE` promotes the peer, so
+    /// deleting `REDRAW` from the promotion list leaves every other test in this
+    /// file green while the repaint is silently dropped on exactly the adoption
+    /// race the comment there claims to cover. Worse, the resize it depends on is
+    /// one this module's own docs argue is useless — a same-size resize signals
+    /// nothing — so the natural cleanup is what would break it.
+    ///
+    /// **The vacuity trap:** a silent peer is promoted anyway once
+    /// [`TAKEOVER_PROBATION`] elapses, so "the incumbent was eventually dropped"
+    /// would pass with no promotion arm at all. The assertion is therefore that the
+    /// handover beats that timer — promotion by frame is a channel send and a loop
+    /// turn, i.e. milliseconds, while the timer cannot fire before a full second.
+    #[tokio::test]
+    async fn a_peer_whose_only_frame_is_a_redraw_takes_the_session_over_at_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = echo_holder(dir.path(), "redrawtakeover").await;
+        let mut first = greet(&socket).await;
+        assert!(echoes_back(&mut first, "FIRST").await);
+
+        let mut second = greet(&socket).await;
+        // The only frame this peer ever sends. No `RESIZE` ahead of it, which is
+        // what makes the promotion attributable to `REDRAW` alone.
+        wire::write_frame(&mut second, wire::REDRAW, &[])
+            .await
+            .unwrap();
+
+        // The displaced connection ending is the only signal the protocol has for a
+        // completed handover. Bounded well under the probation so the timer cannot
+        // be what produced it.
+        let closed = tokio::time::timeout(TAKEOVER_PROBATION * 4 / 5, async {
+            while let Ok(Some(_)) = wire::read_frame(&mut first).await {}
+        })
+        .await;
+        assert!(
+            closed.is_ok(),
+            "a REDRAW must promote a probationary peer by itself — waiting for the \
+             probation timer instead means the repaint is dropped on every adoption"
+        );
+        // And it really owns the session: its input reaches the PTY.
+        assert!(echoes_back(&mut second, "OWNS-IT").await);
     }
 
     #[test]

--- a/crates/veld-daemon/src/pty/holder.rs
+++ b/crates/veld-daemon/src/pty/holder.rs
@@ -509,6 +509,7 @@ async fn serve(cfg: &HolderConfig, listener: UnixListener) -> anyhow::Result<()>
                                 Some((cols, rows)) => resize(master.as_ref(), cols, rows),
                                 None => warn!("ignoring a malformed resize frame"),
                             },
+                            wire::REDRAW => redraw(master.as_ref()),
                             wire::QUERY_BUSY => {
                                 // The answer rides the *current* connection's out
                                 // queue; the daemon that asked is the one attached
@@ -560,7 +561,12 @@ async fn serve(cfg: &HolderConfig, listener: UnixListener) -> anyhow::Result<()>
                     // except that it is not a peer worth promoting.
                     else if pending.as_ref().is_some_and(|c| c.generation == seq)
                         && !frame.is_ignorable()
-                        && !matches!(frame.kind, wire::INPUT | wire::RESIZE)
+                        // `REDRAW` belongs beside `INPUT`/`RESIZE` rather than in the
+                        // drop-the-probation bucket, and load-bearingly so: the daemon
+                        // sends it immediately after an attach, which is exactly when a
+                        // peer is still probationary. Left out, the new right thing would
+                        // cost a peer its probation.
+                        && !matches!(frame.kind, wire::INPUT | wire::RESIZE | wire::REDRAW)
                     {
                         warn!(
                             "dropping a probationary connection: unsupported frame {:#x}",
@@ -910,6 +916,9 @@ async fn attach(
         // This build answers QUERY_BUSY; an older holder that cannot would
         // drop the connection if asked, so the daemon gates on this flag.
         supports_busy: true,
+        // This build acts on REDRAW; an older holder that cannot would drop the
+        // connection if asked, so the daemon gates on this flag.
+        supports_redraw: true,
         // Measured from *this* holder's clock, not the daemon's: the daemon that
         // is connecting may never have seen this session before.
         detached_secs: disconnected_since
@@ -1141,6 +1150,40 @@ fn resize(master: &dyn MasterPty, cols: u16, rows: u16) {
     if let Err(e) = master.resize(size) {
         debug!("terminal resize failed: {e}");
     }
+}
+
+/// Make the foreground program repaint its screen.
+///
+/// A full-screen program — Claude Code, vim, top — owns every cell it draws and
+/// only redraws when something tells it to. Nothing does, when a browser
+/// reattaches to a shell that never stopped: the replayed scrollback lands on
+/// top of whatever the screen already held, and the program has no idea, so the
+/// mixture stays on screen until the user happens to drag the pane and the
+/// resize repaints it. That drag is the whole bug report.
+///
+/// `SIGWINCH` is what the drag actually delivers, so this delivers it directly.
+/// The one thing that cannot work is re-sending the size: [`resize`] issues
+/// `TIOCSWINSZ` unconditionally, but both Linux and XNU compare the new
+/// `winsize` with the old one and skip the signal when they match — which is
+/// every reattach at an unchanged pane size.
+///
+/// Signalled to the **foreground** process group, read from the terminal via
+/// `tcgetpgrp`, not to the shell's: an interactive shell puts each job in its
+/// own group, so `killpg(shell_pid, …)` would reach the shell — which ignores
+/// `SIGWINCH` — and never the program actually holding the screen. The
+/// foreground group is also exactly who the kernel signals on a real resize, so
+/// this is the same delivery by the same rule.
+fn redraw(master: &dyn MasterPty) {
+    let Some(fd) = master.as_raw_fd() else {
+        return;
+    };
+    // -1 when there is no foreground group yet (or the fd is gone). Nothing is
+    // holding the screen in that case, so there is nothing to repaint.
+    let fg = unsafe { libc::tcgetpgrp(fd) };
+    if fg <= 0 {
+        return;
+    }
+    signal_group(fg, libc::SIGWINCH);
 }
 
 /// Duplicate a descriptor, mark it non-blocking, and hand it to tokio's
@@ -1414,6 +1457,141 @@ mod tests {
             text.contains("[veld] Probe exited (0)") && !text.contains("shell exited"),
             "the exit notice must name the pane, not claim a shell ran: {text:?}"
         );
+    }
+
+    /// [`wire::REDRAW`] reaches the foreground program, and a same-size
+    /// [`wire::RESIZE`] does not.
+    ///
+    /// Both halves are the point, and the *negative* one is the reason the frame
+    /// exists at all: re-sending the size a shell already has looks like it must
+    /// wake a full-screen program up, and it does nothing, because Linux
+    /// (`tty_do_resize`) and XNU (`ttioctl_locked`) both compare the new
+    /// `winsize` with the old and skip the `SIGWINCH` when they match. Asserting
+    /// only the `REDRAW` half would leave that premise untested — and it is the
+    /// premise that makes a "just resend the resize on reattach" fix, the obvious
+    /// one, silently ineffective.
+    ///
+    /// The probe busy-loops rather than sleeping between trap checks on purpose:
+    /// a POSIX shell defers a trap until the foreground command it is waiting on
+    /// returns, so a `sleep`-based loop would put up to a whole `sleep` of
+    /// latency between the signal and the `@WINCH@`, and the no-signal half of
+    /// this test would pass by simply not having waited long enough.
+    #[tokio::test]
+    async fn a_redraw_signals_the_foreground_program_and_a_same_size_resize_does_not() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("w.sock");
+        let cfg = HolderConfig {
+            session_id: "winchprobe".to_owned(),
+            worktree_id: 1,
+            label: "test".to_owned(),
+            cwd: dir.path().to_path_buf(),
+            cols: 80,
+            rows: 24,
+            socket: socket.clone(),
+            // A backstop: this probe holds the CPU, so it must never outlive the
+            // test even if the explicit hangup below is lost.
+            orphan_grace_secs: 5,
+            shell_argv: None,
+            // 28 is `SIGWINCH` on both Linux and Darwin; the numeric form is what
+            // every POSIX shell accepts, `WINCH` is not.
+            argv: Some(vec![
+                "sh".to_owned(),
+                "-c".to_owned(),
+                "trap 'printf @WINCH@' 28; printf @READY@; while :; do :; done".to_owned(),
+            ]),
+            env: std::collections::BTreeMap::from([(
+                "PATH".to_owned(),
+                "/usr/bin:/bin".to_owned(),
+            )]),
+            pane_label: Some("Probe".to_owned()),
+        };
+        tokio::spawn(run(cfg));
+
+        let mut stream = loop {
+            match tokio::net::UnixStream::connect(&socket).await {
+                Ok(s) => break s,
+                Err(_) => tokio::time::sleep(Duration::from_millis(20)).await,
+            }
+        };
+
+        let mut seen = Vec::new();
+        let mut pid = 0;
+        // Read frames until `needle` shows up in the pty output.
+        //
+        // The bound is around the *read*, not only between reads: this probe
+        // busy-loops and prints nothing unasked, so a missing signal means no
+        // frame ever arrives and a deadline checked between whole frames is never
+        // reached — the earlier shape of this helper turned a failure into a
+        // ten-minute hang. Cancelling a `read_frame` mid-frame desyncs the
+        // stream, which is why the timeout is fatal rather than retried.
+        macro_rules! read_until {
+            ($needle:expr) => {{
+                let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+                loop {
+                    let text = String::from_utf8_lossy(&seen).to_string();
+                    if text.contains($needle) {
+                        break text;
+                    }
+                    let read = tokio::time::timeout_at(deadline, wire::read_frame(&mut stream));
+                    let Ok(framed) = read.await else {
+                        panic!("never saw {:?}; saw {text:?}", $needle);
+                    };
+                    let Some(frame) = framed.unwrap() else {
+                        panic!("the holder closed before {:?}; saw {text:?}", $needle);
+                    };
+                    match frame.kind {
+                        wire::OUTPUT | wire::SCROLLBACK => seen.extend_from_slice(&frame.payload),
+                        wire::HELLO => {
+                            pid = serde_json::from_slice::<wire::Hello>(&frame.payload)
+                                .unwrap()
+                                .pid;
+                        }
+                        _ => {}
+                    }
+                }
+            }};
+        }
+
+        read_until!("@READY@");
+
+        // The size the holder already spawned with. Nothing must come back.
+        wire::write_frame(&mut stream, wire::RESIZE, &wire::encode_size(80, 24))
+            .await
+            .unwrap();
+        // Deliberately *not* reading during the wait, so nothing is cancelled: any
+        // frame the resize produced queues in the socket and is read below, and the
+        // pty is one ordered stream, so a `@WINCH@` provoked here cannot arrive
+        // after the echo of the marker sent after it.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        // The line discipline echoes input whether or not the child reads it, which
+        // is what makes the marker observable against a probe that never reads stdin.
+        wire::write_frame(&mut stream, wire::INPUT, b"MARK\r")
+            .await
+            .unwrap();
+        let text = read_until!("MARK");
+        assert!(
+            !text.contains("@WINCH@"),
+            "a resize to the size the pty already has must not signal anything — \
+             if this starts passing trivially, the frame under test is unnecessary: \
+             {text:?}"
+        );
+
+        wire::write_frame(&mut stream, wire::REDRAW, &[])
+            .await
+            .unwrap();
+        read_until!("@WINCH@");
+
+        // The probe holds a core; end it rather than leaving it to the grace.
+        wire::write_frame(&mut stream, wire::HANGUP, &[])
+            .await
+            .unwrap();
+        assert!(pid > 0, "the greeting must have carried the probe's pid");
+        let deadline = Instant::now() + Duration::from_secs(20);
+        // SAFETY: signal 0 performs the permission/existence check only.
+        while unsafe { libc::kill(pid, 0) } == 0 {
+            assert!(Instant::now() < deadline, "the probe outlived its hangup");
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
     }
 
     /// An ordinary terminal opens the shell the **daemon** chose, not this

--- a/crates/veld-daemon/src/pty/holder.rs
+++ b/crates/veld-daemon/src/pty/holder.rs
@@ -120,8 +120,8 @@ const TAKEOVER_PROBATION: Duration = Duration::from_secs(1);
 /// this long collapses back into the 0 ms case: both signals coalesce, the program
 /// reads only the final size, and the repaint silently does not happen. There is
 /// no retry and no verification — the daemon cannot tell a program that ignored
-/// the signal from one that had nothing to redraw. The value is chosen for margin
-/// against scheduler latency rather than because 80 ms is a bound on it, and the
+/// the signal from one that had nothing to redraw. The value below is chosen for
+/// margin against scheduler latency, not because it is a *bound* on it, and the
 /// failure mode is the pre-existing one (a screen that needs a manual resize), not
 /// a worse one. Raise it before suspecting anything subtler if the repaint starts
 /// missing under load.
@@ -129,7 +129,11 @@ const TAKEOVER_PROBATION: Duration = Duration::from_secs(1);
 /// Bounded, and that is what makes awaiting it in the control loop acceptable
 /// where the output path needs [`OUTPUT_SEND_TIMEOUT`]: the hazard there is a peer
 /// that never reads, i.e. *unbounded* parking, which would take `HANGUP` handling
-/// down with it. This is a fixed 40 ms, once per resumed attach.
+/// down with it. This is one fixed gap, once per resumed attach.
+///
+/// Deliberately not restated as a figure anywhere above: a comment that repeats
+/// the value drifts from it silently, and this one already had. The number lives on
+/// the line below and nowhere else.
 ///
 /// It parks the whole `select!` for that window, not just the next daemon frame —
 /// the PTY-read branch included, so the repaint the nudge provokes waits in the
@@ -609,15 +613,15 @@ async fn serve(cfg: &HolderConfig, listener: UnixListener) -> anyhow::Result<()>
                     // except that it is not a peer worth promoting.
                     else if pending.as_ref().is_some_and(|c| c.generation == seq)
                         && !frame.is_ignorable()
-                        // `REDRAW` belongs beside `INPUT`/`RESIZE` here *and* in the
-                        // promotion list above, and load-bearingly so: the daemon sends it
+                        // `REDRAW` here is defensive and, as the lists stand, unreachable:
+                        // the promotion arm above matches the same three kinds and does
+                        // `pending.take()`, so a probationary peer's `REDRAW` has already
+                        // become the writer before control gets here. The listing that is
+                        // actually load-bearing is that one — the daemon sends `REDRAW`
                         // immediately after an attach, which is exactly when a peer is
-                        // still probationary. Listed only here it would be dropped with no
-                        // log and no repaint, working purely because `resize_session`
-                        // happens to precede it on the same ordered channel and promote
-                        // the peer first — so removing that redundant same-size resize,
-                        // which this module's own docs argue is useless, would silently
-                        // disable the repaint on every adoption.
+                        // still probationary, and dropping it from up there costs the
+                        // repaint on every adoption with no log to say so. Kept in step
+                        // with it so the two cannot disagree if either is edited.
                         && !matches!(frame.kind, wire::INPUT | wire::RESIZE | wire::REDRAW)
                     {
                         warn!(

--- a/crates/veld-daemon/src/pty/wire.rs
+++ b/crates/veld-daemon/src/pty/wire.rs
@@ -96,6 +96,20 @@ pub const HANGUP: u8 = 0x83;
 /// an older holder that does not know the kind would drop the connection
 /// rather than ignore it, which is the one outcome that must never happen.
 pub const QUERY_BUSY: u8 = 0x84;
+/// Make the foreground program repaint, by signalling `SIGWINCH` to the PTY's
+/// foreground process group.
+///
+/// Empty payload — the size is not part of this frame, deliberately. A repaint
+/// is asked for when the size has *not* changed, which is precisely the case
+/// [`RESIZE`] cannot cover: both Linux (`tty_do_resize`) and XNU
+/// (`ttioctl_locked`) skip the `SIGWINCH` when the new `winsize` equals the old
+/// one, so re-sending the size a shell already has reaches nothing. See
+/// `redraw` in the holder for what this does instead.
+///
+/// Sent only to a holder that advertised [`Hello::supports_redraw`], for the
+/// same reason [`QUERY_BUSY`] is gated: an older holder drops the connection on
+/// a daemon-numbered frame it does not know ([`Frame::is_ignorable`]).
+pub const REDRAW: u8 = 0x85;
 
 /// Cap on one frame's payload, matching the WebSocket frame cap the daemon
 /// applies on the other side of the bridge. The largest legitimate frame is a
@@ -162,6 +176,15 @@ pub struct Hello {
     /// an update defaults to false and its sessions simply report as idle.
     #[serde(default)]
     pub supports_busy: bool,
+    /// Whether this holder acts on [`REDRAW`].
+    ///
+    /// `#[serde(default)]` for the same reason [`Self::supports_busy`] is, and
+    /// gated for the same reason: an older holder adopted after an update would
+    /// drop the connection rather than ignore the frame. Defaulting to false
+    /// costs such a session nothing but the repaint — it reattaches exactly as
+    /// it did before this existed.
+    #[serde(default)]
+    pub supports_redraw: bool,
     /// `Some(code)` if the shell has already exited.
     pub exited: Option<u32>,
     /// Seconds since a daemon was last connected, or `None` if one is attached
@@ -446,7 +469,7 @@ mod tests {
         // An instruction the holder cannot carry out must fail the connection,
         // not be skipped: a silently-dropped resize is a terminal stuck at the
         // wrong size with nothing in any log.
-        for kind in [INPUT, RESIZE, HANGUP, QUERY_BUSY, 0x99] {
+        for kind in [INPUT, RESIZE, HANGUP, QUERY_BUSY, REDRAW, 0x99] {
             assert!(
                 !Frame {
                     kind,
@@ -483,6 +506,7 @@ mod tests {
             ("RESIZE", RESIZE),
             ("HANGUP", HANGUP),
             ("QUERY_BUSY", QUERY_BUSY),
+            ("REDRAW", REDRAW),
         ];
         let unique: std::collections::HashSet<u8> = kinds.iter().map(|(_, k)| *k).collect();
         assert_eq!(
@@ -508,6 +532,36 @@ mod tests {
         // strands shells behind daemons that cannot ask them to stop.
         assert_eq!(HANGUP, 0x83);
         assert_eq!(PROTOCOL, 1);
+    }
+
+    /// A greeting from a holder that predates a capability flag must default it
+    /// to false, not fail to parse.
+    ///
+    /// This is the `veld update` path, and it is the whole reason both flags
+    /// exist: after an update the daemon is the new binary while every holder
+    /// still runs the old one, so the *old* greeting is what the *new* daemon
+    /// reads. A field without `#[serde(default)]` makes that greeting
+    /// undeserializable — and the daemon cannot even report it as a version
+    /// problem, because it never got as far as reading the version. It would
+    /// hang up every surviving terminal instead.
+    ///
+    /// Both flags are asserted rather than only the new one: the failure is a
+    /// property of the struct, so the test has to be the thing that notices the
+    /// next field added without a default.
+    #[test]
+    fn a_greeting_without_the_capability_flags_still_parses() {
+        // Exactly the fields an older holder sends, and nothing this build added.
+        let old = r#"{"protocol":1,"session_id":"s","worktree_id":1,"label":"l",
+                      "cwd":"/tmp","pid":42,"exited":null}"#;
+        let hello: Hello = serde_json::from_str(old).expect("an old greeting must still parse");
+        assert_eq!(hello.protocol, PROTOCOL);
+        assert!(
+            !hello.supports_redraw,
+            "an old holder must not be sent REDRAW: it would drop the connection \
+             on a daemon-numbered frame it cannot ignore, costing a live terminal"
+        );
+        assert!(!hello.supports_busy, "same for QUERY_BUSY");
+        assert_eq!(hello.detached_secs, None);
     }
 
     #[test]

--- a/crates/veld-daemon/src/pty/wire.rs
+++ b/crates/veld-daemon/src/pty/wire.rs
@@ -96,15 +96,19 @@ pub const HANGUP: u8 = 0x83;
 /// an older holder that does not know the kind would drop the connection
 /// rather than ignore it, which is the one outcome that must never happen.
 pub const QUERY_BUSY: u8 = 0x84;
-/// Make the foreground program repaint, by signalling `SIGWINCH` to the PTY's
+/// Make the foreground program repaint, by giving it a real `winsize` change —
+/// one row shorter, a gap, then the true size — so the *kernel* signals the PTY's
 /// foreground process group.
 ///
-/// Empty payload — the size is not part of this frame, deliberately. A repaint
-/// is asked for when the size has *not* changed, which is precisely the case
-/// [`RESIZE`] cannot cover: both Linux (`tty_do_resize`) and XNU
-/// (`ttioctl_locked`) skip the `SIGWINCH` when the new `winsize` equals the old
-/// one, so re-sending the size a shell already has reaches nothing. See
-/// `redraw` in the holder for what this does instead.
+/// Empty payload — the size is not part of this frame, deliberately. The holder
+/// reads the pty's current size itself, because the daemon asks for a repaint
+/// precisely when the size has *not* changed, which is the case [`RESIZE`] cannot
+/// cover: both Linux (`tty_do_resize`) and XNU (`ttioctl_locked`) skip the
+/// `SIGWINCH` when the new `winsize` equals the old one, so re-sending the size a
+/// shell already has reaches nothing. A bare signal is not enough either — a
+/// renderer that diffs its own output recomputes an identical frame and writes
+/// nothing — which is why this is a change and not a notification. See
+/// `redraw_nudge` in the holder.
 ///
 /// Sent only to a holder that advertised [`Hello::supports_redraw`], for the
 /// same reason [`QUERY_BUSY`] is gated: an older holder drops the connection on


### PR DESCRIPTION
## The report

> sometimes when i come back to veld ide terminals especially things like claude
> code it seems like it reconnected to the terminal ... and veld printed something
> like "reconnected" and the TUI text is sometimes polluted artifacts ... when i
> then resize the IDE window/terminal pane, it snaps back to look correct

## Root cause

A reattach already pushes the client's current size to the PTY. The problem is
that when the size is **unchanged** — every reattach into a pane nobody moved —
the kernel drops the signal. Linux (`tty_do_resize`) and XNU (`ttioctl_locked`)
both compare the new `winsize` with the old and skip the `SIGWINCH` when they
match.

So a full-screen program is never told to redraw. The replayed scrollback lands
on top of the screen it drew, the program has no idea, and the mixture sits there
until the pane is dragged — which changes the size, which finally delivers the
signal. That drag is the whole bug report.

Measured before building on it (macOS 25.6, `pty` + `TIOCSWINSZ`):

| ioctl | SIGWINCH delivered |
|---|---|
| 100x30 → 100x30 | no |
| 100x30 → 100x29 | yes |

**So the intuitive fix — "resend the resize on reconnect" — would have shipped and
changed nothing.** That is why this adds a frame rather than a call.

## What this does

A new daemon→holder frame, `REDRAW` (`0x85`). The holder answers it by reading the
pty's current size, applying one row shorter, waiting `REDRAW_NUDGE`, and restoring
the true size — two real `winsize` changes, so the **kernel** signals the foreground
process group by its own rule. The daemon sends it after the replay and `Ready`, on
a `resumed` attach only.

### A bare signal is not enough, and that was the review's main finding

The first implementation delivered a bare `SIGWINCH` via `killpg(tcgetpgrp(fd))`.
Two review angles, blind to each other, independently found that this does not wake
a renderer which **diffs** its own output — ink/`log-update` short-circuits on
`output === previousOutput`, ratatui's `Terminal::autoresize` no-ops on an unchanged
size. Such a program takes the signal, recomputes an identical frame, and writes
nothing. That is exactly the program class the report names.

Measured through the real daemon against a renderer of that shape, one variable:

| holder behaviour | frames redrawn |
|---|---|
| bare same-size `SIGWINCH` | **0** |
| `rows-1` → `rows`, 0 ms gap | **0** (signals coalesce; only the final size is read) |
| `rows-1` → `rows`, 5 ms gap | 2 |
| `rows-1` → `rows`, 20 / 50 ms | 2 |

The gap is therefore load-bearing, not padding, and a test fails if it is removed.
Letting the kernel signal also removed what would have been this module's only
`killpg` at a process group it neither owns nor reaps.

## Why not the obvious alternatives

- **Resend the size on reattach** — no-op, per the table above. This is the one the
  bug report proposed and the one the code now explicitly documents against.
- **Bare `SIGWINCH`** — measured insufficient for the reported program class.
- **Bump `PROTOCOL`** — costs every open terminal on the update that ships it. The
  module documents an additive-`#[serde(default)]` exception precisely for this, and
  `QUERY_BUSY`/`supports_busy` is the existing precedent this copies.
- **Reuse `RESIZE` with a sentinel payload** — overloads a frame whose payload is a
  size, for a request that deliberately carries none.
- **Fix it client-side** — see the open question below; it addresses a different half.

## Compatibility

Gated on a new `Hello::supports_redraw`, so a holder spawned by the previous release
and adopted by this daemon is never sent a daemon-numbered frame it cannot ignore
(which it would answer by dropping the connection — a live terminal). No `PROTOCOL`
bump. Verified there is exactly **one** production send site, behind that gate; one
`Session` construction site; one `redraw_session` caller. An old daemon meeting a new
holder ignores the extra JSON field (`Hello` has no `deny_unknown_fields`).

## A known cost, measured and not hidden

The repaint is ordinary PTY output, so it is recorded into the scrollback and
replayed as history on the next attach. Live `vim` reattached repeatedly at an
unchanged size:

```
reattach 1: replay=2686   reattach 4: replay=5758  (+1024)
reattach 2: replay=3710   reattach 5: replay=6782  (+1024)
reattach 3: replay=4734   reattach 6: replay=7806  (+1024)
```

~1 KiB — one screen — every time, linearly, against a 256 KiB ring. Sending the
request after the snapshot defers this by one attach; it does not remove it. The
cost is inherent to repainting (the bytes *are* the program's screen), and the clean
fix is the same one as the open question below.

## DECISION-REQUIRED — the other half of the symptom

On the in-place reconnect path the client never resets the xterm
(`terminalHost.ts`'s `reconnectTerminal` and the auto-reconnect timer both call
`connect` with no `reset()`), so the daemon replays a scrollback the buffer already
holds — a doubled transcript. Two review angles found this independently.

This PR does not address it, because the options have real trade-offs and the choice
is yours:

| option | cost |
|---|---|
| ship as is | a normal-buffer TUI keeps duplicated history above its frame |
| client `reset()` before a reconnect replay | loses scrollback older than the daemon's 256 KiB ring |
| skip the replay on reconnect | loses output that arrived while disconnected |
| replay-that-resumes-from-an-offset | correct, no loss — its own change |

**Recommendation: ship this, and open the offset-replay change as a follow-up** — it
fixes the duplication *and* the scrollback growth above, since they are one root
cause. Note that an alternate-buffer program (vim, a pager) already comes back clean
with this PR alone, because its repaint clears the screen.

## Evidence

Real stack — dev daemon, real holder, real login shell, real WebSocket, reattached at
an identical 90x30 (fresh sessions, first attach asserted `resumed: false`):

- diffing renderer (ink/ratatui class): `FRAME[90x29]FRAME[90x30]` — two repaints,
  where the bare-signal version produced **0 bytes**
- live `vim`: 1024 bytes, opening `ESC[H ESC[2J` plus a full file redraw

Tests — three, split so each owns one thing:

- `holder::tests::a_redraw_changes_the_size_and_restores_it_while_a_same_size_resize_does_nothing`
  — the semantics, asserting the sizes the program *observed*
- `pty::tests::e2e::a_reattach_at_the_same_size_makes_the_foreground_program_repaint`
  — the wiring, end to end through the real socket
- `holder::tests::a_peer_whose_only_frame_is_a_redraw_takes_the_session_over_at_once`
  — the promotion list, bounded under `TAKEOVER_PROBATION` so the probation timer
  cannot be what satisfies it

All five mutations are caught: bare signal, no restore, zero gap, frame never sent,
and `REDRAW` absent from the promotion list.

## Review

Ran the **standard** staged loop from `docs/agentic-review.md`, not the "light" depth
requested at kickoff: the diff touches the daemon's PTY endpoints, which §3.3 marks
stakes-elevated and explicitly non-downgradable. 4 rounds, 9 spawns, 7 angles.

Findings that changed the code: the bare-signal defect (2 angles, independently); the
scrollback growth; two flaky tests I had introduced (one asserting a scheduling race,
one pinning a core with no backstop); the promotion-list gap (3 angles); a missing
`exited()` gate; and four comments that outlived the code they described — including
one saying "a fixed 40 ms" three lines above a constant reading `80`.

## Docs

Purely internal: no config fields, CLI flags, subcommands, schema, or keyboard
shortcuts, so the AGENTS.md documentation checklist does not apply. Nothing in
`docs/`, `README.md`, `AGENTS.md`, `website/` or `skills/` describes the holder frame
set — it is documented in `wire.rs` itself, which this updates.

**Website: no** — no new or renamed user-visible capability.
**Promotion: no** — a bug fix, which `docs/promotions.md` rules out by name.
**Core, not customization** — this is the terminal primitive itself; no provider API
or provider-specific schema, so no extension-backlog row.
