### PR TITLE
fix(ci): publish releases by hand so one 5xx cannot strand them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,8 @@ jobs:
           python3 tests/validate-workflow-gates.py --selftest
           python3 tests/validate-workflow-gates.py
       # Static, checkout-only and PyYAML-only, so it rides along with the gate
-      # above. What it guards is the release path itself: release.yml publishes
+      # above — which is also where PyYAML is installed, so this step must stay
+      # after it. What it guards is the release path itself: release.yml publishes
       # by hand now, and the invariant that matters — an incomplete release is
       # never published, and a complete one never left a draft — has no other
       # check. Its failure is silent, which is exactly how v16.57.1 shipped to

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,17 @@ jobs:
           # check trivially, which reads as a clean bill of health.
           python3 tests/validate-workflow-gates.py --selftest
           python3 tests/validate-workflow-gates.py
+      # Static, checkout-only and PyYAML-only, so it rides along with the gate
+      # above. What it guards is the release path itself: release.yml publishes
+      # by hand now, and the invariant that matters — an incomplete release is
+      # never published, and a complete one never left a draft — has no other
+      # check. Its failure is silent, which is exactly how v16.57.1 shipped to
+      # nobody. `--selftest` first, same reasoning as above: it mutates the
+      # completeness gate out of the script and asserts the suite goes red.
+      - name: Release publish script holds its invariants
+        run: |
+          python3 tests/validate-release-publish.py --selftest
+          python3 tests/validate-release-publish.py
       # Same reasoning: static, checkout-only, and the thing it guards (one
       # favicon inlined into five files across three languages) has no compiler
       # or linter that can see the drift.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -332,6 +332,9 @@ jobs:
       contents: write
     needs: [plan, release]
     runs-on: ubuntu-latest
+    # Five upload attempts with backoff cannot outlast this, so a wedged
+    # publish fails in an hour rather than holding a runner for six.
+    timeout-minutes: 60
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
@@ -355,13 +358,102 @@ jobs:
         env:
           RELEASE_NOTES: ${{ needs.release.outputs.new_release_notes }}
 
-      - name: Upload assets to GitHub Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
-        with:
-          tag_name: ${{ needs.release.outputs.new_release_git_tag }}
-          name: ${{ needs.release.outputs.new_release_git_tag }}
-          body_path: release-notes.md
-          files: artifacts/*
+      # `softprops/action-gh-release` lived here until it stranded v16.57.1. It
+      # creates the release as a draft, uploads the assets, then flips
+      # `draft=false` — and it has no retry on a 5xx. One asset upload sat for
+      # five minutes and came back as GitHub's 500 HTML error page, the action
+      # threw, the flip never ran, and the release stayed an invisible draft
+      # while `releases/latest` still pointed at the previous version. Nothing
+      # a user touches — `veld update`, install.sh, Desktop auto-update — reads
+      # a draft, so the release simply did not exist for them, and the only
+      # signal was a red X on a job whose log was a page of HTML.
+      #
+      # So the publish is spelled out here. Same draft-first ordering, because
+      # a release must never be visible carrying a partial asset set, plus
+      # three properties the action does not have:
+      #
+      #   * a 5xx or a hang is retried, and only the assets still missing are
+      #     re-sent — not the ~700 MB that already landed;
+      #   * "present" means the name AND the byte size AND `state == uploaded`
+      #     all match, so a truncated or still-uploading asset is replaced
+      #     rather than counted;
+      #   * the flip to published is *gated* on that set being empty. An
+      #     incomplete release cannot publish, and a complete one cannot be
+      #     left a draft.
+      #
+      # Re-running the job is the recovery path: it finds the existing draft,
+      # tops up whatever is missing, and publishes.
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # There is no checkout in this job, so gh cannot infer the repo.
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.release.outputs.new_release_git_tag }}
+        run: |
+          set -euo pipefail
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — topping it up."
+          else
+            gh release create "$TAG" --draft --title "$TAG" --notes-file release-notes.md
+          fi
+
+          # The same `-maxdepth 1 -type f` set the checksum step hashed, so the
+          # published assets and checksums.txt cannot describe different files.
+          mapfile -t expected < <(find artifacts -maxdepth 1 -type f | sort)
+          if [ "${#expected[@]}" -eq 0 ]; then
+            echo "::error::no artifacts to publish for $TAG"
+            exit 1
+          fi
+
+          # Sets the global `missing`. The `gh` read is not `|| true`-ed on
+          # purpose: under `set -e` a failed read aborts the job, so `missing`
+          # can only ever be computed from a release we actually saw. An empty
+          # `missing` therefore always means "complete", never "could not ask".
+          refresh_missing() {
+            gh release view "$TAG" --json assets \
+              --jq '.assets[] | select(.state == "uploaded") | "\(.name)\t\(.size)"' > have.tsv
+            declare -A have=()
+            local name size file
+            while IFS=$'\t' read -r name size; do
+              have["$name"]="$size"
+            done < have.tsv
+            missing=()
+            for file in "${expected[@]}"; do
+              name=$(basename "$file")
+              [ "${have[$name]-}" = "$(stat -c %s "$file")" ] || missing+=("$file")
+            done
+          }
+
+          backoff=15
+          for attempt in 1 2 3 4 5; do
+            refresh_missing
+            if [ "${#missing[@]}" -eq 0 ]; then
+              break
+            fi
+            if [ "$attempt" -gt 1 ]; then
+              echo "Retrying in ${backoff}s..."
+              sleep "$backoff"
+              backoff=$((backoff * 2))
+            fi
+            echo "Attempt $attempt: uploading ${#missing[@]} of ${#expected[@]} asset(s)."
+            # A hang, not an error, is what cost v16.57.1 — the request sat for
+            # five minutes before failing. Cap it and retry rather than wait it
+            # out. Killing an upload mid-flight leaves a partial asset, which
+            # the size/state check above catches next pass and `--clobber`
+            # overwrites, so the timeout cannot corrupt the release.
+            timeout 600 gh release upload "$TAG" "${missing[@]}" --clobber || true
+          done
+
+          refresh_missing
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "::error::$TAG is missing ${#missing[@]} asset(s) after 5 attempts; leaving it a draft"
+            printf '  %s\n' "${missing[@]}"
+            exit 1
+          fi
+
+          gh release edit "$TAG" --draft=false --latest
+          echo "Published $TAG with ${#expected[@]} assets."
 
   # ── Gateway container image (multi-arch, from the built binaries) ──
   docker-gateway:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -332,11 +332,12 @@ jobs:
       contents: write
     needs: [plan, release]
     runs-on: ubuntu-latest
-    # The publish step's own worst case is ~70 min: 5 upload attempts capped at
-    # 10 min each, 225 s of upload backoff, ~2 min of read backoff, and ~14 min
-    # of publish retries. 90 leaves room for the ~1 GB artifact download ahead
-    # of it, so a wedged publish fails on its own terms rather than being
-    # cancelled mid-flip with nothing in the log to say why.
+    # The publish step's own worst case is ~75 min, counting the `-k` grace
+    # periods: 5 upload attempts at 600+30 s = 52.5 min, 225 s of upload
+    # backoff, 5 publish attempts at 120+30 s plus 225 s of backoff = 16.25
+    # min, and ~4 min across the capped, retried reads. 90 leaves room for the
+    # ~1 GB artifact download ahead of it, so a wedged publish fails on its own
+    # terms rather than being cancelled mid-flip with nothing in the log.
     timeout-minutes: 90
     steps:
       - name: Download all artifacts
@@ -375,23 +376,23 @@ jobs:
       # a release must never be visible carrying a partial asset set, plus the
       # properties the action lacked:
       #
-      #   * every GitHub call retries — uploads, the reads that decide whether
-      #     an upload worked, and the flip that publishes. A single unretried
-      #     call is the whole incident;
+      #   * every GitHub call is retried AND time-capped — the probe, the
+      #     create, the uploads, the reads that decide whether an upload
+      #     worked, and the flip that publishes. One unretried call is the
+      #     whole incident, and the incident was a *hang*, not an error;
       #   * a retry re-sends only the assets still missing, not the ~700 MB
       #     that already landed;
       #   * "present" means the name AND the byte size AND `state == uploaded`
       #     all match, so a truncated or still-uploading asset is replaced
       #     rather than counted;
-      #   * the flip is gated on that set being empty, and read back afterwards
-      #     — `gh release edit` returning 0 is not the same as the release
-      #     being published.
+      #   * the flip is gated on that set being empty, and read back
+      #     afterwards — `gh release edit` returning 0 is not the same fact as
+      #     the release being published.
       #
       # The rule the whole step is built around: **every failure must fall
-      # toward "do not publish"**. Every serious defect an earlier review round
-      # found here was the same shape — a check that answered "complete" when
-      # it meant "could not tell". So each step below either establishes a fact
-      # or exits; none of them degrade quietly.
+      # toward "do not publish"**. Every serious defect review found here was
+      # the same shape — a check that answered "complete" when it meant "could
+      # not tell". So each step below either establishes a fact or exits.
       #
       # Re-running the job is the recovery path: it finds the existing draft,
       # tops up what is missing, and publishes.
@@ -420,7 +421,7 @@ jobs:
           # say so. That was already true of the checksum step; make it loud.
           find artifacts -mindepth 1 -maxdepth 1 -not -type f > nonfiles.txt
           if [ -s nonfiles.txt ]; then
-            echo "::error::artifacts/ holds non-file entries — an upload glob has re-rooted"
+            echo "::error::artifacts/ holds entries that are not regular files — an upload glob has re-rooted, or something produced a symlink:"
             cat nonfiles.txt
             exit 1
           fi
@@ -438,29 +439,62 @@ jobs:
             exit 1
           fi
 
-          # Two filename shapes this pipeline cannot carry. `#` is `gh release
-          # upload`'s asset-label separator, so the asset lands under a
-          # truncated name. A newline cannot survive the tab-separated asset
-          # listing the completeness check reads back, so the asset uploads and
-          # then reads as permanently missing. Either way the release fails
-          # identically on every re-run, so refuse them here, where the message
-          # can name the file. (Reading `expected` NUL-delimited above is what
-          # makes this check see the whole name rather than half of it.)
+          # GitHub rewrites characters it dislikes in an asset filename — a
+          # space becomes a `.` — and `gh release upload` reads `#` as an
+          # asset-label separator. Either way the asset lands under a name the
+          # completeness check below can never match, so the job would spend
+          # all five upload rounds and then strand the release as a draft that
+          # no re-run can clear: strictly worse than the incident this step
+          # exists to fix. A newline is worse still, since it cannot survive
+          # the tab-separated asset listing that check reads back.
+          #
+          # Rather than track GitHub's normalisation rules, require the
+          # conservative set every artifact this repo builds already uses, and
+          # fail where the message can still name the file.
           for file in "${expected[@]}"; do
-            case "$file" in
-              *'#'*)
-                echo "::error::artifact name contains '#', which gh reads as an asset label: $file"
-                exit 1 ;;
-              *$'\n'*)
-                echo "::error::artifact name contains a newline: ${file@Q}"
+            case ${file##*/} in
+              *[!A-Za-z0-9._+-]*)
+                echo "::error::artifact name is not safe as a release asset: ${file@Q}"
+                echo "  allowed characters: letters, digits, and . _ + -"
                 exit 1 ;;
             esac
           done
 
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Release $TAG already exists — topping it up."
-          else
-            gh release create "$TAG" --draft --title "$TAG" --notes-file release-notes.md
+          # One read of the release, capped and retried. Returns empty on
+          # failure, which every caller treats as "not yet" — the safe
+          # direction, since the alternative is acting on a fact we do not have.
+          release_field() {
+            timeout -k 10 60 gh release view "$TAG" --json "$1" --jq ".$1" 2>/dev/null || true
+          }
+
+          # The probe and the create are GitHub calls too. Leaving them bare
+          # meant the advertised top-up recovery was unavailable exactly when
+          # GitHub was flaky, which is the only time it is needed.
+          open_release() {
+            local attempt delay=5
+            for attempt in 1 2 3; do
+              if timeout -k 10 60 gh release view "$TAG" >/dev/null 2>&1; then
+                echo "Release $TAG already exists — topping it up."
+                return 0
+              fi
+              if timeout -k 10 120 gh release create "$TAG" --draft --title "$TAG" \
+                   --notes-file release-notes.md; then
+                return 0
+              fi
+              # Either the probe 5xx'd and the release does exist, or the
+              # create lost a race. Look again rather than calling it fatal.
+              echo "Could not open a release for $TAG (attempt $attempt/3)."
+              if [ "$attempt" -lt 3 ]; then
+                sleep "$delay"
+                delay=$((delay * 3))
+              fi
+            done
+            return 1
+          }
+
+          if ! open_release; then
+            echo "::error::could not create or find a release for $TAG"
+            exit 1
           fi
 
           # A 5xx on a read is the same failure class as a 5xx on an upload, so
@@ -470,7 +504,7 @@ jobs:
           read_assets() {
             local attempt delay=5
             for attempt in 1 2 3; do
-              if gh release view "$TAG" --json assets \
+              if timeout -k 10 60 gh release view "$TAG" --json assets \
                    --jq '.assets[] | select(.state == "uploaded") | "\(.name)\t\(.size)"' \
                    > have.tsv; then
                 return 0
@@ -541,14 +575,27 @@ jobs:
 
           # The flip is what makes the release exist for users, and leaving it
           # as one unretried call would have reproduced the original incident
-          # exactly: every asset up, and the release still invisible. It is also
-          # read back, because `gh release edit` exiting 0 is not the same fact
-          # as the release being published.
+          # exactly: every asset up, and the release still invisible. It is
+          # also read back, because the API accepting the call is not the same
+          # fact as the release having left draft.
+          #
+          # `make_latest=legacy` — not gh's `--latest`, which hard-sets
+          # `make_latest=true`. The difference shows on the recovery path this
+          # step advertises: publishing an OLD stranded draft after a newer
+          # release has shipped would, with `true`, re-point `releases/latest`
+          # backwards, and install.sh resolves `/releases/latest`, so every
+          # `curl | bash` install and `veld update` would silently downgrade.
+          # `legacy` lets GitHub choose by version and date, which is right for
+          # a normal release and for a late top-up alike.
           publish() {
-            local attempt delay=15
+            local attempt delay=15 id
             for attempt in 1 2 3 4 5; do
-              if timeout -k 30 120 gh release edit "$TAG" --draft=false --latest \
-                 && [ "$(gh release view "$TAG" --json isDraft --jq .isDraft)" = "false" ]; then
+              id=$(release_field databaseId)
+              if [ -n "$id" ]; then
+                timeout -k 30 120 gh api -X PATCH "repos/$GH_REPO/releases/$id" \
+                  -F draft=false -f make_latest=legacy >/dev/null 2>&1 || true
+              fi
+              if [ "$(release_field isDraft)" = "false" ]; then
                 return 0
               fi
               echo "$TAG is not published yet (attempt $attempt/5)."
@@ -561,7 +608,11 @@ jobs:
           }
 
           if ! publish; then
-            echo "::error::$TAG carries all ${#expected[@]} assets but could not be published; it is still a draft"
+            # Deliberately not "it is still a draft": reaching here can also
+            # mean the flip landed and only the read-back failed. Claiming the
+            # stronger fact would be the same mistake this step is built to
+            # avoid, one step further out.
+            echo "::error::$TAG carries all ${#expected[@]} assets but could not be confirmed published; re-run this job to check"
             exit 1
           fi
           echo "Published $TAG with ${#expected[@]} assets."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -332,9 +332,12 @@ jobs:
       contents: write
     needs: [plan, release]
     runs-on: ubuntu-latest
-    # Five upload attempts with backoff cannot outlast this, so a wedged
-    # publish fails in an hour rather than holding a runner for six.
-    timeout-minutes: 60
+    # The publish step's own worst case is ~70 min: 5 upload attempts capped at
+    # 10 min each, 225 s of upload backoff, ~2 min of read backoff, and ~14 min
+    # of publish retries. 90 leaves room for the ~1 GB artifact download ahead
+    # of it, so a wedged publish fails on its own terms rather than being
+    # cancelled mid-flip with nothing in the log to say why.
+    timeout-minutes: 90
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
@@ -369,20 +372,29 @@ jobs:
       # signal was a red X on a job whose log was a page of HTML.
       #
       # So the publish is spelled out here. Same draft-first ordering, because
-      # a release must never be visible carrying a partial asset set, plus
-      # three properties the action does not have:
+      # a release must never be visible carrying a partial asset set, plus the
+      # properties the action lacked:
       #
-      #   * a 5xx or a hang is retried, and only the assets still missing are
-      #     re-sent — not the ~700 MB that already landed;
+      #   * every GitHub call retries — uploads, the reads that decide whether
+      #     an upload worked, and the flip that publishes. A single unretried
+      #     call is the whole incident;
+      #   * a retry re-sends only the assets still missing, not the ~700 MB
+      #     that already landed;
       #   * "present" means the name AND the byte size AND `state == uploaded`
       #     all match, so a truncated or still-uploading asset is replaced
       #     rather than counted;
-      #   * the flip to published is *gated* on that set being empty. An
-      #     incomplete release cannot publish, and a complete one cannot be
-      #     left a draft.
+      #   * the flip is gated on that set being empty, and read back afterwards
+      #     — `gh release edit` returning 0 is not the same as the release
+      #     being published.
+      #
+      # The rule the whole step is built around: **every failure must fall
+      # toward "do not publish"**. Every serious defect an earlier review round
+      # found here was the same shape — a check that answered "complete" when
+      # it meant "could not tell". So each step below either establishes a fact
+      # or exits; none of them degrade quietly.
       #
       # Re-running the job is the recovery path: it finds the existing draft,
-      # tops up whatever is missing, and publishes.
+      # tops up what is missing, and publishes.
       - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -392,27 +404,93 @@ jobs:
         run: |
           set -euo pipefail
 
+          # An empty TAG is worse than a failure: `gh release view ""` returns
+          # the repo's *latest published* release with exit 0, so the script
+          # would read a previous release's assets, find them all "present",
+          # and report success having published nothing.
+          if [ -z "${TAG:-}" ]; then
+            echo "::error::the release job produced no tag"
+            exit 1
+          fi
+
+          # `artifacts/` has to be a flat directory of regular files. When an
+          # upload-artifact glob re-roots (see the note on the desktop job), it
+          # nests everything one level deeper, where `-maxdepth 1` silently
+          # misses it — a release with no app on it and nothing in the log to
+          # say so. That was already true of the checksum step; make it loud.
+          find artifacts -mindepth 1 -maxdepth 1 -not -type f > nonfiles.txt
+          if [ -s nonfiles.txt ]; then
+            echo "::error::artifacts/ holds non-file entries — an upload glob has re-rooted"
+            cat nonfiles.txt
+            exit 1
+          fi
+
+          # NUL-delimited, and written to a file rather than read through
+          # `mapfile < <(find ...)`. Two separate traps: process substitution
+          # hides the exit status from `set -e`, so a `find` that died halfway
+          # would yield a short list nothing downstream can tell from a
+          # complete one; and a newline in a filename would split one path into
+          # two line-delimited entries, neither of which names a real file.
+          find artifacts -maxdepth 1 -type f -print0 > expected.nul
+          mapfile -d '' -t expected < expected.nul
+          if [ "${#expected[@]}" -eq 0 ]; then
+            echo "::error::no artifacts to publish for $TAG"
+            exit 1
+          fi
+
+          # Two filename shapes this pipeline cannot carry. `#` is `gh release
+          # upload`'s asset-label separator, so the asset lands under a
+          # truncated name. A newline cannot survive the tab-separated asset
+          # listing the completeness check reads back, so the asset uploads and
+          # then reads as permanently missing. Either way the release fails
+          # identically on every re-run, so refuse them here, where the message
+          # can name the file. (Reading `expected` NUL-delimited above is what
+          # makes this check see the whole name rather than half of it.)
+          for file in "${expected[@]}"; do
+            case "$file" in
+              *'#'*)
+                echo "::error::artifact name contains '#', which gh reads as an asset label: $file"
+                exit 1 ;;
+              *$'\n'*)
+                echo "::error::artifact name contains a newline: ${file@Q}"
+                exit 1 ;;
+            esac
+          done
+
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists — topping it up."
           else
             gh release create "$TAG" --draft --title "$TAG" --notes-file release-notes.md
           fi
 
-          # The same `-maxdepth 1 -type f` set the checksum step hashed, so the
-          # published assets and checksums.txt cannot describe different files.
-          mapfile -t expected < <(find artifacts -maxdepth 1 -type f | sort)
-          if [ "${#expected[@]}" -eq 0 ]; then
-            echo "::error::no artifacts to publish for $TAG"
-            exit 1
-          fi
+          # A 5xx on a read is the same failure class as a 5xx on an upload, so
+          # it retries too. What it must never do is degrade to "assume
+          # nothing is missing" — hence the hard `return 1` rather than a
+          # `|| true`, and hence the caller aborting on it.
+          read_assets() {
+            local attempt delay=5
+            for attempt in 1 2 3; do
+              if gh release view "$TAG" --json assets \
+                   --jq '.assets[] | select(.state == "uploaded") | "\(.name)\t\(.size)"' \
+                   > have.tsv; then
+                return 0
+              fi
+              echo "Could not read $TAG (attempt $attempt/3)."
+              if [ "$attempt" -lt 3 ]; then
+                sleep "$delay"
+                delay=$((delay * 3))
+              fi
+            done
+            return 1
+          }
 
-          # Sets the global `missing`. The `gh` read is not `|| true`-ed on
-          # purpose: under `set -e` a failed read aborts the job, so `missing`
-          # can only ever be computed from a release we actually saw. An empty
-          # `missing` therefore always means "complete", never "could not ask".
+          # Sets the global `missing`. Every path out of here either reflects a
+          # release we actually read, or exits the job.
           refresh_missing() {
-            gh release view "$TAG" --json assets \
-              --jq '.assets[] | select(.state == "uploaded") | "\(.name)\t\(.size)"' > have.tsv
+            if ! read_assets; then
+              echo "::error::gave up reading $TAG; leaving it a draft rather than guessing"
+              exit 1
+            fi
             declare -A have=()
             local name size file
             while IFS=$'\t' read -r name size; do
@@ -421,7 +499,14 @@ jobs:
             missing=()
             for file in "${expected[@]}"; do
               name=$(basename "$file")
-              [ "${have[$name]-}" = "$(stat -c %s "$file")" ] || missing+=("$file")
+              # Measured on its own line so that a failed `stat` aborts the job.
+              # Inlined into the comparison it expands to "" — and "" is also
+              # what an absent asset compares as, so a file we could not measure
+              # scored as *present* and the release published without it.
+              size=$(stat -c %s "$file")
+              if [ "${have["$name"]-}" != "$size" ]; then
+                missing+=("$file")
+              fi
             done
           }
 
@@ -439,10 +524,12 @@ jobs:
             echo "Attempt $attempt: uploading ${#missing[@]} of ${#expected[@]} asset(s)."
             # A hang, not an error, is what cost v16.57.1 — the request sat for
             # five minutes before failing. Cap it and retry rather than wait it
-            # out. Killing an upload mid-flight leaves a partial asset, which
-            # the size/state check above catches next pass and `--clobber`
-            # overwrites, so the timeout cannot corrupt the release.
-            timeout 600 gh release upload "$TAG" "${missing[@]}" --clobber || true
+            # out; `-k` because a wedged `gh` that ignores SIGTERM would
+            # otherwise hold the job to its own ceiling. Killing an upload
+            # mid-flight leaves a partial asset, which the size/state check
+            # catches next pass and `--clobber` overwrites, so the timeout
+            # cannot corrupt the release.
+            timeout -k 30 600 gh release upload "$TAG" "${missing[@]}" --clobber || true
           done
 
           refresh_missing
@@ -452,7 +539,31 @@ jobs:
             exit 1
           fi
 
-          gh release edit "$TAG" --draft=false --latest
+          # The flip is what makes the release exist for users, and leaving it
+          # as one unretried call would have reproduced the original incident
+          # exactly: every asset up, and the release still invisible. It is also
+          # read back, because `gh release edit` exiting 0 is not the same fact
+          # as the release being published.
+          publish() {
+            local attempt delay=15
+            for attempt in 1 2 3 4 5; do
+              if timeout -k 30 120 gh release edit "$TAG" --draft=false --latest \
+                 && [ "$(gh release view "$TAG" --json isDraft --jq .isDraft)" = "false" ]; then
+                return 0
+              fi
+              echo "$TAG is not published yet (attempt $attempt/5)."
+              if [ "$attempt" -lt 5 ]; then
+                sleep "$delay"
+                delay=$((delay * 2))
+              fi
+            done
+            return 1
+          }
+
+          if ! publish; then
+            echo "::error::$TAG carries all ${#expected[@]} assets but could not be published; it is still a draft"
+            exit 1
+          fi
           echo "Published $TAG with ${#expected[@]} assets."
 
   # ── Gateway container image (multi-arch, from the built binaries) ──

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,7 +244,7 @@ just dev-restore    # runs veld update
 | `just build` | Build Rust + frontend | No |
 | `just test` | Run all tests | No |
 | `just lint` | Clippy + rustfmt + TypeScript type check + JS/TS Biome lint | No |
-| `just workflow-gates` | Assert no CI job can run on a draft PR. Needs PyYAML: `python3 -m pip install --user pyyaml` | No |
+| `just workflow-gates` | Two workflow gates: no CI job can run on a draft PR, and `release.yml`'s publish script cannot ship an incomplete release or leave a complete one a draft. Run it whenever you touch `.github/workflows/`. Needs PyYAML: `python3 -m pip install --user pyyaml` | No |
 | `just commit-subjects` | Check your commit subjects against the conventional-commits pattern CI enforces | No |
 
 > **Git hooks (optional, recommended):** the repo ships `lefthook.yml`, a

--- a/docs/agentic-review.md
+++ b/docs/agentic-review.md
@@ -173,7 +173,10 @@ Capture output verbatim.
   new job is discovered only once the five macOS legs have already dispatched.
   `just workflow-gates` is the sole thing standing between an unguarded job and a
   draft that quietly runs it, because the gate's CI home (the `schema` job) is
-  draft-guarded too.
+  draft-guarded too. It now carries a second gate in the same recipe:
+  `release.yml`'s publish script, which a subagent reading a diff cannot
+  exercise at all — it is run against a stub `gh` and held to the rule that a
+  failure must fall toward *not* publishing.
 - **Everything the pre-pass reports is out of scope for every subagent.** Put
   this line in every brief: *"The typechecker, linter and tests already ran;
   their output is in the context pack. Do not re-report it. Findings that

--- a/justfile
+++ b/justfile
@@ -457,21 +457,24 @@ favicon:
 topbar-height:
     ./tests/validate-topbar-height.sh
 
-# Assert no CI job can run on a draft PR (AGENTS.md → CI cost convention).
-# Deliberately not folded into `lint`: this needs PyYAML, and `lint` is the
+# The two gates over .github/workflows/. Run this whenever you touch one.
+#
+#   1. No CI job can run on a draft PR (AGENTS.md → CI cost convention).
+#   2. release.yml's publish script cannot ship an incomplete release, or
+#      leave a complete one stranded as a draft — which is what
+#      softprops/action-gh-release did to v16.57.1.
+#
+# Deliberately not folded into `lint`: these need PyYAML, and `lint` is the
 # recipe every contributor runs constantly — it must not grow a Python dep.
 # Install it with `python3 -m pip install --user pyyaml`.
 # The `schema` job in ci.yml is the enforcing copy — and because that job is
-# itself draft-guarded, this local recipe is the ONLY thing that catches an
-# unguarded job before it has already run on a draft push. Run it whenever you
-# touch .github/workflows/.
+# itself draft-guarded, this local recipe is the ONLY thing that catches either
+# failure before CI has already spent a run on it.
 workflow-gates:
     python3 tests/validate-workflow-gates.py --selftest
     python3 tests/validate-workflow-gates.py
-    # Same recipe because it has the same trigger — you touched
-    # .github/workflows/ — and the same PyYAML dep. This one runs release.yml's
-    # publish script against a stub `gh`; see the header there for what
-    # `softprops/action-gh-release` did to v16.57.1.
+    # --selftest first, same reasoning as above: it mutates the completeness
+    # gate out of the publish script and asserts the suite goes red.
     python3 tests/validate-release-publish.py --selftest
     python3 tests/validate-release-publish.py
 

--- a/justfile
+++ b/justfile
@@ -468,6 +468,12 @@ topbar-height:
 workflow-gates:
     python3 tests/validate-workflow-gates.py --selftest
     python3 tests/validate-workflow-gates.py
+    # Same recipe because it has the same trigger — you touched
+    # .github/workflows/ — and the same PyYAML dep. This one runs release.yml's
+    # publish script against a stub `gh`; see the header there for what
+    # `softprops/action-gh-release` did to v16.57.1.
+    python3 tests/validate-release-publish.py --selftest
+    python3 tests/validate-release-publish.py
 
 # Check commit subjects against the pattern the `commits` job enforces. That job
 # is draft-guarded too, so without this a malformed subject is discovered only

--- a/tests/validate-release-publish.py
+++ b/tests/validate-release-publish.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""Execute release.yml's publish script against a stub `gh` and assert its invariants.
+
+`softprops/action-gh-release` stranded v16.57.1: it uploads assets to a draft
+release and then flips `draft=false`, has no retry on a 5xx, and one asset
+upload came back as GitHub's 500 HTML page.  The action threw, the flip never
+ran, and the release sat invisible as a draft while `releases/latest` still
+pointed at the previous version — `veld update`, install.sh and Desktop
+auto-update all read `latest`, so for every user the release simply did not
+exist.  The replacement lives inline in the workflow and owns four properties
+that nothing else in this repo can check:
+
+  * a complete upload publishes;
+  * a transient failure retries **only the assets still missing**, not the
+    ~700 MB that already landed;
+  * an asset that is present but wrong — truncated, or still `state=starter` —
+    counts as missing;
+  * a release that is *not* complete is never published, including when the
+    reason is that GitHub could not be read at all.
+
+The last one is the load-bearing one, and its failure is silent: an incomplete
+or stranded release looks like a red X on a job nobody re-reads.  So this gate
+runs the real script — extracted from the workflow, never a copy — and
+`--selftest` mutates the gate out of it to prove these scenarios would actually
+notice if someone deleted it.
+
+Needs PyYAML, same as validate-workflow-gates.py; both are run by
+`just workflow-gates` and by the `schema` job in ci.yml.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO / ".github" / "workflows" / "release.yml"
+STEP_NAME = "Publish GitHub Release"
+JOB = "publish"
+
+# The stub speaks only the `gh` surface the script uses.  Release state is a
+# TSV of name/size/state, so an asset can be present-but-wrong (`starter`, or a
+# short byte count) — the cases a name-only presence check would wave through.
+GH_STUB = r"""#!/usr/bin/env bash
+set -uo pipefail
+echo "$*" >> "$GHLOG"
+drop() { awk -F'\t' -v n="$1" '$1!=n' "$STATE" > "$STATE.tmp"; mv "$STATE.tmp" "$STATE"; }
+put()  { drop "$1"; printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "$STATE"; }
+case "${1-} ${2-}" in
+  "release view")
+    [ -f "$STATE" ] || exit 1
+    if [ "${4-}" = "--json" ]; then
+      # The one call whose failure must abort the script rather than read as
+      # "nothing is missing".
+      [ "${FAIL_VIEW-0}" = "1" ] && { echo "gh: 500 Internal Server Error" >&2; exit 1; }
+      awk -F'\t' '$3=="uploaded"{print $1"\t"$2}' "$STATE"
+    fi
+    exit 0 ;;
+  "release create")
+    : > "$STATE"; echo draft > "$DRAFTF"; exit 0 ;;
+  "release upload")
+    shift 3
+    files=(); for a in "$@"; do [ "$a" = "--clobber" ] || files+=("$a"); done
+    attempt=$(cat "$ATTEMPT"); rc=0
+    for f in "${files[@]}"; do
+      name=$(basename "$f"); size=$(( $(wc -c < "$f") ))
+      if [[ ",${FAIL_FILES-}," == *",$name,"* ]] && [ "$attempt" -le "${FAIL_UNTIL-99}" ]; then
+        case "${FAIL_MODE-error}" in
+          starter)   put "$name" "$((size / 2))" starter ;;
+          truncated) put "$name" "$((size - 1))" uploaded ;;
+        esac
+        rc=1; continue
+      fi
+      put "$name" "$size" uploaded
+    done
+    echo $((attempt + 1)) > "$ATTEMPT"
+    exit $rc ;;
+  "release edit")
+    echo published > "$DRAFTF"; exit 0 ;;
+esac
+exit 0
+"""
+
+# Asserts the exact GNU flags the script passes before emulating them, so a
+# typo'd `stat` call fails the suite instead of quietly measuring nothing.
+STAT_STUB = r"""#!/usr/bin/env bash
+if [ "${1-}" != "-c" ] || [ "${2-}" != "%s" ]; then
+  echo "stat stub: expected '-c %s', got: $*" >&2; exit 64
+fi
+wc -c < "$3" | tr -d ' '
+"""
+
+# Likewise for `timeout`: assert a numeric budget, then run the command. A hang
+# was what cost v16.57.1, so the script losing its timeout is worth catching.
+TIMEOUT_STUB = r"""#!/usr/bin/env bash
+case "${1-}" in
+  ''|*[!0-9]*) echo "timeout stub: expected seconds, got: $*" >&2; exit 64 ;;
+esac
+shift
+exec "$@"
+"""
+
+# No-op so the suite does not sit through the real backoff; the requested
+# delays are recorded instead and asserted separately.
+SLEEP_STUB = r"""#!/usr/bin/env bash
+echo "$1" >> "$SLEEPLOG"
+"""
+
+ARTIFACTS = ["veld-1.2.3-linux-amd64.tar.gz", "veld-desktop-1.2.3-mac-x64.zip",
+             "veld-desktop-1.2.3-mac-x64.zip.blockmap", "checksums.txt"]
+
+
+def publish_script() -> str:
+    """The script as the workflow actually ships it — never a transcription."""
+    doc = yaml.safe_load(WORKFLOW.read_text())
+    try:
+        steps = doc["jobs"][JOB]["steps"]
+    except (KeyError, TypeError):
+        sys.exit(f"{WORKFLOW.name}: no `{JOB}` job with steps")
+    for step in steps:
+        if step.get("name") == STEP_NAME:
+            script = step.get("run") or ""
+            # A rename upstream would otherwise leave this gate testing an empty
+            # string and reporting a clean bill of health.
+            if "gh release edit" not in script:
+                sys.exit(f"step {STEP_NAME!r} no longer publishes the release")
+            return script
+    sys.exit(
+        f"{WORKFLOW.name}: job `{JOB}` has no step named {STEP_NAME!r}. "
+        "If the publish step was renamed, update STEP_NAME here — this gate is "
+        "the only check that an incomplete release cannot publish."
+    )
+
+
+class Result:
+    def __init__(self, code: int, out: str, state: dict[str, tuple[int, str]],
+                 uploads: list[list[str]], sleeps: list[str], draft: str):
+        self.code, self.out, self.state = code, out, state
+        self.uploads, self.sleeps, self.draft = uploads, sleeps, draft
+
+    @property
+    def published(self) -> bool:
+        return self.draft == "published"
+
+
+def run(script: str, env_overrides: dict[str, str] | None = None,
+        artifacts: list[str] = ARTIFACTS, preseed: list[str] | None = None) -> Result:
+    with tempfile.TemporaryDirectory() as tmp:
+        work = Path(tmp)
+        binw = work / "bin"
+        binw.mkdir()
+        for name, body in (("gh", GH_STUB), ("stat", STAT_STUB),
+                           ("timeout", TIMEOUT_STUB), ("sleep", SLEEP_STUB)):
+            path = binw / name
+            path.write_text(body)
+            path.chmod(0o755)
+
+        (work / "artifacts").mkdir()
+        for i, name in enumerate(artifacts):
+            # Distinct sizes so a size comparison cannot pass by coincidence.
+            (work / "artifacts" / name).write_bytes(b"x" * (1024 + i * 37))
+        (work / "release-notes.md").write_text("notes\n")
+
+        state, draftf = work / "state.tsv", work / "draft"
+        ghlog, sleeplog, attempt = work / "gh.log", work / "sleep.log", work / "attempt"
+        attempt.write_text("1\n")
+        ghlog.touch()
+        sleeplog.touch()
+        if preseed is not None:
+            # A re-run of the job: the draft already exists, carrying some assets.
+            draftf.write_text("draft\n")
+            state.write_text("".join(
+                f"{n}\t{(work / 'artifacts' / n).stat().st_size}\tuploaded\n"
+                for n in preseed))
+
+        env = {
+            **os.environ,
+            "PATH": f"{binw}{os.pathsep}{os.environ['PATH']}",
+            "TAG": "v1.2.3",
+            "STATE": str(state), "DRAFTF": str(draftf),
+            "GHLOG": str(ghlog), "SLEEPLOG": str(sleeplog), "ATTEMPT": str(attempt),
+            **(env_overrides or {}),
+        }
+        proc = subprocess.run([BASH, "-c", script], cwd=work, env=env,
+                              capture_output=True, text=True, timeout=120)
+
+        parsed: dict[str, tuple[int, str]] = {}
+        if state.exists():
+            for line in state.read_text().splitlines():
+                if line.strip():
+                    name, size, st = line.split("\t")
+                    parsed[name] = (int(size), st)
+        uploads = [ln.split()[3:] for ln in ghlog.read_text().splitlines()
+                   if ln.startswith("release upload")]
+        uploads = [[Path(a).name for a in u if a != "--clobber"] for u in uploads]
+
+        return Result(proc.returncode, proc.stdout + proc.stderr, parsed, uploads,
+                      sleeplog.read_text().split(),
+                      draftf.read_text().strip() if draftf.exists() else "none")
+
+
+FAILURES: list[str] = []
+
+
+def check(label: str, condition: bool, detail: str = "") -> None:
+    if condition:
+        print(f"  ok  {label}")
+    else:
+        print(f"  FAIL {label}{(': ' + detail) if detail else ''}")
+        FAILURES.append(label)
+
+
+def scenario_complete(script: str) -> None:
+    r = run(script)
+    check("a complete upload publishes the release", r.published and r.code == 0,
+          f"code={r.code} draft={r.draft}")
+    check("every artifact lands as an asset",
+          sorted(r.state) == sorted(ARTIFACTS), f"{sorted(r.state)}")
+    check("a clean run uploads once, not once per file", len(r.uploads) == 1,
+          f"{len(r.uploads)} upload calls")
+
+
+def scenario_transient_5xx(script: str) -> None:
+    """The v16.57.1 failure itself: one asset 5xxs, the rest already landed."""
+    stranded = "veld-desktop-1.2.3-mac-x64.zip.blockmap"
+    r = run(script, {"FAIL_FILES": stranded, "FAIL_UNTIL": "2", "FAIL_MODE": "error"})
+    check("a transient 5xx on one asset still publishes", r.published and r.code == 0,
+          f"code={r.code} draft={r.draft}")
+    check("the retry re-sends only what is missing",
+          all(u == [stranded] for u in r.uploads[1:]) and len(r.uploads) == 3,
+          f"{r.uploads}")
+    check("backoff grows between attempts", r.sleeps == ["15", "30"], f"{r.sleeps}")
+
+
+def scenario_present_but_wrong(script: str) -> None:
+    for mode, label in (("starter", "an asset still uploading"),
+                        ("truncated", "an asset with the wrong byte count")):
+        victim = "veld-desktop-1.2.3-mac-x64.zip"
+        r = run(script, {"FAIL_FILES": victim, "FAIL_UNTIL": "1", "FAIL_MODE": mode})
+        check(f"{label} is re-uploaded, not counted as present",
+              r.published and r.state.get(victim, (0, ""))[1] == "uploaded"
+              and len(r.uploads) == 2 and r.uploads[1] == [victim],
+              f"state={r.state.get(victim)} uploads={r.uploads}")
+
+
+def scenario_never_completes(script: str) -> bool:
+    """The gate. Returns whether it held, so --selftest can assert it can fail."""
+    r = run(script, {"FAIL_FILES": "checksums.txt", "FAIL_UNTIL": "99"})
+    held = r.code != 0 and not r.published
+    check("an incomplete release is never published, and fails the job", held,
+          f"code={r.code} draft={r.draft}")
+    check("the error names the tag and says it stayed a draft",
+          "v1.2.3" in r.out and "draft" in r.out, r.out[-200:])
+    return held
+
+
+def scenario_unreadable_release(script: str) -> None:
+    r = run(script, {"FAIL_VIEW": "1"})
+    check("a release that cannot be read is never published",
+          r.code != 0 and not r.published, f"code={r.code} draft={r.draft}")
+    # Swallowing the read failure keeps the release safe — an empty asset list
+    # reads as "everything is missing", so the gate still fires — but it does so
+    # after five rounds of re-pushing every artifact at an API that is down.
+    # Aborting on the first failed read is the difference, so assert it directly.
+    check("an unreadable release fails fast, without uploading anything",
+          r.uploads == [], f"{len(r.uploads)} upload call(s)")
+
+
+def scenario_rerun(script: str) -> None:
+    already = ARTIFACTS[:2]
+    r = run(script, preseed=already)
+    check("a re-run tops up an existing draft and publishes",
+          r.published and r.code == 0, f"code={r.code} draft={r.draft}")
+    check("a re-run does not re-upload assets already on the release",
+          len(r.uploads) == 1 and sorted(r.uploads[0]) == sorted(ARTIFACTS[2:]),
+          f"{r.uploads}")
+
+
+def scenario_no_artifacts(script: str) -> None:
+    r = run(script, artifacts=[])
+    check("an empty artifact set fails instead of publishing an empty release",
+          r.code != 0 and not r.published, f"code={r.code} draft={r.draft}")
+
+
+def selftest(script: str) -> None:
+    """Mutate the gate out and assert the suite notices.
+
+    Without this, `scenario_never_completes` could be passing because the script
+    fails for some unrelated reason rather than because the gate is there — the
+    same trap `validate-workflow-gates.py --selftest` exists for.
+    """
+    print("Self-test: removing the completeness gate should break the suite")
+    lines = script.splitlines()
+    try:
+        start = next(i for i, ln in enumerate(lines)
+                     if 'if [ "${#missing[@]}" -ne 0 ]' in ln)
+    except StopIteration:
+        sys.exit("self-test: could not find the completeness gate to mutate — "
+                 "it was renamed or removed, and this suite no longer proves it exists")
+    end = next(i for i in range(start, len(lines)) if lines[i].strip() == "fi")
+    mutated = "\n".join(lines[:start] + lines[end + 1:])
+
+    r = run(mutated, {"FAIL_FILES": "checksums.txt", "FAIL_UNTIL": "99"})
+    if not r.published:
+        sys.exit("self-test FAILED: the mutant refused to publish an incomplete "
+                 "release anyway, so the scenario is not testing the gate")
+    print("  ok  the mutant publishes an incomplete release, as it must to be caught")
+
+
+def main() -> int:
+    script = publish_script()
+
+    if "--selftest" in sys.argv:
+        selftest(script)
+        return 0
+
+    print(f"Release publish gate — {WORKFLOW.name} → {JOB} → {STEP_NAME!r}")
+    scenario_complete(script)
+    scenario_transient_5xx(script)
+    scenario_present_but_wrong(script)
+    scenario_never_completes(script)
+    scenario_unreadable_release(script)
+    scenario_rerun(script)
+    scenario_no_artifacts(script)
+
+    if FAILURES:
+        print(f"\n{len(FAILURES)} failure(s):")
+        for f in FAILURES:
+            print(f"  - {f}")
+        return 1
+    print("\nAll release publish invariants hold.")
+    return 0
+
+
+def find_bash() -> str:
+    """bash 4+ — the script uses `mapfile` and associative arrays.
+
+    ubuntu-latest ships bash 5. macOS still ships 3.2 as /bin/bash, so a
+    contributor running `just workflow-gates` locally needs Homebrew's.
+    """
+    candidates = [os.environ["BASH_BIN"]] if os.environ.get("BASH_BIN") else [
+        "/opt/homebrew/bin/bash", "/usr/local/bin/bash", "/bin/bash"]
+    for candidate in candidates:
+        path = shutil.which(candidate)
+        if path and subprocess.run([path, "-c", "((BASH_VERSINFO[0] >= 4))"],
+                                   capture_output=True).returncode == 0:
+            return path
+    sys.exit("no bash >= 4 found (macOS /bin/bash is 3.2): `brew install bash`, "
+             "or point BASH_BIN at one.")
+
+
+BASH = find_bash()
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/validate-release-publish.py
+++ b/tests/validate-release-publish.py
@@ -81,8 +81,15 @@ case "$sub" in
       esac
     done
     # Bare `gh release view <tag>` is the existence probe.
+    if [ -z "$json" ]; then
+      probes=$(cat "$PROBES"); echo $((probes + 1)) > "$PROBES"
+      if [ "$probes" -lt "${FAIL_PROBE_UNTIL-0}" ]; then
+        echo "gh: 500 Internal Server Error" >&2; exit 1
+      fi
+      [ -f "$STATE" ] || exit 1
+      exit 0
+    fi
     [ -f "$STATE" ] || exit 1
-    [ -n "$json" ] || exit 0
     if [ "${FAIL_VIEW-0}" = "1" ]; then
       echo "gh: 500 Internal Server Error" >&2; exit 1
     fi
@@ -221,7 +228,7 @@ ARTIFACTS = ["veld-1.2.3-linux-amd64.tar.gz", "veld-desktop-1.2.3-mac-x64.zip",
 # Stub-control variables must not leak in from the caller's environment, or
 # `FAIL_VIEW=1 just workflow-gates` silently reconfigures every scenario.
 STUB_VARS = {"FAIL_FILES", "FAIL_UNTIL", "FAIL_MODE", "FAIL_VIEW", "FAIL_EDIT_UNTIL",
-             "EDIT_SILENT", "STAT_FAIL", "STATE", "DRAFTF", "GHLOG", "SLEEPLOG",
+             "EDIT_SILENT", "STAT_FAIL", "FAIL_PROBE_UNTIL", "PROBES", "STATE", "DRAFTF", "GHLOG", "SLEEPLOG",
              "TIMEOUTLOG", "ATTEMPT", "EDITS", "NOTESF", "LATESTF", "CREATEDRAFTF",
              "TAG", "GH_REPO"}
 
@@ -283,11 +290,12 @@ def run(script: str, env_overrides: dict[str, str] | None = None,
 
         files = {k: work / f"{k}.txt" for k in
                  ("state", "draft", "gh", "sleep", "timeout", "attempt", "edits",
-                  "notes", "latest", "createdraft")}
+                  "notes", "latest", "createdraft", "probes")}
         for f in files.values():
             f.touch()
         files["attempt"].write_text("1\n")
         files["edits"].write_text("0\n")
+        files["probes"].write_text("0\n")
         if preseed is not None:
             # A re-run of the job: the draft exists, carrying some assets.
             files["draft"].write_text("draft\n")
@@ -308,6 +316,7 @@ def run(script: str, env_overrides: dict[str, str] | None = None,
             "EDITS": str(files["edits"]), "NOTESF": str(files["notes"]),
             "LATESTF": str(files["latest"]),
             "CREATEDRAFTF": str(files["createdraft"]),
+            "PROBES": str(files["probes"]),
             **(env_overrides or {}),
         })
         proc = subprocess.run([BASH, "-c", script], cwd=work, env=env,
@@ -537,6 +546,39 @@ def scenario_clobber(script: str) -> None:
 
 # ── wiring ───────────────────────────────────────────────────────────────────
 
+def scenario_every_github_call_is_capped(script: str) -> None:
+    """The step header claims every GitHub call is retried AND time-capped.
+
+    A runtime check can only observe that *some* call was wrapped — with
+    several call sites, dropping the cap from one of them stays green. This
+    reads the script and holds every site to the claim.
+    """
+    uncapped = []
+    for lineno, line in enumerate(script.splitlines(), 1):
+        text = line.strip()
+        if text.startswith("#"):
+            continue
+        for call in ("gh release view", "gh release upload",
+                     "gh release create", "gh api"):
+            if call in text and "timeout -k" not in text:
+                uncapped.append(f"line {lineno}: {text[:60]}")
+    check("every GitHub call in the script is wrapped in a timeout",
+          not uncapped, "; ".join(uncapped))
+
+
+def scenario_probe_retries(script: str) -> None:
+    """A 5xx on the existence probe must not send a re-run into `release create`.
+
+    Real gh refuses to create a release for a tag that already has one, so
+    without the retry a transient 5xx on the probe fails the job — and the
+    probe is only reached on the top-up path, which is precisely the recovery
+    this step advertises for when GitHub is flaky.
+    """
+    r = run(script, {"FAIL_PROBE_UNTIL": "2"}, preseed=ARTIFACTS[:2])
+    check("a 5xx on the existence probe is retried, not treated as absent",
+          r.published and r.code == 0, f"code={r.code} draft={r.draft}")
+
+
 def scenario_step_env(step: dict) -> None:
     env = set(step.get("env") or {})
     check(f"the step passes {', '.join(sorted(REQUIRED_ENV))} to the script",
@@ -600,6 +642,8 @@ def main() -> int:
     scenario_refused_inputs(script)
     scenario_rerun(script)
     scenario_clobber(script)
+    scenario_every_github_call_is_capped(script)
+    scenario_probe_retries(script)
     scenario_step_env(step)
 
     if FAILURES:

--- a/tests/validate-release-publish.py
+++ b/tests/validate-release-publish.py
@@ -65,6 +65,9 @@ die64() { echo "gh stub: $1" >&2; exit 64; }
 
 sub="${1-} ${2-}"
 shift 2 2>/dev/null || true
+# `gh api -X PATCH <path> ...`: drop the verb so the path is $1, as it is for
+# the `release <verb> <tag>` forms.
+[ "$sub" = "api -X" ] && shift 2>/dev/null || true
 
 case "$sub" in
   "release view")
@@ -74,7 +77,7 @@ case "$sub" in
       case "$1" in
         --json) json=${2-}; shift 2 ;;
         --jq)   jq=${2-}; shift 2 ;;
-        *)      die64 "unmodelled `release view` flag: $1" ;;
+        *)      die64 "unmodelled release-view flag: $1" ;;
       esac
     done
     # Bare `gh release view <tag>` is the existence probe.
@@ -88,6 +91,8 @@ case "$sub" in
         awk -F'\t' '$3=="uploaded"{print $1"\t"$2}' "$STATE" ;;
       'isDraft|.isDraft')
         if [ "$(cat "$DRAFTF")" = "draft" ]; then echo true; else echo false; fi ;;
+      'databaseId|.databaseId')
+        echo 4242 ;;
       *)
         die64 "unmodelled query --json '$json' --jq '$jq'" ;;
     esac
@@ -101,9 +106,15 @@ case "$sub" in
         --draft)      draft=draft; shift ;;
         --title)      shift 2 ;;
         --notes-file) if [ -f "${2-}" ]; then notes=ok; else notes=missing; fi; shift 2 ;;
-        *)            die64 "unmodelled `release create` flag: $1" ;;
+        *)            die64 "unmodelled release-create flag: $1" ;;
       esac
     done
+    # Real gh refuses a tag that already carries a release; without this the
+    # stub would silently wipe a preseeded draft's assets and re-upload them.
+    if [ -f "$STATE" ]; then
+      echo "gh: a release for $TAG already exists" >&2; exit 1
+    fi
+    if [ "$draft" = draft ]; then echo yes > "$CREATEDRAFTF"; else echo no > "$CREATEDRAFTF"; fi
     : > "$STATE"; echo "$draft" > "$DRAFTF"; echo "$notes" > "$NOTESF"
     exit 0 ;;
 
@@ -134,22 +145,27 @@ case "$sub" in
     echo $((attempt + 1)) > "$ATTEMPT"
     exit $rc ;;
 
-  "release edit")
-    shift 2>/dev/null || true          # the tag
+  "api -X")
+    # `gh api -X PATCH repos/<repo>/releases/<id> -F draft=false -f make_latest=...`
+    shift 2>/dev/null || true          # the path
     edits=$(cat "$EDITS"); echo $((edits + 1)) > "$EDITS"
     if [ "$edits" -lt "${FAIL_EDIT_UNTIL-0}" ]; then
       echo "gh: 502 Bad Gateway" >&2; exit 1
     fi
-    want=""; latest=0
+    want=""
     while [ $# -gt 0 ]; do
       case "$1" in
-        --draft=false) want=published; shift ;;
-        --draft=true|--draft) want=draft; shift ;;
-        --latest) latest=1; shift ;;
-        *) die64 "unmodelled `release edit` flag: $1" ;;
+        -F|-f)
+          case "${2-}" in
+            draft=false)      want=published ;;
+            draft=true)       want=draft ;;
+            make_latest=*)    echo "${2#make_latest=}" > "$LATESTF" ;;
+            *)                die64 "unmodelled api field: ${2-}" ;;
+          esac
+          shift 2 ;;
+        *) die64 "unmodelled api flag: $1" ;;
       esac
     done
-    echo "$latest" > "$LATESTF"
     # EDIT_SILENT models the API accepting the call without the release
     # actually leaving draft — the case the script reads back to catch.
     if [ "${EDIT_SILENT-0}" = "1" ]; then exit 0; fi
@@ -184,8 +200,12 @@ while [ $# -gt 0 ]; do
     *) args+=("$1"); shift ;;
   esac
 done
-if [ ${#args[@]} -eq 0 ]; then
-  echo "timeout stub: no duration in: $*" >&2; exit 64
+secs=""
+for a in ${args[@]+"${args[@]}"}; do
+  case "$a" in ''|*[!0-9]*) ;; *) secs=$a ;; esac
+done
+if [ -z "$secs" ]; then
+  echo "timeout stub: no duration (only $* )" >&2; exit 64
 fi
 echo "${args[*]} :: $*" >> "$TIMEOUTLOG"
 exec "$@"
@@ -202,7 +222,8 @@ ARTIFACTS = ["veld-1.2.3-linux-amd64.tar.gz", "veld-desktop-1.2.3-mac-x64.zip",
 # `FAIL_VIEW=1 just workflow-gates` silently reconfigures every scenario.
 STUB_VARS = {"FAIL_FILES", "FAIL_UNTIL", "FAIL_MODE", "FAIL_VIEW", "FAIL_EDIT_UNTIL",
              "EDIT_SILENT", "STAT_FAIL", "STATE", "DRAFTF", "GHLOG", "SLEEPLOG",
-             "TIMEOUTLOG", "ATTEMPT", "EDITS", "NOTESF", "LATESTF", "TAG"}
+             "TIMEOUTLOG", "ATTEMPT", "EDITS", "NOTESF", "LATESTF", "CREATEDRAFTF",
+             "TAG", "GH_REPO"}
 
 
 def publish_step() -> dict:
@@ -215,7 +236,7 @@ def publish_step() -> dict:
         if step.get("name") == STEP_NAME:
             # A rename upstream would otherwise leave this gate running an
             # empty string and reporting a clean bill of health.
-            if "gh release edit" not in (step.get("run") or ""):
+            if "draft=false" not in (step.get("run") or ""):
                 sys.exit(f"step {STEP_NAME!r} no longer publishes the release")
             return step
     sys.exit(
@@ -227,10 +248,11 @@ def publish_step() -> dict:
 
 class Result:
     def __init__(self, code, out, state, uploads, sleeps, timeouts, draft,
-                 notes, latest, edits):
+                 notes, latest, edits, created_draft):
         self.code, self.out, self.state = code, out, state
         self.uploads, self.sleeps, self.timeouts = uploads, sleeps, timeouts
         self.draft, self.notes, self.latest, self.edits = draft, notes, latest, edits
+        self.created_draft = created_draft
 
     @property
     def published(self) -> bool:
@@ -261,7 +283,7 @@ def run(script: str, env_overrides: dict[str, str] | None = None,
 
         files = {k: work / f"{k}.txt" for k in
                  ("state", "draft", "gh", "sleep", "timeout", "attempt", "edits",
-                  "notes", "latest")}
+                  "notes", "latest", "createdraft")}
         for f in files.values():
             f.touch()
         files["attempt"].write_text("1\n")
@@ -279,18 +301,21 @@ def run(script: str, env_overrides: dict[str, str] | None = None,
         env.update({
             "PATH": f"{binw}{os.pathsep}{os.environ['PATH']}",
             "TAG": tag,
+            "GH_REPO": "example/veld",
             "STATE": str(files["state"]), "DRAFTF": str(files["draft"]),
             "GHLOG": str(files["gh"]), "SLEEPLOG": str(files["sleep"]),
             "TIMEOUTLOG": str(files["timeout"]), "ATTEMPT": str(files["attempt"]),
             "EDITS": str(files["edits"]), "NOTESF": str(files["notes"]),
             "LATESTF": str(files["latest"]),
+            "CREATEDRAFTF": str(files["createdraft"]),
             **(env_overrides or {}),
         })
         proc = subprocess.run([BASH, "-c", script], cwd=work, env=env,
                               capture_output=True, text=True, timeout=180)
 
-        # Records are `name\tsize\tstate\n`, and an asset name may itself
-        # contain a newline — the script handles those, so the parser must too.
+        # Records are `name\tsize\tstate\n`. Parsed by regex rather than by
+        # line so that a scenario feeding a rejected name (newline, tab) can
+        # still be inspected instead of crashing the harness.
         state: dict[str, tuple[int, str]] = {
             m[1]: (int(m[2]), m[3]) for m in re.finditer(
                 r"(?s)(.*?)\t(\d+)\t(uploaded|starter)\n",
@@ -305,7 +330,8 @@ def run(script: str, env_overrides: dict[str, str] | None = None,
             files["draft"].read_text().strip() or "none",
             files["notes"].read_text().strip() or "none",
             files["latest"].read_text().strip(),
-            [ln for ln in ghlog if ln.startswith("release edit")],
+            [ln for ln in ghlog if ln.startswith("api -X")],
+            files["createdraft"].read_text().strip() or "none",
         )
 
 
@@ -340,22 +366,36 @@ def scenario_draft_first(script: str) -> None:
     every release exactly as v16.57.1 was stranded — left the suite green.
     """
     r = run(script)
+    # Asserted from what the stub recorded, not from stdout: `"--draft" in
+    # r.out or r.published` was true on every successful run, so the check
+    # could not fail even when the release was created already visible.
     check("the release is created as a draft, not published mid-upload",
-          "--draft" in r.out or r.published,  # create path ran; see state below
-          r.out[-200:])
+          r.created_draft == "yes", f"created_draft={r.created_draft}")
     check("the release ends up explicitly published, not left in draft",
-          r.published and any("--draft=false" in e for e in r.edits), f"{r.edits}")
-    check("the published release is marked latest", r.latest == "1",
-          f"--latest seen: {r.latest}")
+          r.published and any("draft=false" in e for e in r.edits), f"{r.edits}")
+    # `legacy`, never `true`. `true` re-points `releases/latest` at whatever it
+    # is called on, so publishing an old stranded draft after a newer release
+    # shipped would downgrade every `curl | bash` install and `veld update`
+    # (install.sh resolves `/releases/latest`). `legacy` lets GitHub pick by
+    # version and date, which is correct for both a normal release and a
+    # late top-up.
+    check("latest is left to GitHub's version/date rule, not forced to this tag",
+          r.latest == "legacy", f"make_latest={r.latest!r}")
 
 
 def scenario_uploads_are_time_capped(script: str) -> None:
     r = run(script)
-    check("every upload runs under a timeout with a kill fallback",
-          len(r.timeouts) >= 1
-          and all("-k" in t for t in r.timeouts)
-          and all("gh release upload" in t for t in r.timeouts if "upload" in t),
+    # `any(...)` per call, not `all(... if "upload" in t)`: the latter is
+    # vacuously true when no upload was wrapped at all, and `publish()` wraps
+    # its own call, so the count alone stays satisfied. A hang — not an error —
+    # is what cost v16.57.1, so "wrapped at all" is the property worth naming.
+    check("the upload runs under a timeout with a kill fallback",
+          any("gh release upload" in t and "-k" in t for t in r.timeouts),
           f"{r.timeouts}")
+    check("the publish call runs under a timeout too",
+          any("gh api" in t and "-k" in t for t in r.timeouts), f"{r.timeouts}")
+    check("the release reads run under a timeout too",
+          any("gh release view" in t and "-k" in t for t in r.timeouts), f"{r.timeouts}")
 
 
 # ── retries ──────────────────────────────────────────────────────────────────
@@ -445,32 +485,34 @@ def scenario_never_completes(script: str) -> None:
 # ── inputs the job must refuse ───────────────────────────────────────────────
 
 def scenario_refused_inputs(script: str) -> None:
-    cases = [
+    cases: list = [
         ("an empty tag", dict(tag=""), "would otherwise read the latest published release"),
         ("no artifacts", dict(artifacts=[]), "an empty release"),
         ("a nested artifacts/ directory", dict(subdir=True), "a re-rooted upload glob"),
-        ("a '#' in an artifact name",
-         dict(artifacts=ARTIFACTS + ["veld#1.dmg"]), "gh reads it as an asset label"),
     ]
+    # Names GitHub or gh would not round-trip. Each uploads fine and then can
+    # never be matched back, so the job would spend all five upload rounds and
+    # strand the release as a draft no re-run can clear — worse than the
+    # incident this step fixes. `#` is gh's asset-label separator; a space is
+    # rewritten to `.` by GitHub; tab and newline cannot survive the
+    # tab-separated asset listing the completeness check reads back.
+    for bad, why in (("veld#1.dmg", "gh reads '#' as an asset label"),
+                     ("veld 1.dmg", "GitHub rewrites a space to '.'"),
+                     ("veld\t1.dmg", "a tab breaks the asset listing"),
+                     ("veld\n1.dmg", "a newline breaks the asset listing")):
+        cases.append((f"the artifact name {bad!r}",
+                      dict(artifacts=ARTIFACTS + [bad]), why))
+
     for label, kwargs, why in cases:
         r = run(script, **kwargs)
-        check(f"{label} fails the job instead of publishing ({why})",
-              r.code != 0 and not r.published, f"code={r.code} draft={r.draft}")
+        # `r.uploads == []` matters as much as the exit code: each of these is
+        # knowable before a byte is sent, and refusing only after five upload
+        # rounds is a different (worse) behaviour that the exit code alone
+        # cannot distinguish.
+        check(f"{label} fails the job before uploading anything ({why})",
+              r.code != 0 and not r.published and r.uploads == [],
+              f"code={r.code} draft={r.draft} uploads={len(r.uploads)}")
 
-
-def scenario_newline_in_name(script: str) -> None:
-    """A newline must be refused up front, not discovered as a stuck release.
-
-    It uploads fine, but cannot survive the tab-separated listing the
-    completeness check reads back, so the asset reads as permanently missing
-    and every re-run fails the same way. Reading `expected` NUL-delimited is
-    what lets the guard see the whole name and say so.
-    """
-    weird = "veld\nbad.dmg"
-    r = run(script, artifacts=ARTIFACTS + [weird])
-    check("an artifact name containing a newline is refused with a clear error",
-          r.code != 0 and not r.published and "newline" in r.out,
-          f"code={r.code} draft={r.draft} out={r.out[-160:]}")
 
 
 def scenario_rerun(script: str) -> None:
@@ -556,7 +598,6 @@ def main() -> int:
     scenario_unreadable_release(script)
     scenario_never_completes(script)
     scenario_refused_inputs(script)
-    scenario_newline_in_name(script)
     scenario_rerun(script)
     scenario_clobber(script)
     scenario_step_env(step)
@@ -571,7 +612,7 @@ def main() -> int:
 
 
 def find_bash() -> str:
-    """bash 4+ — the script uses `mapfile` and associative arrays.
+    """bash 4.4+ — the script uses `mapfile -d ''` and `${x@Q}`.
 
     ubuntu-latest ships bash 5. macOS still ships 3.2 as /bin/bash, so a
     contributor running `just workflow-gates` locally needs Homebrew's.
@@ -580,10 +621,10 @@ def find_bash() -> str:
         "/opt/homebrew/bin/bash", "/usr/local/bin/bash", "/bin/bash", "bash"]
     for candidate in candidates:
         path = shutil.which(candidate)
-        if path and subprocess.run([path, "-c", "((BASH_VERSINFO[0] >= 4))"],
+        if path and subprocess.run([path, "-c", "((BASH_VERSINFO[0] > 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 4)))"],
                                    capture_output=True).returncode == 0:
             return path
-    sys.exit("no bash >= 4 found (macOS /bin/bash is 3.2): `brew install bash`, "
+    sys.exit("no bash >= 4.4 found (macOS /bin/bash is 3.2): `brew install bash`, "
              "or point BASH_BIN at one.")
 
 

--- a/tests/validate-release-publish.py
+++ b/tests/validate-release-publish.py
@@ -6,31 +6,33 @@ release and then flips `draft=false`, has no retry on a 5xx, and one asset
 upload came back as GitHub's 500 HTML page.  The action threw, the flip never
 ran, and the release sat invisible as a draft while `releases/latest` still
 pointed at the previous version — `veld update`, install.sh and Desktop
-auto-update all read `latest`, so for every user the release simply did not
-exist.  The replacement lives inline in the workflow and owns four properties
-that nothing else in this repo can check:
+auto-update all read `latest`, so for every user the release did not exist.
 
-  * a complete upload publishes;
-  * a transient failure retries **only the assets still missing**, not the
-    ~700 MB that already landed;
-  * an asset that is present but wrong — truncated, or still `state=starter` —
-    counts as missing;
-  * a release that is *not* complete is never published, including when the
-    reason is that GitHub could not be read at all.
+The replacement lives inline in the workflow, and every rule it follows bends
+one way: **a failure must fall toward "do not publish"**.  This gate exists to
+hold it to that, because the opposite failure is silent — an incomplete or
+stranded release looks like a red X on a job nobody re-reads.
 
-The last one is the load-bearing one, and its failure is silent: an incomplete
-or stranded release looks like a red X on a job nobody re-reads.  So this gate
-runs the real script — extracted from the workflow, never a copy — and
-`--selftest` mutates the gate out of it to prove these scenarios would actually
-notice if someone deleted it.
+It runs the real script, extracted from the workflow rather than transcribed,
+against a stub `gh` that models release state (name / size / `state`), the
+draft flag, and `--clobber`.  Two things follow from the history here and are
+worth keeping when editing:
 
-Needs PyYAML, same as validate-workflow-gates.py; both are run by
-`just workflow-gates` and by the `schema` job in ci.yml.
+  * **The stub refuses anything it does not model** (exit 64) rather than
+    guessing.  An earlier version hardcoded the `--jq` semantics, so deleting
+    `select(.state == "uploaded")` from the script left the suite green while
+    the property that filter implements was named in two passing checks.
+  * **`--selftest` mutates the completeness gate out** and asserts the suite
+    goes red, so the gate cannot rot into something that passes trivially.
+
+Needs PyYAML, same as validate-workflow-gates.py; both run from
+`just workflow-gates` and from the `schema` job in ci.yml.
 """
 
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -44,32 +46,82 @@ WORKFLOW = REPO / ".github" / "workflows" / "release.yml"
 STEP_NAME = "Publish GitHub Release"
 JOB = "publish"
 
-# The stub speaks only the `gh` surface the script uses.  Release state is a
-# TSV of name/size/state, so an asset can be present-but-wrong (`starter`, or a
-# short byte count) — the cases a name-only presence check would wave through.
+# The env the step must hand the script. There is no checkout in this job, so
+# `GH_REPO` is what lets gh find the repo at all; `TAG` empty is worse than
+# absent, because `gh release view ""` returns the latest published release.
+REQUIRED_ENV = {"GH_TOKEN", "GH_REPO", "TAG"}
+
+# Release state is a TSV of name/size/state so an asset can be present-but-wrong
+# — `starter`, or short — which is what a name-only check waves through.
+# Unmodelled flags and queries exit 64 rather than being ignored: a stub that
+# quietly tolerates a changed argument proves nothing about the changed script.
 GH_STUB = r"""#!/usr/bin/env bash
 set -uo pipefail
 echo "$*" >> "$GHLOG"
 drop() { awk -F'\t' -v n="$1" '$1!=n' "$STATE" > "$STATE.tmp"; mv "$STATE.tmp" "$STATE"; }
 put()  { drop "$1"; printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "$STATE"; }
-case "${1-} ${2-}" in
+has()  { awk -F'\t' -v n="$1" '$1==n{f=1} END{exit !f}' "$STATE"; }
+die64() { echo "gh stub: $1" >&2; exit 64; }
+
+sub="${1-} ${2-}"
+shift 2 2>/dev/null || true
+
+case "$sub" in
   "release view")
+    shift 2>/dev/null || true          # the tag
+    json=""; jq=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --json) json=${2-}; shift 2 ;;
+        --jq)   jq=${2-}; shift 2 ;;
+        *)      die64 "unmodelled `release view` flag: $1" ;;
+      esac
+    done
+    # Bare `gh release view <tag>` is the existence probe.
     [ -f "$STATE" ] || exit 1
-    if [ "${4-}" = "--json" ]; then
-      # The one call whose failure must abort the script rather than read as
-      # "nothing is missing".
-      [ "${FAIL_VIEW-0}" = "1" ] && { echo "gh: 500 Internal Server Error" >&2; exit 1; }
-      awk -F'\t' '$3=="uploaded"{print $1"\t"$2}' "$STATE"
+    [ -n "$json" ] || exit 0
+    if [ "${FAIL_VIEW-0}" = "1" ]; then
+      echo "gh: 500 Internal Server Error" >&2; exit 1
     fi
+    case "$json|$jq" in
+      'assets|.assets[] | select(.state == "uploaded") | "\(.name)\t\(.size)"')
+        awk -F'\t' '$3=="uploaded"{print $1"\t"$2}' "$STATE" ;;
+      'isDraft|.isDraft')
+        if [ "$(cat "$DRAFTF")" = "draft" ]; then echo true; else echo false; fi ;;
+      *)
+        die64 "unmodelled query --json '$json' --jq '$jq'" ;;
+    esac
     exit 0 ;;
+
   "release create")
-    : > "$STATE"; echo draft > "$DRAFTF"; exit 0 ;;
+    shift 2>/dev/null || true          # the tag
+    draft=published; notes=none
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --draft)      draft=draft; shift ;;
+        --title)      shift 2 ;;
+        --notes-file) if [ -f "${2-}" ]; then notes=ok; else notes=missing; fi; shift 2 ;;
+        *)            die64 "unmodelled `release create` flag: $1" ;;
+      esac
+    done
+    : > "$STATE"; echo "$draft" > "$DRAFTF"; echo "$notes" > "$NOTESF"
+    exit 0 ;;
+
   "release upload")
-    shift 3
-    files=(); for a in "$@"; do [ "$a" = "--clobber" ] || files+=("$a"); done
+    shift 2>/dev/null || true          # the tag
+    clobber=0; files=()
+    for arg in "$@"; do
+      if [ "$arg" = "--clobber" ]; then clobber=1; else files+=("$arg"); fi
+    done
     attempt=$(cat "$ATTEMPT"); rc=0
     for f in "${files[@]}"; do
-      name=$(basename "$f"); size=$(( $(wc -c < "$f") ))
+      name=$(basename "$f")
+      if [ ! -f "$f" ]; then echo "gh: $f: no such file" >&2; rc=1; continue; fi
+      size=$(( $(wc -c < "$f") ))
+      # Real gh rejects a name already on the release unless --clobber.
+      if has "$name" && [ "$clobber" -eq 0 ]; then
+        echo "gh: asset $name already exists" >&2; rc=1; continue
+      fi
       if [[ ",${FAIL_FILES-}," == *",$name,"* ]] && [ "$attempt" -le "${FAIL_UNTIL-99}" ]; then
         case "${FAIL_MODE-error}" in
           starter)   put "$name" "$((size / 2))" starter ;;
@@ -81,33 +133,64 @@ case "${1-} ${2-}" in
     done
     echo $((attempt + 1)) > "$ATTEMPT"
     exit $rc ;;
+
   "release edit")
-    echo published > "$DRAFTF"; exit 0 ;;
+    shift 2>/dev/null || true          # the tag
+    edits=$(cat "$EDITS"); echo $((edits + 1)) > "$EDITS"
+    if [ "$edits" -lt "${FAIL_EDIT_UNTIL-0}" ]; then
+      echo "gh: 502 Bad Gateway" >&2; exit 1
+    fi
+    want=""; latest=0
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --draft=false) want=published; shift ;;
+        --draft=true|--draft) want=draft; shift ;;
+        --latest) latest=1; shift ;;
+        *) die64 "unmodelled `release edit` flag: $1" ;;
+      esac
+    done
+    echo "$latest" > "$LATESTF"
+    # EDIT_SILENT models the API accepting the call without the release
+    # actually leaving draft — the case the script reads back to catch.
+    if [ "${EDIT_SILENT-0}" = "1" ]; then exit 0; fi
+    [ -n "$want" ] && echo "$want" > "$DRAFTF"
+    exit 0 ;;
 esac
-exit 0
+die64 "unmodelled subcommand: $sub"
 """
 
 # Asserts the exact GNU flags the script passes before emulating them, so a
-# typo'd `stat` call fails the suite instead of quietly measuring nothing.
+# typo'd `stat` fails the suite instead of quietly measuring nothing. STAT_FAIL
+# names one file it refuses to measure — the case where an unmeasurable file
+# must count as missing, never as present.
 STAT_STUB = r"""#!/usr/bin/env bash
 if [ "${1-}" != "-c" ] || [ "${2-}" != "%s" ]; then
   echo "stat stub: expected '-c %s', got: $*" >&2; exit 64
 fi
+if [ -n "${STAT_FAIL-}" ] && [ "$(basename "$3")" = "$STAT_FAIL" ]; then
+  echo "stat: cannot statx '$3'" >&2; exit 1
+fi
 wc -c < "$3" | tr -d ' '
 """
 
-# Likewise for `timeout`: assert a numeric budget, then run the command. A hang
-# was what cost v16.57.1, so the script losing its timeout is worth catching.
+# Logs every wrapped invocation, so "the upload is wrapped in a timeout at all"
+# is assertable — a hang, not an error, is what actually cost v16.57.1.
 TIMEOUT_STUB = r"""#!/usr/bin/env bash
-case "${1-}" in
-  ''|*[!0-9]*) echo "timeout stub: expected seconds, got: $*" >&2; exit 64 ;;
-esac
-shift
+args=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -k) args+=("-k $2"); shift 2 ;;
+    ''|*[!0-9]*) break ;;
+    *) args+=("$1"); shift ;;
+  esac
+done
+if [ ${#args[@]} -eq 0 ]; then
+  echo "timeout stub: no duration in: $*" >&2; exit 64
+fi
+echo "${args[*]} :: $*" >> "$TIMEOUTLOG"
 exec "$@"
 """
 
-# No-op so the suite does not sit through the real backoff; the requested
-# delays are recorded instead and asserted separately.
 SLEEP_STUB = r"""#!/usr/bin/env bash
 echo "$1" >> "$SLEEPLOG"
 """
@@ -115,9 +198,14 @@ echo "$1" >> "$SLEEPLOG"
 ARTIFACTS = ["veld-1.2.3-linux-amd64.tar.gz", "veld-desktop-1.2.3-mac-x64.zip",
              "veld-desktop-1.2.3-mac-x64.zip.blockmap", "checksums.txt"]
 
+# Stub-control variables must not leak in from the caller's environment, or
+# `FAIL_VIEW=1 just workflow-gates` silently reconfigures every scenario.
+STUB_VARS = {"FAIL_FILES", "FAIL_UNTIL", "FAIL_MODE", "FAIL_VIEW", "FAIL_EDIT_UNTIL",
+             "EDIT_SILENT", "STAT_FAIL", "STATE", "DRAFTF", "GHLOG", "SLEEPLOG",
+             "TIMEOUTLOG", "ATTEMPT", "EDITS", "NOTESF", "LATESTF", "TAG"}
 
-def publish_script() -> str:
-    """The script as the workflow actually ships it — never a transcription."""
+
+def publish_step() -> dict:
     doc = yaml.safe_load(WORKFLOW.read_text())
     try:
         steps = doc["jobs"][JOB]["steps"]
@@ -125,24 +213,24 @@ def publish_script() -> str:
         sys.exit(f"{WORKFLOW.name}: no `{JOB}` job with steps")
     for step in steps:
         if step.get("name") == STEP_NAME:
-            script = step.get("run") or ""
-            # A rename upstream would otherwise leave this gate testing an empty
-            # string and reporting a clean bill of health.
-            if "gh release edit" not in script:
+            # A rename upstream would otherwise leave this gate running an
+            # empty string and reporting a clean bill of health.
+            if "gh release edit" not in (step.get("run") or ""):
                 sys.exit(f"step {STEP_NAME!r} no longer publishes the release")
-            return script
+            return step
     sys.exit(
-        f"{WORKFLOW.name}: job `{JOB}` has no step named {STEP_NAME!r}. "
-        "If the publish step was renamed, update STEP_NAME here — this gate is "
-        "the only check that an incomplete release cannot publish."
+        f"{WORKFLOW.name}: job `{JOB}` has no step named {STEP_NAME!r}. If the "
+        "publish step was renamed, update STEP_NAME here — this gate is the only "
+        "check that an incomplete release cannot publish."
     )
 
 
 class Result:
-    def __init__(self, code: int, out: str, state: dict[str, tuple[int, str]],
-                 uploads: list[list[str]], sleeps: list[str], draft: str):
+    def __init__(self, code, out, state, uploads, sleeps, timeouts, draft,
+                 notes, latest, edits):
         self.code, self.out, self.state = code, out, state
-        self.uploads, self.sleeps, self.draft = uploads, sleeps, draft
+        self.uploads, self.sleeps, self.timeouts = uploads, sleeps, timeouts
+        self.draft, self.notes, self.latest, self.edits = draft, notes, latest, edits
 
     @property
     def published(self) -> bool:
@@ -150,7 +238,8 @@ class Result:
 
 
 def run(script: str, env_overrides: dict[str, str] | None = None,
-        artifacts: list[str] = ARTIFACTS, preseed: list[str] | None = None) -> Result:
+        artifacts: list[str] = ARTIFACTS, preseed: list[str] | None = None,
+        subdir: bool = False, tag: str = "v1.2.3") -> Result:
     with tempfile.TemporaryDirectory() as tmp:
         work = Path(tmp)
         binw = work / "bin"
@@ -163,46 +252,61 @@ def run(script: str, env_overrides: dict[str, str] | None = None,
 
         (work / "artifacts").mkdir()
         for i, name in enumerate(artifacts):
-            # Distinct sizes so a size comparison cannot pass by coincidence.
+            # Distinct sizes, so a size comparison cannot pass by coincidence.
             (work / "artifacts" / name).write_bytes(b"x" * (1024 + i * 37))
+        if subdir:
+            (work / "artifacts" / "dist").mkdir()
+            (work / "artifacts" / "dist" / "nested.dmg").write_bytes(b"x" * 99)
         (work / "release-notes.md").write_text("notes\n")
 
-        state, draftf = work / "state.tsv", work / "draft"
-        ghlog, sleeplog, attempt = work / "gh.log", work / "sleep.log", work / "attempt"
-        attempt.write_text("1\n")
-        ghlog.touch()
-        sleeplog.touch()
+        files = {k: work / f"{k}.txt" for k in
+                 ("state", "draft", "gh", "sleep", "timeout", "attempt", "edits",
+                  "notes", "latest")}
+        for f in files.values():
+            f.touch()
+        files["attempt"].write_text("1\n")
+        files["edits"].write_text("0\n")
         if preseed is not None:
-            # A re-run of the job: the draft already exists, carrying some assets.
-            draftf.write_text("draft\n")
-            state.write_text("".join(
+            # A re-run of the job: the draft exists, carrying some assets.
+            files["draft"].write_text("draft\n")
+            files["state"].write_text("".join(
                 f"{n}\t{(work / 'artifacts' / n).stat().st_size}\tuploaded\n"
                 for n in preseed))
+        else:
+            files["state"].unlink()
 
-        env = {
-            **os.environ,
+        env = {k: v for k, v in os.environ.items() if k not in STUB_VARS}
+        env.update({
             "PATH": f"{binw}{os.pathsep}{os.environ['PATH']}",
-            "TAG": "v1.2.3",
-            "STATE": str(state), "DRAFTF": str(draftf),
-            "GHLOG": str(ghlog), "SLEEPLOG": str(sleeplog), "ATTEMPT": str(attempt),
+            "TAG": tag,
+            "STATE": str(files["state"]), "DRAFTF": str(files["draft"]),
+            "GHLOG": str(files["gh"]), "SLEEPLOG": str(files["sleep"]),
+            "TIMEOUTLOG": str(files["timeout"]), "ATTEMPT": str(files["attempt"]),
+            "EDITS": str(files["edits"]), "NOTESF": str(files["notes"]),
+            "LATESTF": str(files["latest"]),
             **(env_overrides or {}),
-        }
+        })
         proc = subprocess.run([BASH, "-c", script], cwd=work, env=env,
-                              capture_output=True, text=True, timeout=120)
+                              capture_output=True, text=True, timeout=180)
 
-        parsed: dict[str, tuple[int, str]] = {}
-        if state.exists():
-            for line in state.read_text().splitlines():
-                if line.strip():
-                    name, size, st = line.split("\t")
-                    parsed[name] = (int(size), st)
-        uploads = [ln.split()[3:] for ln in ghlog.read_text().splitlines()
-                   if ln.startswith("release upload")]
-        uploads = [[Path(a).name for a in u if a != "--clobber"] for u in uploads]
-
-        return Result(proc.returncode, proc.stdout + proc.stderr, parsed, uploads,
-                      sleeplog.read_text().split(),
-                      draftf.read_text().strip() if draftf.exists() else "none")
+        # Records are `name\tsize\tstate\n`, and an asset name may itself
+        # contain a newline — the script handles those, so the parser must too.
+        state: dict[str, tuple[int, str]] = {
+            m[1]: (int(m[2]), m[3]) for m in re.finditer(
+                r"(?s)(.*?)\t(\d+)\t(uploaded|starter)\n",
+                files["state"].read_text() if files["state"].exists() else "")}
+        ghlog = files["gh"].read_text().splitlines()
+        uploads = [[Path(a).name for a in ln.split()[3:] if a != "--clobber"]
+                   for ln in ghlog if ln.startswith("release upload")]
+        return Result(
+            proc.returncode, proc.stdout + proc.stderr, state, uploads,
+            files["sleep"].read_text().split(),
+            files["timeout"].read_text().splitlines(),
+            files["draft"].read_text().strip() or "none",
+            files["notes"].read_text().strip() or "none",
+            files["latest"].read_text().strip(),
+            [ln for ln in ghlog if ln.startswith("release edit")],
+        )
 
 
 FAILURES: list[str] = []
@@ -216,15 +320,45 @@ def check(label: str, condition: bool, detail: str = "") -> None:
         FAILURES.append(label)
 
 
+# ── the happy path, and the shape of it ──────────────────────────────────────
+
 def scenario_complete(script: str) -> None:
     r = run(script)
     check("a complete upload publishes the release", r.published and r.code == 0,
           f"code={r.code} draft={r.draft}")
-    check("every artifact lands as an asset",
-          sorted(r.state) == sorted(ARTIFACTS), f"{sorted(r.state)}")
+    check("every artifact lands as an asset", sorted(r.state) == sorted(ARTIFACTS),
+          f"{sorted(r.state)}")
     check("a clean run uploads once, not once per file", len(r.uploads) == 1,
           f"{len(r.uploads)} upload calls")
+    check("release notes are attached from the notes file", r.notes == "ok", r.notes)
 
+
+def scenario_draft_first(script: str) -> None:
+    """The ordering the workflow comment calls load-bearing.
+
+    Without this, flipping the script to `--draft=true` — which would strand
+    every release exactly as v16.57.1 was stranded — left the suite green.
+    """
+    r = run(script)
+    check("the release is created as a draft, not published mid-upload",
+          "--draft" in r.out or r.published,  # create path ran; see state below
+          r.out[-200:])
+    check("the release ends up explicitly published, not left in draft",
+          r.published and any("--draft=false" in e for e in r.edits), f"{r.edits}")
+    check("the published release is marked latest", r.latest == "1",
+          f"--latest seen: {r.latest}")
+
+
+def scenario_uploads_are_time_capped(script: str) -> None:
+    r = run(script)
+    check("every upload runs under a timeout with a kill fallback",
+          len(r.timeouts) >= 1
+          and all("-k" in t for t in r.timeouts)
+          and all("gh release upload" in t for t in r.timeouts if "upload" in t),
+          f"{r.timeouts}")
+
+
+# ── retries ──────────────────────────────────────────────────────────────────
 
 def scenario_transient_5xx(script: str) -> None:
     """The v16.57.1 failure itself: one asset 5xxs, the rest already landed."""
@@ -233,10 +367,33 @@ def scenario_transient_5xx(script: str) -> None:
     check("a transient 5xx on one asset still publishes", r.published and r.code == 0,
           f"code={r.code} draft={r.draft}")
     check("the retry re-sends only what is missing",
-          all(u == [stranded] for u in r.uploads[1:]) and len(r.uploads) == 3,
+          len(r.uploads) == 3 and all(u == [stranded] for u in r.uploads[1:]),
           f"{r.uploads}")
-    check("backoff grows between attempts", r.sleeps == ["15", "30"], f"{r.sleeps}")
+    check("backoff grows between attempts", r.sleeps[:2] == ["15", "30"], f"{r.sleeps}")
 
+
+def scenario_last_attempt_counts(script: str) -> None:
+    """The final re-verify: a release whose last upload succeeds must publish."""
+    r = run(script, {"FAIL_FILES": "checksums.txt", "FAIL_UNTIL": "4"})
+    check("an upload that succeeds on the last attempt still publishes",
+          r.published and r.code == 0, f"code={r.code} draft={r.draft}")
+
+
+def scenario_publish_flip_retries(script: str) -> None:
+    """The flip is the call that stranded v16.57.1. It must retry like the rest."""
+    r = run(script, {"FAIL_EDIT_UNTIL": "2"})
+    check("a 5xx on the publish call itself is retried, not fatal",
+          r.published and r.code == 0, f"code={r.code} draft={r.draft} edits={len(r.edits)}")
+
+
+def scenario_publish_is_read_back(script: str) -> None:
+    """`gh release edit` exiting 0 is not the same fact as being published."""
+    r = run(script, {"EDIT_SILENT": "1"})
+    check("a publish call that reports success but leaves a draft fails the job",
+          r.code != 0 and not r.published, f"code={r.code} draft={r.draft}")
+
+
+# ── present-but-wrong ────────────────────────────────────────────────────────
 
 def scenario_present_but_wrong(script: str) -> None:
     for mode, label in (("starter", "an asset still uploading"),
@@ -249,16 +406,19 @@ def scenario_present_but_wrong(script: str) -> None:
               f"state={r.state.get(victim)} uploads={r.uploads}")
 
 
-def scenario_never_completes(script: str) -> bool:
-    """The gate. Returns whether it held, so --selftest can assert it can fail."""
-    r = run(script, {"FAIL_FILES": "checksums.txt", "FAIL_UNTIL": "99"})
-    held = r.code != 0 and not r.published
-    check("an incomplete release is never published, and fails the job", held,
-          f"code={r.code} draft={r.draft}")
-    check("the error names the tag and says it stayed a draft",
-          "v1.2.3" in r.out and "draft" in r.out, r.out[-200:])
-    return held
+def scenario_unmeasurable_file(script: str) -> None:
+    """An unmeasurable local file must count as missing, never as present.
 
+    Comparing `"${have[$name]-}"` against an inline `$(stat ...)` makes both
+    sides empty when stat fails, so the file scored as present and the release
+    published without it.
+    """
+    r = run(script, {"STAT_FAIL": "checksums.txt"})
+    check("a local file that cannot be measured never counts as present",
+          r.code != 0 and not r.published, f"code={r.code} draft={r.draft}")
+
+
+# ── reads ────────────────────────────────────────────────────────────────────
 
 def scenario_unreadable_release(script: str) -> None:
     r = run(script, {"FAIL_VIEW": "1"})
@@ -266,10 +426,51 @@ def scenario_unreadable_release(script: str) -> None:
           r.code != 0 and not r.published, f"code={r.code} draft={r.draft}")
     # Swallowing the read failure keeps the release safe — an empty asset list
     # reads as "everything is missing", so the gate still fires — but it does so
-    # after five rounds of re-pushing every artifact at an API that is down.
-    # Aborting on the first failed read is the difference, so assert it directly.
-    check("an unreadable release fails fast, without uploading anything",
+    # after rounds of re-pushing every artifact at an API that is down.
+    check("an unreadable release fails without re-pushing every artifact",
           r.uploads == [], f"{len(r.uploads)} upload call(s)")
+    check("the read is retried before giving up", len(r.sleeps) >= 2, f"{r.sleeps}")
+
+
+# ── the gate ─────────────────────────────────────────────────────────────────
+
+def scenario_never_completes(script: str) -> None:
+    r = run(script, {"FAIL_FILES": "checksums.txt", "FAIL_UNTIL": "99"})
+    check("an incomplete release is never published, and fails the job",
+          r.code != 0 and not r.published, f"code={r.code} draft={r.draft}")
+    check("the error names the tag and says it stayed a draft",
+          "v1.2.3" in r.out and "draft" in r.out, r.out[-200:])
+
+
+# ── inputs the job must refuse ───────────────────────────────────────────────
+
+def scenario_refused_inputs(script: str) -> None:
+    cases = [
+        ("an empty tag", dict(tag=""), "would otherwise read the latest published release"),
+        ("no artifacts", dict(artifacts=[]), "an empty release"),
+        ("a nested artifacts/ directory", dict(subdir=True), "a re-rooted upload glob"),
+        ("a '#' in an artifact name",
+         dict(artifacts=ARTIFACTS + ["veld#1.dmg"]), "gh reads it as an asset label"),
+    ]
+    for label, kwargs, why in cases:
+        r = run(script, **kwargs)
+        check(f"{label} fails the job instead of publishing ({why})",
+              r.code != 0 and not r.published, f"code={r.code} draft={r.draft}")
+
+
+def scenario_newline_in_name(script: str) -> None:
+    """A newline must be refused up front, not discovered as a stuck release.
+
+    It uploads fine, but cannot survive the tab-separated listing the
+    completeness check reads back, so the asset reads as permanently missing
+    and every re-run fails the same way. Reading `expected` NUL-delimited is
+    what lets the guard see the whole name and say so.
+    """
+    weird = "veld\nbad.dmg"
+    r = run(script, artifacts=ARTIFACTS + [weird])
+    check("an artifact name containing a newline is refused with a clear error",
+          r.code != 0 and not r.published and "newline" in r.out,
+          f"code={r.code} draft={r.draft} out={r.out[-160:]}")
 
 
 def scenario_rerun(script: str) -> None:
@@ -282,10 +483,25 @@ def scenario_rerun(script: str) -> None:
           f"{r.uploads}")
 
 
-def scenario_no_artifacts(script: str) -> None:
-    r = run(script, artifacts=[])
-    check("an empty artifact set fails instead of publishing an empty release",
-          r.code != 0 and not r.published, f"code={r.code} draft={r.draft}")
+def scenario_clobber(script: str) -> None:
+    """Without --clobber, real gh refuses a name already on the release, so a
+    truncated asset could never be repaired — the retry would spin and the
+    release would strand. The stub enforces the same rule."""
+    victim = "veld-desktop-1.2.3-mac-x64.zip"
+    r = run(script, {"FAIL_FILES": victim, "FAIL_UNTIL": "1", "FAIL_MODE": "truncated"})
+    check("a damaged asset is overwritten rather than rejected as existing",
+          r.published and "already exists" not in r.out, r.out[-200:])
+
+
+# ── wiring ───────────────────────────────────────────────────────────────────
+
+def scenario_step_env(step: dict) -> None:
+    env = set(step.get("env") or {})
+    check(f"the step passes {', '.join(sorted(REQUIRED_ENV))} to the script",
+          REQUIRED_ENV <= env, f"missing {sorted(REQUIRED_ENV - env)}")
+    tag = (step.get("env") or {}).get("TAG", "")
+    check("TAG is wired to the release job's tag output",
+          "new_release_git_tag" in str(tag), str(tag))
 
 
 def selftest(script: str) -> None:
@@ -295,26 +511,33 @@ def selftest(script: str) -> None:
     fails for some unrelated reason rather than because the gate is there — the
     same trap `validate-workflow-gates.py --selftest` exists for.
     """
-    print("Self-test: removing the completeness gate should break the suite")
+    print("Self-test: removing the completeness gate should let a bad release publish")
     lines = script.splitlines()
-    try:
-        start = next(i for i, ln in enumerate(lines)
-                     if 'if [ "${#missing[@]}" -ne 0 ]' in ln)
-    except StopIteration:
-        sys.exit("self-test: could not find the completeness gate to mutate — "
-                 "it was renamed or removed, and this suite no longer proves it exists")
-    end = next(i for i in range(start, len(lines)) if lines[i].strip() == "fi")
-    mutated = "\n".join(lines[:start] + lines[end + 1:])
+    marker = 'if [ "${#missing[@]}" -ne 0 ]; then'
+    starts = [i for i, ln in enumerate(lines) if marker in ln]
+    if len(starts) != 1:
+        sys.exit(f"self-test: expected exactly one completeness gate, found "
+                 f"{len(starts)}. It was renamed, reformatted onto one line, or "
+                 "duplicated — this suite no longer proves the gate exists.")
+    start = starts[0]
+    indent = len(lines[start]) - len(lines[start].lstrip())
+    ends = [i for i in range(start + 1, len(lines))
+            if lines[i].strip() == "fi" and len(lines[i]) - len(lines[i].lstrip()) == indent]
+    if not ends:
+        sys.exit("self-test: could not find the end of the completeness gate; "
+                 "the block was reformatted and the mutation would be wrong.")
+    mutated = "\n".join(lines[:start] + lines[ends[0] + 1:])
 
     r = run(mutated, {"FAIL_FILES": "checksums.txt", "FAIL_UNTIL": "99"})
     if not r.published:
         sys.exit("self-test FAILED: the mutant refused to publish an incomplete "
-                 "release anyway, so the scenario is not testing the gate")
+                 "release anyway, so scenario_never_completes is not testing the gate")
     print("  ok  the mutant publishes an incomplete release, as it must to be caught")
 
 
 def main() -> int:
-    script = publish_script()
+    step = publish_step()
+    script = step["run"]
 
     if "--selftest" in sys.argv:
         selftest(script)
@@ -322,12 +545,21 @@ def main() -> int:
 
     print(f"Release publish gate — {WORKFLOW.name} → {JOB} → {STEP_NAME!r}")
     scenario_complete(script)
+    scenario_draft_first(script)
+    scenario_uploads_are_time_capped(script)
     scenario_transient_5xx(script)
+    scenario_last_attempt_counts(script)
+    scenario_publish_flip_retries(script)
+    scenario_publish_is_read_back(script)
     scenario_present_but_wrong(script)
-    scenario_never_completes(script)
+    scenario_unmeasurable_file(script)
     scenario_unreadable_release(script)
+    scenario_never_completes(script)
+    scenario_refused_inputs(script)
+    scenario_newline_in_name(script)
     scenario_rerun(script)
-    scenario_no_artifacts(script)
+    scenario_clobber(script)
+    scenario_step_env(step)
 
     if FAILURES:
         print(f"\n{len(FAILURES)} failure(s):")
@@ -345,7 +577,7 @@ def find_bash() -> str:
     contributor running `just workflow-gates` locally needs Homebrew's.
     """
     candidates = [os.environ["BASH_BIN"]] if os.environ.get("BASH_BIN") else [
-        "/opt/homebrew/bin/bash", "/usr/local/bin/bash", "/bin/bash"]
+        "/opt/homebrew/bin/bash", "/usr/local/bin/bash", "/bin/bash", "bash"]
     for candidate in candidates:
         path = shutil.which(candidate)
         if path and subprocess.run([path, "-c", "((BASH_VERSINFO[0] >= 4))"],


### PR DESCRIPTION
## What happened

[The v16.57.1 release run](https://github.com/prosperity-solutions/veld/actions/runs/33076739952/job/98536587185) failed in **Publish Artifacts**. All four build legs and Tag & Release succeeded; the tag and version commit landed.

`softprops/action-gh-release` creates the release as a **draft**, uploads the assets, then flips `draft=false`. It has no retry on a 5xx. One asset upload — `veld-desktop-16.57.1-mac-x64.zip.blockmap` — sat for five minutes and came back as GitHub's 500 HTML error page. The action threw, and the flip never ran.

**So v16.57.1 sat as an invisible draft with 20 of its 21 assets on it, while `releases/latest` still pointed at v16.57.0.** Nothing a user touches reads a draft — `veld update`, `install.sh` and Desktop auto-update all resolve `/releases/latest` — so for every user the release did not exist. The only signal was a red X on a job whose log was a page of HTML. `checksums.txt` also listed a file that was not on the release.

## Fixed by hand, first

v16.57.1 is now published (21/21 assets, all `uploaded`, `releases/latest` → v16.57.1). The missing blockmap was recovered from the run artifact and its SHA-256 verified against the release's own `checksums.txt` before upload.

## What this PR changes

The publish is spelled out in the job instead of delegated to the action. Same draft-first ordering — a release is never visible carrying a partial asset set — plus the properties the action lacked:

- **Every GitHub call is retried *and* time-capped**: the existence probe, the create, the uploads, the reads that decide whether an upload worked, and the flip that publishes. One unretried call is the whole incident — and the incident was a *hang*, which a retry loop alone does not rescue.
- **A retry re-sends only what is still missing**, not the ~700 MB that already landed.
- **"Present" means name AND byte size AND `state == uploaded`**, so a truncated or still-uploading asset is replaced rather than counted.
- **The flip is gated on that set being empty, and read back afterwards** — the API accepting the call is not the same fact as the release having left draft.
- **Re-running the job is the recovery path**: it finds the existing draft, tops up what is missing, and publishes.

The rule the whole step is built around: **every failure must fall toward "do not publish"**. Every serious defect review found here was the same shape — a check that answered "complete" when it meant "could not tell".

### One deliberate behaviour change vs the old action

The flip goes through `gh api -X PATCH … -f make_latest=legacy`, not `gh release edit --latest`.

`--latest` hard-sets `make_latest=true`. That is wrong on the recovery path this step advertises: publishing an **old** stranded draft after a newer release has shipped would re-point `releases/latest` backwards, and `install.sh:236` resolves `/releases/latest` — so every `curl | bash` install and `veld update` would silently downgrade. `legacy` lets GitHub choose by version and date, which is correct for a normal release and for a late top-up alike.

## Adjacent things fixed on the way

- An **empty `$TAG`** is now refused. `gh release view ""` returns the repo's *latest published* release with exit 0 (verified), so the script would otherwise have read a previous release's assets, found them all present, and reported success having published nothing.
- A **nested `artifacts/` directory** is now refused. The comment above the desktop job already describes this failure — a re-rooted upload glob nests everything a level deeper, `-maxdepth 1` misses it, and you get "a release with no app on it and nothing in the log to say so". It was silent before this PR and is silent in the checksum step; now it is loud.
- **Artifact names are held to a conservative allowlist.** GitHub rewrites a space to `.`, `gh release upload` reads `#` as an asset-label separator, and a tab or newline cannot survive the tab-separated asset listing the completeness check reads back. Each of those uploads fine and then can never be matched back — the job would spend all five upload rounds and strand the release as a draft *no re-run could clear*, which is strictly worse than the incident this PR fixes. The old action compensated for the space case only. No current artifact name is affected.

## Test evidence

`tests/validate-release-publish.py` extracts the script **as the workflow ships it** — never a transcription — and runs it against a stub `gh` that models release state (name / size / `state`), the draft flag and `--clobber`. 30 checks covering the happy path, draft-first ordering, the transient-5xx replay, present-but-wrong assets, an unmeasurable local file, unreadable releases, the publish read-back, job re-runs, and every refused input.

Two things make it a gate rather than decoration:

- **The stub refuses anything it does not model** (exit 64). An earlier version hardcoded the `--jq` semantics, so deleting `select(.state == "uploaded")` from the script left the suite green *while the property that filter implements was named in two passing checks*.
- **`--selftest` mutates the completeness gate out of the script and asserts the suite goes red**, so the gate cannot rot into something that passes trivially.

**Mutation sweep: 22/22 single-edit mutants caught**, including flipping the script to `--draft=true` (which would strand every release), dropping `--clobber`, removing the `state` filter, un-capping any one of the six GitHub call sites, and removing either retry loop.

That number started at **9 of 17 mutants surviving green** against the first version of this gate — the review rounds below are what closed it.

Wired into `just workflow-gates` and ci.yml's `schema` job, alongside the draft-PR gate it shares a trigger and a PyYAML dependency with.

Also run: `shellcheck --severity=style` clean on the extracted script; `just workflow-gates` clean (58 checks); draft-PR gate intact. No Rust or TS in the diff, so clippy/fmt/cargo-test were deliberately skipped.

## Review

Four angles across two rounds (bash correctness, Actions/release semantics, test quality, and the fix delta on its own). 5 🔴 and 12 🟠 found and fixed; every 🔴/🟠 verified before fixing rather than taken on trust. The two 🔴s worth naming:

- The flip that publishes was itself **a single unretried call** — a 5xx there reproduces the original incident exactly: every asset uploaded, release still invisible.
- `[ "${have[$name]-}" = "$(stat -c %s "$file")" ]` compares empty to empty when `stat` fails, scoring an **unmeasurable file as present**. `set -e` does not apply inside `[ ]` on the left of `||`. Reproduced in bash 5.3.

Notably, the test-quality angle found the gate itself was issuing a false clean bill of health, and the fix-delta angle found a vacuous assertion introduced by the previous fix round.

## Reviewer scope notes

- `timeout-minutes` goes 60 → 90. The step's worst case is ~75 min counting the `-k` grace periods; the old comment claimed a number the arithmetic did not support.
- Title and notes are set on the create path only. The old action re-applied them on every run; I could not construct a reachable case where they drift (GitHub's "Re-run failed jobs" preserves `needs.release.outputs.new_release_notes` verbatim), so this is a lost self-healing property rather than a live bug — flagged rather than fixed.
- A top-level **symlink** in `artifacts/` now hard-fails the job where the old action would have published it. `actions/upload-artifact@v4` dereferences symlinks, so no current glob can produce one.
- `CONTRIBUTING.md`, the `justfile` recipe and `docs/agentic-review.md` all described `just workflow-gates` as the draft-PR gate alone; updated.

## Docs

Purely internal CI change — no config fields, CLI flags, subcommands or user-visible behaviour, so the AGENTS.md documentation checklist does not apply. **No website change** (no user-visible capability). **No promotion** — this is a fix, and fixes are never promoted.
