### PR TITLE
fix(helper): activate the privileged helper's uid gate without user action

### DIFF
--- a/crates/veld-core/src/helper_gate.rs
+++ b/crates/veld-core/src/helper_gate.rs
@@ -163,10 +163,16 @@ impl Gate {
     /// property of the install, and the install changes by replacing this
     /// binary — which restarts the process (`veld update` bounces the helper,
     /// and `watch_own_binary` exits onto a swapped one), so the derivation
-    /// re-runs exactly when its inputs can have changed. A `chown` of the
-    /// install directory under a running helper does leave a stale gate until
-    /// the next restart; `veld doctor` compares the reported uid against the
-    /// invoking user's, so that state is visible rather than mysterious.
+    /// re-runs exactly when its inputs can have changed.
+    ///
+    /// Two things do go stale in between, and neither is silent. A `chown` of
+    /// the install directory under a running helper leaves the old uid until the
+    /// next restart. And an `--allow-uid` in the service definition is never
+    /// re-derived at all, so an account renumbered under it — Migration
+    /// Assistant, MDM re-creating the user, a restored backup — keeps a gate
+    /// pointing at a uid that no longer exists. In both cases `veld doctor`
+    /// compares the reported uid against the invoking user's and, if the peer is
+    /// refused outright, says the gate refused *you* rather than "helper down".
     ///
     /// **Why the error paths leave the socket ungated rather than shut.** Every
     /// "cannot tell" branch here resolves to no gate, which is fail-open — but
@@ -182,14 +188,20 @@ impl Gate {
     /// [`Gate::resolve`] with the filesystem lookup already done, so the policy
     /// is testable without a chown.
     pub fn from_owner(flag: Option<u32>, privileged: bool, lib_dir_owner: Option<u32>) -> Self {
-        if !privileged {
-            return Self::unprivileged();
-        }
         match flag {
+            // Honoured on any socket, not just the system one. `privileged`
+            // gates the *derivation* — the guess — not an instruction somebody
+            // wrote down; dropping the flag on an unprivileged helper would
+            // silently discard it (`log_gate` says nothing in that case) and
+            // contradict the rule two paragraphs up. It also matches what
+            // origin/main did, which applied the flag whatever the socket path.
+            // No shipped path passes it to a user helper — both setup writers
+            // use the system socket — so this is consistency, not a feature.
             Some(uid) => Self {
                 uid: Some(uid),
                 source: GateSource::Flag,
             },
+            None if !privileged => Self::unprivileged(),
             None => match lib_dir_owner {
                 Some(0) => Self {
                     uid: None,
@@ -234,6 +246,15 @@ impl Gate {
 /// be — the one branch where a symlinked path component would decide the
 /// admitted uid, and the only place the gap between resolving and stat'ing is
 /// worth anything to anyone. "Cannot tell" is a state this code already handles.
+///
+/// **The exe is resolved first, then its parent taken — not the other way
+/// round**, and the order is the whole point. `exe.parent()` on a helper exec'd
+/// through a symlink gives the directory the *symlink* sits in, which can be
+/// root-owned `/tmp` while the real install belongs to the user; resolving
+/// first lands on the directory the binary is actually served from.
+/// `a_helper_reached_through_a_symlink_derives_from_the_real_install_dir` pins
+/// it, because "just take the parent, it is all you need" is the natural
+/// simplification and it is wrong.
 fn lib_dir_owner(exe: &Path) -> Option<u32> {
     use std::os::unix::fs::MetadataExt;
     let resolved = std::fs::canonicalize(exe).ok()?;
@@ -251,11 +272,18 @@ mod tests {
     fn gate_policy_covers_every_way_a_uid_can_be_absent() {
         const INSTALLING: u32 = 501;
 
-        // An unprivileged helper is never gated, whatever the filesystem says:
-        // its 0o700 owner-only socket is the restriction.
-        let g = Gate::from_owner(Some(INSTALLING), false, Some(INSTALLING));
+        // An unprivileged helper never *derives* a gate, whatever the filesystem
+        // says: its 0o700 owner-only socket is the restriction.
+        let g = Gate::from_owner(None, false, Some(INSTALLING));
         assert_eq!(g.uid(), None);
         assert_eq!(g.source(), GateSource::Unprivileged);
+
+        // But an explicit flag is honoured wherever it appears — `privileged`
+        // gates the guess, not a written-down instruction. Silently dropping it
+        // is what origin/main did not do, and it would leave no trace.
+        let g = Gate::from_owner(Some(INSTALLING), false, Some(999));
+        assert_eq!(g.uid(), Some(INSTALLING));
+        assert_eq!(g.source(), GateSource::Flag);
 
         // The service definition wins when it carries a usable uid.
         let g = Gate::from_owner(Some(INSTALLING), true, Some(999));
@@ -317,6 +345,39 @@ mod tests {
         }
         // A helper newer than this build is "unknown", never a wrong match.
         assert_eq!(GateSource::from_wire("invented-later"), None);
+    }
+
+    /// Exec'd through a symlink, the gate must derive from the **real** install
+    /// directory's owner — not from the directory the symlink happens to sit in.
+    ///
+    /// This is the test that stops `lib_dir_owner` being "simplified" to
+    /// `exe.parent()` then canonicalise. That reads as equivalent and is not: a
+    /// helper reached through a link in a root-owned directory would derive root
+    /// and refuse to gate, turning a protected install into an unprotected one.
+    /// Proven on real hardware before it was written — a root helper exec'd via
+    /// `/tmp/veld-helper-symlink` still gated to the lib dir's owner.
+    #[test]
+    fn a_helper_reached_through_a_symlink_derives_from_the_real_install_dir() {
+        let real = tempfile::tempdir().unwrap();
+        let exe = real.path().join("veld-helper");
+        std::fs::write(&exe, b"not really a binary").unwrap();
+
+        // The link lives somewhere else entirely; only the target's directory
+        // may decide the uid.
+        let elsewhere = tempfile::tempdir().unwrap();
+        let link = elsewhere.path().join("veld-helper-symlink");
+        std::os::unix::fs::symlink(&exe, &link).unwrap();
+
+        assert_eq!(
+            super::lib_dir_owner(&link),
+            super::lib_dir_owner(&exe),
+            "a symlinked path must resolve to the real install directory's owner"
+        );
+
+        // A dangling link is "cannot tell", never a guess at the link's own
+        // parent — which is the branch a root-owned link directory would abuse.
+        std::fs::remove_file(&exe).unwrap();
+        assert_eq!(super::lib_dir_owner(&link), None);
     }
 
     /// The derivation reads a real directory's owner, not a constant — and

--- a/crates/veld-core/src/helper_gate.rs
+++ b/crates/veld-core/src/helper_gate.rs
@@ -5,8 +5,12 @@
 //! two crates must agree. The helper *decides* the gate at startup; `veld
 //! doctor` *reports* it from the helper's `status` response, and the wire values
 //! it matches on are [`GateSource::as_str`]. One definition, parsed back with
-//! [`GateSource::from_wire`], so the CLI's rendering is a compiler-checked match
-//! over the same enum rather than a second list of strings to drift from.
+//! [`GateSource::from_wire`], so the CLI renders by matching this enum rather
+//! than a second list of strings to drift from — and every one of those matches
+//! (`as_str` here, `gate_source_label` and `ungated_reason` in `veld doctor`) is
+//! deliberately wildcard-free, so a new variant fails to build until each side
+//! has said what to do with it. The field *names* are constants below for the
+//! same reason; the values alone were not the whole contract.
 
 use std::path::Path;
 
@@ -51,6 +55,11 @@ pub enum GateSource {
     UnreadableLibDir,
     /// Not the privileged system daemon. Its `0o700` owner-only socket is the
     /// restriction; there is nothing for a peer gate to add.
+    ///
+    /// Benign where it belongs — on the user helper — but an **anomaly** coming
+    /// back over the *system* socket, which is the only place `veld doctor`
+    /// reads it: a helper answering there while believing itself unprivileged
+    /// was given a `--socket-path` that does not match what setup writes.
     Unprivileged,
 }
 
@@ -66,19 +75,28 @@ impl GateSource {
         }
     }
 
+    /// Every variant, so [`Self::from_wire`] and the round-trip test share one
+    /// list instead of two.
+    ///
+    /// The one thing here a compiler cannot check: adding a variant and
+    /// forgetting this array. `as_str` and both of `veld doctor`'s rendering
+    /// functions are wildcard-free and *will* fail to build, so the omission
+    /// cannot escape a `cargo build` — but if it somehow did, the effect is the
+    /// designed degrade path (an unrecognised source reads as unknown), never a
+    /// wrong claim.
+    pub const ALL: [GateSource; 5] = [
+        GateSource::Flag,
+        GateSource::LibDirOwner,
+        GateSource::RefusedRootLibDir,
+        GateSource::UnreadableLibDir,
+        GateSource::Unprivileged,
+    ];
+
     /// Parse a wire value back. `None` for a value this build does not know —
     /// a helper newer than the CLI reading it, which must degrade to a vaguer
     /// message rather than to a wrong one.
     pub fn from_wire(value: &str) -> Option<Self> {
-        [
-            GateSource::Flag,
-            GateSource::LibDirOwner,
-            GateSource::RefusedRootLibDir,
-            GateSource::UnreadableLibDir,
-            GateSource::Unprivileged,
-        ]
-        .into_iter()
-        .find(|s| s.as_str() == value)
+        Self::ALL.into_iter().find(|s| s.as_str() == value)
     }
 }
 
@@ -276,6 +294,9 @@ mod tests {
     /// matching. Round-tripping every variant is what catches that.
     #[test]
     fn every_gate_source_round_trips_through_the_wire() {
+        // Driven off `ALL`, so a variant missing from it fails here rather than
+        // in a caller — and the literal pairs still pin the exact bytes, which
+        // is what `veld doctor` actually matches on.
         for (source, wire) in [
             (GateSource::Flag, "flag"),
             (GateSource::LibDirOwner, "lib-dir-owner"),
@@ -285,6 +306,14 @@ mod tests {
         ] {
             assert_eq!(source.as_str(), wire);
             assert_eq!(GateSource::from_wire(wire), Some(source));
+            assert!(GateSource::ALL.contains(&source));
+        }
+        for source in GateSource::ALL {
+            assert_eq!(
+                GateSource::from_wire(source.as_str()),
+                Some(source),
+                "{source:?} is in ALL but does not round-trip"
+            );
         }
         // A helper newer than this build is "unknown", never a wrong match.
         assert_eq!(GateSource::from_wire("invented-later"), None);

--- a/crates/veld-core/src/helper_gate.rs
+++ b/crates/veld-core/src/helper_gate.rs
@@ -10,6 +10,26 @@
 
 use std::path::Path;
 
+/// The `status` response field carrying the admitted uid (`null` when the socket
+/// is ungated).
+///
+/// A constant, not a literal at each end, because the *names* are as much of the
+/// contract as the values: rename one side and both crates still compile while
+/// the `veld doctor` row silently reports a current helper as too old to check.
+pub const ALLOW_UID_FIELD: &str = "allow_uid";
+
+/// The `status` response field carrying [`GateSource::as_str`].
+pub const ALLOW_UID_SOURCE_FIELD: &str = "allow_uid_source";
+
+/// What the helper writes back before dropping a connection the gate refused.
+///
+/// Shared because `veld doctor` matches on it to tell "the gate refused *you*"
+/// apart from "the helper is down" — which is the difference between naming the
+/// one failure mode this gate can introduce and saying nothing at all. The peer
+/// is untrusted, so this is for diagnosis only; nothing may depend on receiving
+/// it (see `reject_connection`).
+pub const REJECTED_PEER_ERROR: &str = "permission denied: untrusted peer uid";
+
 /// Where the privileged helper's peer-uid gate got the uid it admits — or why
 /// it has none.
 ///
@@ -24,9 +44,6 @@ pub enum GateSource {
     /// Derived from the owner of the directory the helper binary lives in,
     /// because the service definition carries no `--allow-uid`.
     LibDirOwner,
-    /// The service definition says `--allow-uid 0`. Ignored — see
-    /// [`Gate::resolve`].
-    RefusedRootFlag,
     /// The install directory is root-owned, so there is no installing user to
     /// derive. Ignored — see [`Gate::resolve`].
     RefusedRootLibDir,
@@ -43,7 +60,6 @@ impl GateSource {
         match self {
             GateSource::Flag => "flag",
             GateSource::LibDirOwner => "lib-dir-owner",
-            GateSource::RefusedRootFlag => "refused-root-flag",
             GateSource::RefusedRootLibDir => "refused-root-lib-dir",
             GateSource::UnreadableLibDir => "unreadable-lib-dir",
             GateSource::Unprivileged => "unprivileged",
@@ -57,7 +73,6 @@ impl GateSource {
         [
             GateSource::Flag,
             GateSource::LibDirOwner,
-            GateSource::RefusedRootFlag,
             GateSource::RefusedRootLibDir,
             GateSource::UnreadableLibDir,
             GateSource::Unprivileged,
@@ -98,17 +113,42 @@ impl Gate {
     /// the helper lives in `$HOME/.local/lib/veld`, created by `install.sh` as
     /// the installing user — the same user whose CLI drives this helper. The
     /// owner is also not attacker-controllable: giving a file away to another
-    /// uid requires root on both macOS and Linux, so no local process can point
-    /// the gate at itself. (A directory an attacker can *write* is a strictly
-    /// larger problem — they would replace the binary — and is what #262
-    /// closes.) The uid is never taken from the socket caller, which would be
-    /// the caller nominating its own permissions.
+    /// uid requires root on both macOS and Linux (`_POSIX_CHOWN_RESTRICTED`,
+    /// `CAP_CHOWN`), so no local process can point the gate at itself. The one
+    /// way an owner appears without a `chown` is a `uid=`-mapped mount
+    /// (exFAT/msdos, SMB/NFS, an image attached with ownership disabled) — and
+    /// there a non-root mount maps to the *mounting* user, so an attacker still
+    /// cannot name somebody else's uid. (A directory an attacker can *write* is
+    /// a strictly larger problem — they would replace the binary — and is what
+    /// #262 closes.) The uid is never taken from the socket caller, which would
+    /// be the caller nominating its own permissions.
     ///
-    /// **Why uid 0 is never a gate target, whatever its source.** A system-paths
-    /// install (`/usr/local/lib/veld`, created under `sudo`) is root-owned, and
-    /// gating to 0 would admit only root — locking the user's own CLI out of its
+    /// **Why a *derived* uid 0 is refused.** A system-paths install
+    /// (`/usr/local/lib/veld`, created under `sudo`) is root-owned, and gating
+    /// to 0 would admit only root — locking the user's own CLI out of its
     /// helper. That is the exact bug `resolve_real_uid()` was fixed for in #253,
-    /// and it presents as a helper that is simply broken.
+    /// and it presents as a helper that is simply broken. So that class of
+    /// install stays **ungated**, which is an acknowledged exception to #338's
+    /// "no user runs anything" rule: nothing on disk says who its installing
+    /// user is, so there is nothing to derive, and the remedy is the `veld setup
+    /// privileged` that `veld doctor` names.
+    ///
+    /// **An explicit `--allow-uid 0` is honoured, not refused.** The rule above
+    /// is about a uid this code *guessed*; a 0 in the service definition is one
+    /// an operator typed, and it means "root only". No veld version writes it
+    /// (`resolve_real_uid()` bails), so it only exists by hand-editing —
+    /// and turning it into "no gate" would silently reopen a root socket that
+    /// was deliberately closed. Availability is the user's to trade away here;
+    /// it is not ours to trade away for them.
+    ///
+    /// **Why once, at startup, rather than per connection.** The gate is a
+    /// property of the install, and the install changes by replacing this
+    /// binary — which restarts the process (`veld update` bounces the helper,
+    /// and `watch_own_binary` exits onto a swapped one), so the derivation
+    /// re-runs exactly when its inputs can have changed. A `chown` of the
+    /// install directory under a running helper does leave a stale gate until
+    /// the next restart; `veld doctor` compares the reported uid against the
+    /// invoking user's, so that state is visible rather than mysterious.
     ///
     /// **Why the error paths leave the socket ungated rather than shut.** Every
     /// "cannot tell" branch here resolves to no gate, which is fail-open — but
@@ -128,10 +168,6 @@ impl Gate {
             return Self::unprivileged();
         }
         match flag {
-            Some(0) => Self {
-                uid: None,
-                source: GateSource::RefusedRootFlag,
-            },
             Some(uid) => Self {
                 uid: Some(uid),
                 source: GateSource::Flag,
@@ -174,9 +210,15 @@ impl Gate {
 /// helper exec'd through a symlink: Linux's `/proc/self/exe` is already
 /// resolved, while macOS's `_NSGetExecutablePath` hands back the path used to
 /// exec.
+///
+/// A canonicalise that fails is `None`, never a fallback to the unresolved
+/// path. Guessing there would stat whatever the unresolved parent happens to
+/// be — the one branch where a symlinked path component would decide the
+/// admitted uid, and the only place the gap between resolving and stat'ing is
+/// worth anything to anyone. "Cannot tell" is a state this code already handles.
 fn lib_dir_owner(exe: &Path) -> Option<u32> {
     use std::os::unix::fs::MetadataExt;
-    let resolved = std::fs::canonicalize(exe).unwrap_or_else(|_| exe.to_path_buf());
+    let resolved = std::fs::canonicalize(exe).ok()?;
     let dir = resolved.parent()?;
     std::fs::metadata(dir).ok().map(|m| m.uid())
 }
@@ -214,10 +256,13 @@ mod tests {
         assert_eq!(g.uid(), None);
         assert_eq!(g.source(), GateSource::RefusedRootLibDir);
 
-        // Same rule for a hand-written `--allow-uid 0`, whatever its source.
+        // A hand-written `--allow-uid 0` is HONOURED, not refused: it is an
+        // operator's explicit "root only", no veld version writes it, and
+        // turning it into `None` would silently reopen a root socket somebody
+        // deliberately closed. The refusal above is for a uid this code guessed.
         let g = Gate::from_owner(Some(0), true, Some(INSTALLING));
-        assert_eq!(g.uid(), None);
-        assert_eq!(g.source(), GateSource::RefusedRootFlag);
+        assert_eq!(g.uid(), Some(0));
+        assert_eq!(g.source(), GateSource::Flag);
 
         // An unreadable directory is "no gate", never uid 0.
         let g = Gate::from_owner(None, true, None);
@@ -234,7 +279,6 @@ mod tests {
         for (source, wire) in [
             (GateSource::Flag, "flag"),
             (GateSource::LibDirOwner, "lib-dir-owner"),
-            (GateSource::RefusedRootFlag, "refused-root-flag"),
             (GateSource::RefusedRootLibDir, "refused-root-lib-dir"),
             (GateSource::UnreadableLibDir, "unreadable-lib-dir"),
             (GateSource::Unprivileged, "unprivileged"),

--- a/crates/veld-core/src/helper_gate.rs
+++ b/crates/veld-core/src/helper_gate.rs
@@ -1,0 +1,276 @@
+//! The privileged helper's peer-uid gate: which uid its socket admits, and
+//! where that uid came from.
+//!
+//! Lives here, not in `veld-helper`, for the reason [`crate::signing`] does —
+//! two crates must agree. The helper *decides* the gate at startup; `veld
+//! doctor` *reports* it from the helper's `status` response, and the wire values
+//! it matches on are [`GateSource::as_str`]. One definition, parsed back with
+//! [`GateSource::from_wire`], so the CLI's rendering is a compiler-checked match
+//! over the same enum rather than a second list of strings to drift from.
+
+use std::path::Path;
+
+/// Where the privileged helper's peer-uid gate got the uid it admits — or why
+/// it has none.
+///
+/// Reported over `status` (and rendered by `veld doctor`) because a privileged
+/// helper that is *not* gated is invisible from the outside: it serves every
+/// command exactly as a gated one does, to anybody. See [`Gate::resolve`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GateSource {
+    /// `--allow-uid` from the service definition, written by
+    /// `veld setup privileged`.
+    Flag,
+    /// Derived from the owner of the directory the helper binary lives in,
+    /// because the service definition carries no `--allow-uid`.
+    LibDirOwner,
+    /// The service definition says `--allow-uid 0`. Ignored — see
+    /// [`Gate::resolve`].
+    RefusedRootFlag,
+    /// The install directory is root-owned, so there is no installing user to
+    /// derive. Ignored — see [`Gate::resolve`].
+    RefusedRootLibDir,
+    /// The install directory could not be read at all.
+    UnreadableLibDir,
+    /// Not the privileged system daemon. Its `0o700` owner-only socket is the
+    /// restriction; there is nothing for a peer gate to add.
+    Unprivileged,
+}
+
+impl GateSource {
+    /// The wire value carried in the helper's `status` response.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            GateSource::Flag => "flag",
+            GateSource::LibDirOwner => "lib-dir-owner",
+            GateSource::RefusedRootFlag => "refused-root-flag",
+            GateSource::RefusedRootLibDir => "refused-root-lib-dir",
+            GateSource::UnreadableLibDir => "unreadable-lib-dir",
+            GateSource::Unprivileged => "unprivileged",
+        }
+    }
+
+    /// Parse a wire value back. `None` for a value this build does not know —
+    /// a helper newer than the CLI reading it, which must degrade to a vaguer
+    /// message rather than to a wrong one.
+    pub fn from_wire(value: &str) -> Option<Self> {
+        [
+            GateSource::Flag,
+            GateSource::LibDirOwner,
+            GateSource::RefusedRootFlag,
+            GateSource::RefusedRootLibDir,
+            GateSource::UnreadableLibDir,
+            GateSource::Unprivileged,
+        ]
+        .into_iter()
+        .find(|s| s.as_str() == value)
+    }
+}
+
+/// The peer-uid gate a helper enforces on its socket.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Gate {
+    uid: Option<u32>,
+    source: GateSource,
+}
+
+impl Gate {
+    /// A helper that is not the privileged system daemon: no peer gate.
+    pub fn unprivileged() -> Self {
+        Self {
+            uid: None,
+            source: GateSource::Unprivileged,
+        }
+    }
+
+    /// Decide the gate from the service definition and, failing that, from the
+    /// filesystem.
+    ///
+    /// **Why derive at all.** `--allow-uid` is a launchd/systemd *argument*, and
+    /// only `veld setup privileged` writes the service definition — `install.sh`
+    /// and `veld update` swap the binary and leave the plist alone. So every
+    /// privileged install that predates the flag would stay ungated until its
+    /// owner ran a `sudo` command, which is not a migration story (#337). The
+    /// helper can work the uid out for itself instead, and does so the moment
+    /// `veld update` bounces it, with no service-definition change at all.
+    ///
+    /// **Why the install directory's owner.** On the default privileged install
+    /// the helper lives in `$HOME/.local/lib/veld`, created by `install.sh` as
+    /// the installing user — the same user whose CLI drives this helper. The
+    /// owner is also not attacker-controllable: giving a file away to another
+    /// uid requires root on both macOS and Linux, so no local process can point
+    /// the gate at itself. (A directory an attacker can *write* is a strictly
+    /// larger problem — they would replace the binary — and is what #262
+    /// closes.) The uid is never taken from the socket caller, which would be
+    /// the caller nominating its own permissions.
+    ///
+    /// **Why uid 0 is never a gate target, whatever its source.** A system-paths
+    /// install (`/usr/local/lib/veld`, created under `sudo`) is root-owned, and
+    /// gating to 0 would admit only root — locking the user's own CLI out of its
+    /// helper. That is the exact bug `resolve_real_uid()` was fixed for in #253,
+    /// and it presents as a helper that is simply broken.
+    ///
+    /// **Why the error paths leave the socket ungated rather than shut.** Every
+    /// "cannot tell" branch here resolves to no gate, which is fail-open — but
+    /// the alternative is a root daemon that refuses to serve, and under
+    /// launchd's `KeepAlive` that is a throttled restart loop with Caddy down
+    /// and every URL dropped. Ungated is also exactly the pre-existing state, so
+    /// it is a non-regression rather than a new hole, and `veld doctor` reports
+    /// it as a failing row with a remedy — loud, not silent.
+    pub fn resolve(flag: Option<u32>, privileged: bool, exe: Option<&Path>) -> Self {
+        Self::from_owner(flag, privileged, exe.and_then(lib_dir_owner))
+    }
+
+    /// [`Gate::resolve`] with the filesystem lookup already done, so the policy
+    /// is testable without a chown.
+    pub fn from_owner(flag: Option<u32>, privileged: bool, lib_dir_owner: Option<u32>) -> Self {
+        if !privileged {
+            return Self::unprivileged();
+        }
+        match flag {
+            Some(0) => Self {
+                uid: None,
+                source: GateSource::RefusedRootFlag,
+            },
+            Some(uid) => Self {
+                uid: Some(uid),
+                source: GateSource::Flag,
+            },
+            None => match lib_dir_owner {
+                Some(0) => Self {
+                    uid: None,
+                    source: GateSource::RefusedRootLibDir,
+                },
+                Some(uid) => Self {
+                    uid: Some(uid),
+                    source: GateSource::LibDirOwner,
+                },
+                None => Self {
+                    uid: None,
+                    source: GateSource::UnreadableLibDir,
+                },
+            },
+        }
+    }
+
+    /// The uid admitted alongside root, or `None` for an ungated socket.
+    pub fn uid(&self) -> Option<u32> {
+        self.uid
+    }
+
+    pub fn source(&self) -> GateSource {
+        self.source
+    }
+}
+
+/// The owning uid of the directory `exe` lives in.
+///
+/// `None` when the path has no parent or the directory cannot be stat'd — the
+/// caller must treat that as "no gate", never as uid 0, which would gate to
+/// root.
+///
+/// The path is canonicalised first so the answer describes the directory the
+/// binary is actually served from. Without it the two platforms disagree for a
+/// helper exec'd through a symlink: Linux's `/proc/self/exe` is already
+/// resolved, while macOS's `_NSGetExecutablePath` hands back the path used to
+/// exec.
+fn lib_dir_owner(exe: &Path) -> Option<u32> {
+    use std::os::unix::fs::MetadataExt;
+    let resolved = std::fs::canonicalize(exe).unwrap_or_else(|_| exe.to_path_buf());
+    let dir = resolved.parent()?;
+    std::fs::metadata(dir).ok().map(|m| m.uid())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Gate, GateSource};
+
+    /// The gate's whole policy, as pure logic — the filesystem lookup is the one
+    /// thing held out (see `derives_the_gate_from_a_real_directorys_owner`).
+    #[test]
+    fn gate_policy_covers_every_way_a_uid_can_be_absent() {
+        const INSTALLING: u32 = 501;
+
+        // An unprivileged helper is never gated, whatever the filesystem says:
+        // its 0o700 owner-only socket is the restriction.
+        let g = Gate::from_owner(Some(INSTALLING), false, Some(INSTALLING));
+        assert_eq!(g.uid(), None);
+        assert_eq!(g.source(), GateSource::Unprivileged);
+
+        // The service definition wins when it carries a usable uid.
+        let g = Gate::from_owner(Some(INSTALLING), true, Some(999));
+        assert_eq!(g.uid(), Some(INSTALLING));
+        assert_eq!(g.source(), GateSource::Flag);
+
+        // No flag — the pre-#337 install every existing privileged machine has —
+        // derives from the install directory's owner. This is the whole point.
+        let g = Gate::from_owner(None, true, Some(INSTALLING));
+        assert_eq!(g.uid(), Some(INSTALLING));
+        assert_eq!(g.source(), GateSource::LibDirOwner);
+
+        // A root-owned install directory (system paths) must NOT gate to 0: that
+        // admits only root and locks the user's own CLI out.
+        let g = Gate::from_owner(None, true, Some(0));
+        assert_eq!(g.uid(), None);
+        assert_eq!(g.source(), GateSource::RefusedRootLibDir);
+
+        // Same rule for a hand-written `--allow-uid 0`, whatever its source.
+        let g = Gate::from_owner(Some(0), true, Some(INSTALLING));
+        assert_eq!(g.uid(), None);
+        assert_eq!(g.source(), GateSource::RefusedRootFlag);
+
+        // An unreadable directory is "no gate", never uid 0.
+        let g = Gate::from_owner(None, true, None);
+        assert_eq!(g.uid(), None);
+        assert_eq!(g.source(), GateSource::UnreadableLibDir);
+    }
+
+    /// The wire values are the contract between the helper that writes them and
+    /// the `veld doctor` row that reads them, and nothing else pins them: a
+    /// renamed variant would still compile on both sides and quietly stop
+    /// matching. Round-tripping every variant is what catches that.
+    #[test]
+    fn every_gate_source_round_trips_through_the_wire() {
+        for (source, wire) in [
+            (GateSource::Flag, "flag"),
+            (GateSource::LibDirOwner, "lib-dir-owner"),
+            (GateSource::RefusedRootFlag, "refused-root-flag"),
+            (GateSource::RefusedRootLibDir, "refused-root-lib-dir"),
+            (GateSource::UnreadableLibDir, "unreadable-lib-dir"),
+            (GateSource::Unprivileged, "unprivileged"),
+        ] {
+            assert_eq!(source.as_str(), wire);
+            assert_eq!(GateSource::from_wire(wire), Some(source));
+        }
+        // A helper newer than this build is "unknown", never a wrong match.
+        assert_eq!(GateSource::from_wire("invented-later"), None);
+    }
+
+    /// The derivation reads a real directory's owner, not a constant — and
+    /// `resolve` reaches it from a binary path the way the helper does.
+    ///
+    /// Written to hold whoever the suite runs as: on a machine where the test
+    /// user *is* root the correct answer is "refuse", which is the same property
+    /// stated from the other side.
+    #[test]
+    fn derives_the_gate_from_a_real_directorys_owner() {
+        let dir = tempfile::tempdir().unwrap();
+        let exe = dir.path().join("veld-helper");
+        std::fs::write(&exe, b"not really a binary").unwrap();
+        let me = nix::unistd::Uid::effective().as_raw();
+
+        let gate = Gate::resolve(None, true, Some(&exe));
+        if me == 0 {
+            assert_eq!(gate.uid(), None);
+            assert_eq!(gate.source(), GateSource::RefusedRootLibDir);
+        } else {
+            assert_eq!(gate.uid(), Some(me));
+            assert_eq!(gate.source(), GateSource::LibDirOwner);
+        }
+
+        // A path with no parent directory to stat is "no gate", not uid 0.
+        let gate = Gate::resolve(None, true, Some(std::path::Path::new("/")));
+        assert_eq!(gate.uid(), None);
+        assert_eq!(gate.source(), GateSource::UnreadableLibDir);
+    }
+}

--- a/crates/veld-core/src/lib.rs
+++ b/crates/veld-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod files;
 pub mod graph;
 pub mod health;
 pub mod helper;
+pub mod helper_gate;
 pub mod ide;
 pub mod include;
 pub mod instance;

--- a/crates/veld-helper/src/handler.rs
+++ b/crates/veld-helper/src/handler.rs
@@ -352,8 +352,8 @@ impl State {
             // flag can front a perfectly gated helper, and reading the plist
             // would report the opposite. `null` means the socket is ungated;
             // `allow_uid_source` says why.
-            "allow_uid": self.gate.uid(),
-            "allow_uid_source": self.gate.source().as_str(),
+            veld_core::helper_gate::ALLOW_UID_FIELD: self.gate.uid(),
+            veld_core::helper_gate::ALLOW_UID_SOURCE_FIELD: self.gate.source().as_str(),
         }))
     }
 
@@ -521,6 +521,49 @@ mod tests {
         // Wrong shape (a string where an object is expected) → default, no panic.
         let args = serde_json::json!({ "proxy": "not-an-object" });
         assert!(parse_proxy_arg(&args).is_empty());
+    }
+
+    /// The `status` response must carry the gate under the exact field names
+    /// `veld doctor` reads, with the uid as a bare number.
+    ///
+    /// Nothing else pins this. Rename a field or drop it and both crates still
+    /// compile, while the doctor row degrades to "this helper is too old to
+    /// report the gate" on a perfectly current helper — a red row nobody can
+    /// act on, for a machine that is fine. `helper_gate`'s round-trip test
+    /// covers the source *values*; this covers the *keys* and the payload shape.
+    #[tokio::test]
+    async fn status_reports_the_uid_gate_under_the_names_doctor_reads() {
+        use veld_core::helper_gate::{ALLOW_UID_FIELD, ALLOW_UID_SOURCE_FIELD, Gate};
+
+        // Ungated (the unprivileged fixture): the field is present and null, not
+        // absent — doctor tells those two apart, and only "absent" means "this
+        // helper predates the report".
+        let data = test_state().handle_status().await.data.unwrap();
+        assert_eq!(data.get(ALLOW_UID_FIELD), Some(&serde_json::Value::Null));
+        assert_eq!(
+            data.get(ALLOW_UID_SOURCE_FIELD).and_then(|v| v.as_str()),
+            Some("unprivileged")
+        );
+
+        // Gated: a bare number, so `as_u64()` on the reading side works.
+        let (tx, _rx) = tokio::sync::watch::channel(false);
+        let gated = State::new(
+            443,
+            80,
+            None,
+            tx,
+            true,
+            Gate::from_owner(None, true, Some(501)),
+        );
+        let data = gated.handle_status().await.data.unwrap();
+        assert_eq!(
+            data.get(ALLOW_UID_FIELD).and_then(|v| v.as_u64()),
+            Some(501)
+        );
+        assert_eq!(
+            data.get(ALLOW_UID_SOURCE_FIELD).and_then(|v| v.as_str()),
+            Some("lib-dir-owner")
+        );
     }
 
     /// An **unprivileged** `State`: it holds no `SleepManager` at all.

--- a/crates/veld-helper/src/handler.rs
+++ b/crates/veld-helper/src/handler.rs
@@ -28,6 +28,13 @@ pub struct State {
     /// a signature requirement there would only add spurious refusals for
     /// unsigned dev builds.
     privileged: bool,
+    /// The peer-uid gate this helper enforces on its socket, reported over
+    /// `status`. Held here purely so `veld doctor` can tell an active gate from
+    /// an absent one — a privileged helper that is not gated serves every
+    /// command to anybody and looks identical from the outside, which is the
+    /// green-but-unprotected state #337 removes. The accept loop reads the same
+    /// value directly; this is not a second source of truth.
+    gate: veld_core::helper_gate::Gate,
 }
 
 impl State {
@@ -40,6 +47,7 @@ impl State {
         // helper may take the sleep setting — see the `sleep` field — or is
         // bound by the swap-relaunch signing gate (`crate::signing`).
         privileged: bool,
+        gate: veld_core::helper_gate::Gate,
     ) -> Self {
         Self {
             dns: DnsManager::new(),
@@ -53,6 +61,7 @@ impl State {
             sleep: (privileged && cfg!(target_os = "macos")).then(SleepManager::new),
             shutdown_tx,
             privileged,
+            gate,
         }
     }
 
@@ -336,6 +345,15 @@ impl State {
                 Some(sleep) => sleep.held().await,
                 None => false,
             },
+            // The peer-uid gate, as this process actually resolved it — read by
+            // `veld doctor` (`crates/veld/src/commands/doctor.rs`). The service
+            // definition is NOT the answer: a privileged helper with no
+            // `--allow-uid` derives the uid at startup (#337), so a plist with no
+            // flag can front a perfectly gated helper, and reading the plist
+            // would report the opposite. `null` means the socket is ungated;
+            // `allow_uid_source` says why.
+            "allow_uid": self.gate.uid(),
+            "allow_uid_source": self.gate.source().as_str(),
         }))
     }
 
@@ -516,7 +534,14 @@ mod tests {
     /// assert on is still the argument one.
     fn test_state() -> State {
         let (tx, _rx) = tokio::sync::watch::channel(false);
-        State::new(443, 80, None, tx, false)
+        State::new(
+            443,
+            80,
+            None,
+            tx,
+            false,
+            veld_core::helper_gate::Gate::unprivileged(),
+        )
     }
 
     /// A lease request with no usable `lease_secs` is refused *before* anything

--- a/crates/veld-helper/src/main.rs
+++ b/crates/veld-helper/src/main.rs
@@ -777,6 +777,55 @@ mod tests {
         );
     }
 
+    /// The refusal a gated socket writes must reach `veld doctor` as the error
+    /// it keys off — end to end, through the real client.
+    ///
+    /// Two halves already had tests and the seam between them had none:
+    /// `a_refused_peer_gets_the_same_bytes_it_always_did` pins what the helper
+    /// writes, and `gate_check`'s tests cover what the row does with a refusal,
+    /// but nothing asserted that `HelperClient` turns the first into the second.
+    /// A change to `HelperError`'s variants, or to `send_inner`'s `ok: false`
+    /// handling, would make the doctor branch dead code with every other test
+    /// still green.
+    #[tokio::test]
+    async fn a_refused_peer_reaches_the_client_as_the_error_doctor_matches_on() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("helper.sock");
+        let listener = tokio::net::UnixListener::bind(&socket).unwrap();
+
+        // Stand in for the accept loop's gate: refuse without reading, exactly
+        // as `reject_connection` does.
+        tokio::spawn(async move {
+            while let Ok((mut stream, _)) = listener.accept().await {
+                use tokio::io::AsyncWriteExt;
+                let _ = stream.write_all(super::rejection_bytes().as_bytes()).await;
+            }
+        });
+
+        let err = veld_core::helper::HelperClient::connect_to(&socket)
+            .await
+            .err()
+            .expect("a refused peer must not connect successfully");
+
+        match err {
+            veld_core::helper::HelperError::CommandError(message) => assert!(
+                message.contains(veld_core::helper_gate::REJECTED_PEER_ERROR),
+                "doctor matches this error's text; got {message:?}"
+            ),
+            // The write can still lose the race against the client's own — which
+            // is why `veld doctor` has an `Unreadable` arm and does not depend on
+            // this message. Anything else means the mapping changed.
+            other => assert!(
+                matches!(
+                    other,
+                    veld_core::helper::HelperError::SendFailed(_)
+                        | veld_core::helper::HelperError::ReadFailed(_)
+                ),
+                "unexpected error kind for a refused peer: {other:?}"
+            ),
+        }
+    }
+
     /// `is_system_socket` is the switch deciding whether a root helper derives a
     /// gate at all, so the real socket paths must land on the right side of it —
     /// including on Linux, where the user socket must not be mistaken for a

--- a/crates/veld-helper/src/main.rs
+++ b/crates/veld-helper/src/main.rs
@@ -188,11 +188,14 @@ async fn main() -> Result<()> {
     // no `--allow-uid` in its service definition (only `veld setup privileged`
     // writes one) and must still end up gated. See [`Gate::resolve`].
     let privileged = is_system_socket(&config.socket_path);
-    let gate = Gate::resolve(
-        config.allow_uid,
-        privileged,
-        std::env::current_exe().ok().as_deref(),
-    );
+    // `current_exe()` failing and the install directory being unreadable both
+    // land on `UnreadableLibDir`, whose user-facing text names the directory —
+    // so log the io error here or it is gone from the one place a support
+    // transcript would look for it.
+    let exe = std::env::current_exe()
+        .inspect_err(|e| warn!(error = %e, "could not read own executable path; the peer-uid gate cannot be derived"))
+        .ok();
+    let gate = Gate::resolve(config.allow_uid, privileged, exe.as_deref());
     log_gate(&gate);
 
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
@@ -478,7 +481,16 @@ async fn reject_connection(stream: tokio::net::UnixStream) {
     use tokio::io::AsyncWriteExt;
     let mut stream = stream;
     let _ = stream
-        .write_all(b"{\"ok\":false,\"error\":\"permission denied: untrusted peer uid\"}\n")
+        .write_all(
+            format!(
+                "{}\n",
+                serde_json::json!({
+                    "ok": false,
+                    "error": veld_core::helper_gate::REJECTED_PEER_ERROR,
+                })
+            )
+            .as_bytes(),
+        )
         .await;
 }
 
@@ -740,6 +752,32 @@ mod tests {
         assert!(!peer_allowed(502, INSTALLING));
         // A root helper whose --allow-uid is root-only still allows root.
         assert!(peer_allowed(0, 0));
+    }
+
+    /// `is_system_socket` is the switch deciding whether a root helper gates its
+    /// socket *at all*, so the two real socket paths must land on the right side
+    /// of it — including on Linux, where the user socket must not be mistaken
+    /// for a system one.
+    #[test]
+    fn only_the_system_domain_socket_reads_as_privileged() {
+        use super::is_system_socket;
+        use std::path::Path;
+
+        // The paths `veld-core` actually hands out.
+        assert!(is_system_socket(&veld_core::helper::system_socket_path()));
+        assert!(!is_system_socket(&veld_core::helper::user_socket_path()));
+
+        // Both platforms' system paths read as privileged wherever the suite
+        // runs, because the plist/unit pins an absolute path, not a cfg.
+        assert!(is_system_socket(Path::new("/var/run/veld-helper.sock")));
+        assert!(is_system_socket(Path::new("/run/veld-helper.sock")));
+
+        // The user helper's own path, and the `/tmp` fallback `user_socket_path`
+        // degrades to when there is no home directory, are NOT privileged —
+        // they rely on the 0o700 owner-only socket instead.
+        assert!(!is_system_socket(Path::new("/Users/x/.veld/helper.sock")));
+        assert!(!is_system_socket(Path::new("/home/x/.veld/helper.sock")));
+        assert!(!is_system_socket(Path::new("/tmp/veld-helper.sock")));
     }
 
     /// The kernel-attested peer uid of a same-process peer is this process's

--- a/crates/veld-helper/src/main.rs
+++ b/crates/veld-helper/src/main.rs
@@ -777,10 +777,13 @@ mod tests {
         );
     }
 
-    /// `is_system_socket` is the switch deciding whether a root helper gates its
-    /// socket *at all*, so the two real socket paths must land on the right side
-    /// of it — including on Linux, where the user socket must not be mistaken
-    /// for a system one.
+    /// `is_system_socket` is the switch deciding whether a root helper derives a
+    /// gate at all, so the real socket paths must land on the right side of it —
+    /// including on Linux, where the user socket must not be mistaken for a
+    /// system one.
+    ///
+    /// The last assertion pins a known imprecision rather than a guarantee; read
+    /// its comment before "fixing" it.
     #[test]
     fn only_the_system_domain_socket_reads_as_privileged() {
         use super::is_system_socket;
@@ -801,6 +804,20 @@ mod tests {
         assert!(!is_system_socket(Path::new("/Users/x/.veld/helper.sock")));
         assert!(!is_system_socket(Path::new("/home/x/.veld/helper.sock")));
         assert!(!is_system_socket(Path::new("/tmp/veld-helper.sock")));
+
+        // **The gap, asserted rather than glossed.** This is a string prefix,
+        // not a path-component match, so Linux's user-writable
+        // `$XDG_RUNTIME_DIR` (`/run/user/<uid>`) reads as privileged too. Benign
+        // today and deliberately left alone: no shipped path passes such a
+        // `--socket-path` (both service writers use the two paths above, and
+        // auto-bootstrap uses `user_socket_path()`), and a helper there would
+        // run as the user, derive a gate to itself, and gate *more* than it does
+        // now. Tightening it would also move the signing gate and the sleep
+        // manager, which read the same predicate and which this change did not
+        // introduce — so it is a separate change, not a silent one made here.
+        assert!(is_system_socket(Path::new(
+            "/run/user/1000/veld-helper.sock"
+        )));
     }
 
     /// The kernel-attested peer uid of a same-process peer is this process's

--- a/crates/veld-helper/src/main.rs
+++ b/crates/veld-helper/src/main.rs
@@ -13,6 +13,7 @@ use anyhow::{Context, Result};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixListener;
 use tracing::{debug, error, info, warn};
+use veld_core::helper_gate::{Gate, GateSource};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -53,10 +54,11 @@ struct HelperConfig {
     http_port: u16,
     /// Override the Caddy binary path (avoids lib_dir() resolution issues under sudo).
     caddy_bin: Option<PathBuf>,
-    /// When set, only this uid (and root, uid 0 — privileged setup connects as
-    /// root to verify the socket) may drive this helper over its socket. Only
-    /// the privileged system daemon is given one; an unprivileged helper relies
-    /// on its 0o700 owner-only socket instead.
+    /// `--allow-uid` as written into the service definition by
+    /// `veld setup privileged`: the one uid (besides root) allowed to drive this
+    /// helper over its socket. An *override*, not the whole story — a privileged
+    /// helper with no flag derives the uid instead, so that installs predating
+    /// the flag are gated without anyone re-running setup. See [`Gate::resolve`].
     allow_uid: Option<u32>,
 }
 
@@ -181,6 +183,18 @@ async fn main() -> Result<()> {
         config.socket_path.display()
     );
 
+    // The peer-uid gate. Resolved once, here, rather than read straight off
+    // `config.allow_uid` in the accept loop: an existing privileged install has
+    // no `--allow-uid` in its service definition (only `veld setup privileged`
+    // writes one) and must still end up gated. See [`Gate::resolve`].
+    let privileged = is_system_socket(&config.socket_path);
+    let gate = Gate::resolve(
+        config.allow_uid,
+        privileged,
+        std::env::current_exe().ok().as_deref(),
+    );
+    log_gate(&gate);
+
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
 
     let state = Arc::new(handler::State::new(
@@ -191,7 +205,8 @@ async fn main() -> Result<()> {
         // The privileged system daemon (root) is the only one the swap-relaunch
         // signing gate protects; an unprivileged user helper relaunches as the
         // user and needs no signature to shut down.
-        is_system_socket(&config.socket_path),
+        privileged,
+        gate,
     ));
 
     // Startup reconcile: if a Caddy is already running (orphaned across our own
@@ -277,7 +292,7 @@ async fn main() -> Result<()> {
     // LaunchAgent is already restarted by the installer via user-domain
     // launchctl (no sudo), and the auto-bootstrapped helper is ephemeral and
     // has nothing to relaunch it — so exiting there would just drop URLs.
-    if is_system_socket(&config.socket_path) {
+    if privileged {
         tokio::spawn(watch_own_binary());
     }
 
@@ -291,15 +306,16 @@ async fn main() -> Result<()> {
                 match result {
                     Ok((stream, _addr)) => {
                         // Peer-credential gate, applied to the *privileged* system
-                        // daemon only (the one with `--allow-uid`). The socket is
-                        // world-writable (0o777) so the unprivileged CLI can connect,
-                        // which means *any* local process can currently drive a root
-                        // helper — including `shutdown`, which stops Caddy and drops
-                        // every live URL. The kernel attests the connecting process's
-                        // uid at connect time, so this cannot be spoofed by holding the
-                        // socket open. Only the installing user (and root, which
-                        // privileged setup connects as to verify the socket) is allowed.
-                        if let Some(allowed) = config.allow_uid {
+                        // daemon only. The socket is world-writable (0o777) so the
+                        // unprivileged CLI can connect, which means *any* local process
+                        // could otherwise drive a root helper — including `shutdown`,
+                        // which stops Caddy and drops every live URL. The kernel
+                        // attests the connecting process's uid at connect time, so this
+                        // cannot be spoofed by holding the socket open. Only the
+                        // installing user (and root, which privileged setup connects as
+                        // to verify the socket) is allowed; `gate` decides which uid
+                        // that is, from the service definition or from the filesystem.
+                        if let Some(allowed) = gate.uid() {
                             match peer_uid(&stream) {
                                 Some(uid) if peer_allowed(uid, allowed) => {}
                                 Some(uid) => {
@@ -629,6 +645,27 @@ async fn service_manager_owns_us() -> bool {
 fn is_system_socket(path: &Path) -> bool {
     let s = path.to_string_lossy();
     s.starts_with("/var/run") || s.starts_with("/run")
+}
+
+/// Say what the peer-uid gate resolved to, once, at startup.
+///
+/// An ungated *privileged* helper warns rather than informs: it is the state
+/// #337 exists to remove, and the helper's own log is where a support
+/// transcript looks first. See [`veld_core::helper_gate::Gate::resolve`].
+fn log_gate(gate: &Gate) {
+    match gate.uid() {
+        Some(uid) => info!(
+            allow_uid = uid,
+            source = gate.source().as_str(),
+            "privileged helper socket gated to a single uid"
+        ),
+        None if gate.source() == GateSource::Unprivileged => {}
+        None => warn!(
+            source = gate.source().as_str(),
+            "privileged helper socket is NOT uid-gated — any local process can drive it; \
+             run `veld setup privileged` to write the gate explicitly"
+        ),
+    }
 }
 
 /// A cheap change signature for a file: (size, mtime-seconds).

--- a/crates/veld-helper/src/main.rs
+++ b/crates/veld-helper/src/main.rs
@@ -480,18 +480,23 @@ fn peer_uid_fd(fd: i32) -> Option<u32> {
 async fn reject_connection(stream: tokio::net::UnixStream) {
     use tokio::io::AsyncWriteExt;
     let mut stream = stream;
-    let _ = stream
-        .write_all(
-            format!(
-                "{}\n",
-                serde_json::json!({
-                    "ok": false,
-                    "error": veld_core::helper_gate::REJECTED_PEER_ERROR,
-                })
-            )
-            .as_bytes(),
-        )
-        .await;
+    let _ = stream.write_all(rejection_bytes().as_bytes()).await;
+}
+
+/// The exact bytes [`reject_connection`] writes.
+///
+/// Built from [`crate::protocol::Response`] rather than a hand-written literal
+/// so the shared [`veld_core::helper_gate::REJECTED_PEER_ERROR`] is escaped by
+/// the same serializer as every other reply — and so the field order stays the
+/// one a struct gives (`ok` then `error`), which a `serde_json::json!` map would
+/// have sorted alphabetically instead. Separate from the writer so a test can
+/// read it without a socket.
+fn rejection_bytes() -> String {
+    let response = protocol::Response::err(veld_core::helper_gate::REJECTED_PEER_ERROR);
+    format!(
+        "{}\n",
+        serde_json::to_string(&response).expect("response serialization cannot fail")
+    )
 }
 
 /// Poll the helper's own executable; when its size/mtime changes and settles,
@@ -752,6 +757,24 @@ mod tests {
         assert!(!peer_allowed(502, INSTALLING));
         // A root helper whose --allow-uid is root-only still allows root.
         assert!(peer_allowed(0, 0));
+    }
+
+    /// The refusal a gated socket writes back is a wire contract in two
+    /// directions: `veld doctor` matches its text to say "the gate refused you"
+    /// rather than "helper down", and it must stay the shape every other reply
+    /// has. Pinned to the exact bytes `origin/main` sent, since a client reading
+    /// it is by definition one the helper cannot negotiate with.
+    #[test]
+    fn a_refused_peer_gets_the_same_bytes_it_always_did() {
+        assert_eq!(
+            super::rejection_bytes(),
+            "{\"ok\":false,\"error\":\"permission denied: untrusted peer uid\"}\n"
+        );
+        // And the text `veld doctor` keys off is really in there.
+        assert!(
+            super::rejection_bytes().contains(veld_core::helper_gate::REJECTED_PEER_ERROR),
+            "doctor's refusal detection matches on this string"
+        );
     }
 
     /// `is_system_socket` is the switch deciding whether a root helper gates its

--- a/crates/veld/src/commands/doctor.rs
+++ b/crates/veld/src/commands/doctor.rs
@@ -527,6 +527,24 @@ impl Diagnostics {
             .and_then(|v| v.as_str())
             .and_then(GateSource::from_wire);
 
+        // `null` is the only shape that means "ungated". Anything else that is
+        // not a number — a uid emitted as a string by some future helper, say —
+        // is a response this build cannot read, and the field-absent case above
+        // already established that "cannot read" must never become the definite
+        // claim that the socket is open. `as_u64()` alone would collapse the two.
+        if !reported.is_null() && reported.as_u64().is_none() {
+            self.checks.push(Check {
+                pass: false,
+                label: format!(
+                    "Helper socket uid gate cannot be confirmed — the helper reported \
+                     `{}` as its allowed uid, which this version of `veld` cannot read. \
+                     Run `veld update` so the CLI and the helper match.",
+                    veld_core::helper_gate::ALLOW_UID_FIELD
+                ),
+            });
+            return;
+        }
+
         let check = match reported.as_u64() {
             // Gated to root only. Reachable solely from a hand-written
             // `--allow-uid 0`, which the helper honours as the deliberate

--- a/crates/veld/src/commands/doctor.rs
+++ b/crates/veld/src/commands/doctor.rs
@@ -1502,6 +1502,25 @@ fn gate_source_label(source: Option<GateSource>) -> &'static str {
     }
 }
 
+/// Appended to every *failing* gate row.
+///
+/// The row runs for whoever types `veld doctor`, because the reader a
+/// newly-derived gate locks out is by construction not the installing user (see
+/// [`Diagnostics::check_helper_uid_gate`]). The cost is that a second reader —
+/// someone on a shared machine whose privileged veld legitimately belongs to
+/// another account — sees the same red row, and every remedy it could offer is
+/// wrong for them: `veld setup privileged` resolves the binary through
+/// `which_self`, so following it would leave a root LaunchDaemon exec'ing a
+/// binary out of *their* home directory and gate the socket to them, locking the
+/// real owner out. `veld update` is merely futile — it cannot touch somebody
+/// else's root service, so the row would stay red forever.
+///
+/// Nothing here can tell the two readers apart, so every failing row says so.
+/// One sentence of noise for the owner is the right price for not handing the
+/// other reader a hijack.
+const NOT_YOUR_INSTALL: &str = " If this machine's privileged veld belongs to another account, \
+                                none of this is yours to fix — leave it to its owner.";
+
 /// What the privileged helper told `veld doctor` about its gate.
 ///
 /// A type rather than a bare `Option<Value>` so the *refused* answer — which
@@ -1556,7 +1575,7 @@ fn gate_check(report: &GateReport, invoking: Option<u64>) -> Option<Check> {
         return Some(Check {
             pass: false,
             label: format!(
-                "Helper socket uid gate cannot be confirmed — {}",
+                "Helper socket uid gate cannot be confirmed — {}{NOT_YOUR_INSTALL}",
                 unreportable_gate_reason()
             ),
         });
@@ -1577,7 +1596,7 @@ fn gate_check(report: &GateReport, invoking: Option<u64>) -> Option<Check> {
             label: format!(
                 "Helper socket uid gate cannot be confirmed — the helper reported `{}` as its \
                  allowed uid, which this version of `veld` cannot read. Run `veld update` so \
-                 the CLI and the helper match.",
+                 the CLI and the helper match.{NOT_YOUR_INSTALL}",
                 veld_core::helper_gate::ALLOW_UID_FIELD
             ),
         });
@@ -1590,10 +1609,11 @@ fn gate_check(report: &GateReport, invoking: Option<u64>) -> Option<Check> {
         // helper, and only a root reader ever gets far enough to see this.
         Some(0) => Check {
             pass: false,
-            label: "Helper socket gated to uid 0 — that admits only root, so the `veld` CLI \
-                    cannot drive its own helper. Run `veld setup privileged` to write the \
-                    installing user's uid."
-                .into(),
+            label: format!(
+                "Helper socket gated to uid 0 — that admits only root, so the `veld` CLI \
+                 cannot drive its own helper. Run `veld setup privileged` to write the \
+                 installing user's uid.{NOT_YOUR_INSTALL}"
+            ),
         },
         // Gated, but not to the user reading this. Only reachable as root
         // (every other uid is refused before it can ask), which is exactly
@@ -1603,7 +1623,8 @@ fn gate_check(report: &GateReport, invoking: Option<u64>) -> Option<Check> {
             pass: false,
             label: format!(
                 "Helper socket gated to uid {uid}, but you are uid {} — your `veld` commands \
-                 cannot drive it. Run `veld setup privileged` to write the correct uid.",
+                 cannot drive it. Run `veld setup privileged` to write the correct \
+                 uid.{NOT_YOUR_INSTALL}",
                 invoking.unwrap_or(0)
             ),
         },
@@ -1618,7 +1639,8 @@ fn gate_check(report: &GateReport, invoking: Option<u64>) -> Option<Check> {
             pass: false,
             label: format!(
                 "Helper socket NOT gated to a uid — any local process can drive the root \
-                 helper, including `shutdown`, which stops Caddy and drops every live URL. {}",
+                 helper, including `shutdown`, which stops Caddy and drops every live \
+                 URL. {}{NOT_YOUR_INSTALL}",
                 ungated_reason(source)
             ),
         },
@@ -2650,6 +2672,51 @@ mod tests {
         );
         assert!(c.pass);
         assert!(c.label.contains("source unknown"));
+    }
+
+    /// No failing gate row may hand a reader a remedy without saying it might
+    /// not be theirs to run.
+    ///
+    /// The row runs for whoever types `veld doctor`, and on a shared machine
+    /// that includes somebody whose privileged veld belongs to another account.
+    /// For them `veld setup privileged` is a hijack — it repoints a root service
+    /// at their own binary and gates the socket to them — and `veld update`
+    /// cannot touch the other account's service at all. An earlier fix put the
+    /// caveat on the refused branch only, and the ungated branch (which every
+    /// local uid reaches, because an ungated helper refuses nobody) went on
+    /// advising the hijack. This asserts the property across every branch rather
+    /// than one at a time, so a new branch inherits the requirement.
+    #[test]
+    fn no_failing_gate_row_tells_a_stranger_to_take_over_the_service() {
+        use super::{GateReport, gate_check};
+
+        let reports = [
+            GateReport::Refused,
+            GateReport::Status(serde_json::json!({ "version": "16.58.1" })),
+            GateReport::Status(serde_json::json!({ "allow_uid": "501" })),
+            GateReport::Status(serde_json::json!({ "allow_uid": 0 })),
+            GateReport::Status(serde_json::json!({ "allow_uid": 999 })),
+            GateReport::Status(serde_json::json!({
+                "allow_uid": serde_json::Value::Null,
+                "allow_uid_source": "refused-root-lib-dir",
+            })),
+        ];
+
+        for report in &reports {
+            for me in [Some(501u64), Some(0), None] {
+                let Some(check) = gate_check(report, me) else {
+                    continue;
+                };
+                if check.pass {
+                    continue;
+                }
+                assert!(
+                    check.label.contains("belongs to another account"),
+                    "a failing row offered a remedy with no owner caveat: {}",
+                    check.label
+                );
+            }
+        }
     }
 
     /// The uid-match rule, isolated from the socket call so the `root` escape

--- a/crates/veld/src/commands/doctor.rs
+++ b/crates/veld/src/commands/doctor.rs
@@ -482,9 +482,17 @@ impl Diagnostics {
     async fn check_helper_uid_gate(&mut self) {
         let socket = veld_core::helper::system_socket_path();
         let reported = match veld_core::helper::HelperClient::connect_to(&socket).await {
+            // `connect_to` already *made* a status call as its liveness probe —
+            // and threw the payload away. This second one is the round-trip that
+            // actually carries the gate, so it can fail where the first
+            // succeeded (a helper that restarted in between, which `veld update`
+            // makes routine). A failure here is the same "something answered and
+            // the gate could not be read" as the error arms below; going silent
+            // was the third instance of the disappearing-row bug this review
+            // found, so it does not get a fourth spelling.
             Ok(client) => match client.status().await.ok().and_then(|r| r.data) {
                 Some(data) => GateReport::Status(data),
-                None => return,
+                None => GateReport::Unreadable,
             },
             // The gate refused *us*. `connect_to` probes with a `status`, and a
             // rejected peer gets an `ok:false` reply, so a live-but-refusing

--- a/crates/veld/src/commands/doctor.rs
+++ b/crates/veld/src/commands/doctor.rs
@@ -517,7 +517,7 @@ impl Diagnostics {
                 pass: false,
                 label: format!(
                     "Helper socket uid gate cannot be confirmed — {}",
-                    ungated_reason(None)
+                    unreportable_gate_reason()
                 ),
             });
             return;
@@ -1565,24 +1565,17 @@ fn gate_source_label(source: Option<GateSource>) -> &'static str {
 /// Why an *ungated* privileged helper has no uid, and what to do about it.
 ///
 /// Every branch names a remedy that actually works, because a red row with no
-/// exit is a row users learn to ignore. The common case — a pre-#337 helper —
-/// is fixed by `veld update` alone, with no sudo and nothing to configure; that
-/// is the bar #338 sets, and this row exists to prove it was met.
+/// exit is a row users learn to ignore.
+///
+/// `None` here means the helper reported a source string this build does not
+/// know — a helper newer than the CLI — **not** a helper too old to report one.
+/// Those two are different rows entirely; the second is
+/// [`unreportable_gate_reason`]. Reaching this function at all means the helper
+/// said, in so many words, that its socket is ungated.
+///
+/// Each string is a complete sentence, because it is appended to one.
 fn ungated_reason(source: Option<GateSource>) -> &'static str {
     match source {
-        // The helper predates the derivation *and* the field, so it can only be
-        // gated by a plist that was never rewritten. Its own uid is unknowable
-        // from here; updating replaces it with one that gates itself.
-        // The FIELD was absent, so this helper predates #337 entirely. It may
-        // still be gated by an `--allow-uid` its plist carries (every install
-        // that ran `veld setup privileged` on v16.58.x has one), so this must
-        // not claim the socket is open — only that the answer is unavailable.
-        // Updating replaces it with a helper that gates itself and says so.
-        None => {
-            "this helper predates the check and cannot report it. Its socket may or may not be \
-             gated by an `--allow-uid` in its service definition. Run `veld update`; the new \
-             helper gates itself and reports it."
-        }
         Some(GateSource::RefusedRootLibDir) => {
             "The helper's install directory is root-owned (a system-paths install), so the \
              installing user cannot be derived — gating to root would admit only root and \
@@ -1592,14 +1585,34 @@ fn ungated_reason(source: Option<GateSource>) -> &'static str {
             "The helper's install directory could not be read, so the installing user could \
              not be derived. Run `veld setup privileged` to write the uid explicitly."
         }
-        // `Unprivileged` here means this helper does not consider itself the
-        // system daemon while setup mode says it is — a socket-path mismatch,
-        // which re-running setup is also the fix for. `Flag`/`LibDirOwner`
-        // cannot reach this branch: both carry a uid.
-        Some(GateSource::Flag | GateSource::LibDirOwner | GateSource::Unprivileged) => {
+        // `Unprivileged` means the helper does not consider itself the system
+        // daemon even though it answered on the system socket — a `--socket-path`
+        // that does not match what setup writes. `Flag`/`LibDirOwner` cannot
+        // reach this branch: both carry a uid. `None` is a source only a newer
+        // helper knows; the remedy is the same one, and it is better than
+        // guessing at a cause.
+        Some(GateSource::Flag | GateSource::LibDirOwner | GateSource::Unprivileged) | None => {
             "Run `veld setup privileged` to write the uid explicitly."
         }
     }
+}
+
+/// What to say when the helper does not report the gate at all.
+///
+/// The field being **absent** means a helper predating #337. It may still be
+/// perfectly gated by an `--allow-uid` its service definition carries — every
+/// install that ran `veld setup privileged` on v16.58.x has one — so this must
+/// never claim the socket is open, only that the answer is unavailable.
+/// `veld update` settles it either way: the new helper gates itself and says so,
+/// with no sudo and nothing to configure. That is #338's bar, and this row is
+/// how it gets checked.
+///
+/// Lower-case and mid-sentence: it is appended to a clause, not started after
+/// a full stop like [`ungated_reason`]'s strings.
+fn unreportable_gate_reason() -> &'static str {
+    "this helper predates the check and cannot report it. Its socket may or may not be gated \
+     by an `--allow-uid` in its service definition. Run `veld update`; the new helper gates \
+     itself and reports it."
 }
 
 fn tilde_path(path: &Path) -> String {
@@ -2458,19 +2471,29 @@ mod tests {
     /// at all.
     #[test]
     fn every_ungated_state_names_a_remedy() {
-        use super::{GateSource, gate_source_label, ungated_reason};
+        use super::{GateSource, gate_source_label, ungated_reason, unreportable_gate_reason};
 
         // The case that matters: a helper too old to report the gate. `veld
         // update` alone fixes it — no sudo, nothing to configure. That is #338's
         // bar. It must NOT claim the socket is open: an install that ran
         // `veld setup privileged` on v16.58.x carries `--allow-uid` in its plist
         // and is genuinely gated, it just cannot say so.
-        let unknown = ungated_reason(None);
+        let unknown = unreportable_gate_reason();
         assert!(unknown.contains("`veld update`"));
         assert!(!unknown.contains("sudo"));
         assert!(
             unknown.contains("may or may not be"),
             "the unknown state must not be reported as a known-open socket: {unknown}"
+        );
+
+        // A source only a NEWER helper knows is not the same thing as a helper
+        // too old to report one, and must not borrow its text: this helper said
+        // outright that its socket is ungated.
+        let newer = ungated_reason(None);
+        assert!(newer.contains("`veld setup privileged`"));
+        assert!(
+            !newer.contains("predates"),
+            "an unknown source from a newer helper must not read as an older one: {newer}"
         );
 
         for source in [

--- a/crates/veld/src/commands/doctor.rs
+++ b/crates/veld/src/commands/doctor.rs
@@ -1534,9 +1534,21 @@ fn gate_source_label(source: Option<GateSource>) -> &'static str {
 ///   prevent, arriving through the more likely door.
 fn gate_report_for_error(error: &veld_core::helper::HelperError) -> Option<GateReport> {
     match error {
-        veld_core::helper::HelperError::ConnectionFailed { source, .. } => {
-            (source.kind() == std::io::ErrorKind::TimedOut).then_some(GateReport::Unreadable)
-        }
+        veld_core::helper::HelperError::ConnectionFailed { source, .. } => match source.kind() {
+            // The only two kinds that actually mean "nothing is listening".
+            // Named explicitly, rather than treating silence as the default and
+            // listing the exceptions: every bug this row has had came from a
+            // state falling into "say nothing", so the fall-through must be the
+            // safe direction. A `PermissionDenied`, say, means something is
+            // there and we could not reach it — a row, not silence.
+            std::io::ErrorKind::NotFound | std::io::ErrorKind::ConnectionRefused => None,
+            _ => Some(GateReport::Unreadable),
+        },
+        // Every other variant reached a helper that answered: `SendFailed` /
+        // `ReadFailed` (the refusal without its message, above), `ParseError` (a
+        // reply this build cannot parse), and a `CommandError` that is not the
+        // refusal (an older helper answering "unknown command"). All of them are
+        // the same fact — a helper answered, the gate could not be read.
         _ => Some(GateReport::Unreadable),
     }
 }
@@ -2789,6 +2801,29 @@ mod tests {
             gate_report_for_error(&HelperError::CommandError("unknown command".into())),
             Some(GateReport::Unreadable)
         ));
+        assert!(matches!(
+            gate_report_for_error(&HelperError::ParseError(
+                serde_json::from_str::<serde_json::Value>("{").unwrap_err()
+            )),
+            Some(GateReport::Unreadable)
+        ));
+
+        // Any OTHER connect failure reached something. Silence is reserved for
+        // the two kinds above, so a kind nobody anticipated errs toward saying
+        // so — the direction every earlier bug in this row got backwards.
+        for kind in [
+            ErrorKind::PermissionDenied,
+            ErrorKind::WouldBlock,
+            ErrorKind::AddrInUse,
+        ] {
+            assert!(
+                matches!(
+                    gate_report_for_error(&connection_failed(kind)),
+                    Some(GateReport::Unreadable)
+                ),
+                "{kind:?} must not be mistaken for an absent helper"
+            );
+        }
     }
 
     /// No failing gate row may hand a reader a remedy without saying it might

--- a/crates/veld/src/commands/doctor.rs
+++ b/crates/veld/src/commands/doctor.rs
@@ -498,21 +498,10 @@ impl Diagnostics {
             {
                 GateReport::Refused
             }
-            // Nothing is listening. The socket row above already says so, and a
-            // helper that is down has no gate to report.
-            Err(veld_core::helper::HelperError::ConnectionFailed { .. }) => return,
-            // Something accepted the connection and then the exchange broke.
-            //
-            // This is the refusal above arriving by its other route, and the
-            // reason this arm exists at all: `reject_connection` writes its
-            // refusal and drops the stream **without reading the request**, so
-            // if that close wins the race against our own write we get
-            // `SendFailed(EPIPE)` instead of the message. Both `reject_connection`
-            // and `REJECTED_PEER_ERROR` are explicit that the reply is
-            // best-effort and must never be depended on — so this row does not
-            // depend on it. It claims only what is certain in both cases: a
-            // helper answered, and the gate could not be read.
-            Err(_) => GateReport::Unreadable,
+            Err(e) => match gate_report_for_error(&e) {
+                Some(report) => report,
+                None => return,
+            },
         };
 
         self.checks.push(gate_check(&reported, invoking_uid()));
@@ -1511,6 +1500,36 @@ fn gate_source_label(source: Option<GateSource>) -> &'static str {
             GateSource::RefusedRootLibDir | GateSource::UnreadableLibDir | GateSource::Unprivileged,
         )
         | None => "source unknown",
+    }
+}
+
+/// What a failed `status` probe on the system socket says about the gate.
+///
+/// `None` means stay silent: nothing is listening, which the socket row above
+/// already reports, and a helper that is down has no gate to report.
+///
+/// Everything else becomes [`GateReport::Unreadable`] — something answered, and
+/// the gate could not be read. Two distinct routes land there and neither may be
+/// swallowed:
+///
+/// * `SendFailed`/`ReadFailed`, which is **the refusal arriving without its
+///   message**. `reject_connection` writes and drops the stream *without reading
+///   the request*, so when that close wins the race against our own write we get
+///   `EPIPE` rather than the text. Both `reject_connection` and
+///   `REJECTED_PEER_ERROR` are explicit that the reply is best-effort and must
+///   never be depended on, so this row does not depend on it.
+/// * `ConnectionFailed` **carrying `TimedOut`**, which is not a connection
+///   failure at all: `HelperClient::try_connect` synthesises it when its own 3s
+///   status probe expires against a helper that accepted the connection and then
+///   wedged. Reading that as "nothing is listening" is how the row disappeared
+///   for a helper that is running — the exact failure this whole arm exists to
+///   prevent, arriving through the more likely door.
+fn gate_report_for_error(error: &veld_core::helper::HelperError) -> Option<GateReport> {
+    match error {
+        veld_core::helper::HelperError::ConnectionFailed { source, .. } => {
+            (source.kind() == std::io::ErrorKind::TimedOut).then_some(GateReport::Unreadable)
+        }
+        _ => Some(GateReport::Unreadable),
     }
 }
 
@@ -2707,6 +2726,61 @@ mod tests {
         );
         assert!(c.pass);
         assert!(c.label.contains("source unknown"));
+    }
+
+    /// Which probe failures make the gate row appear, and which make it stay
+    /// silent.
+    ///
+    /// The trap this pins: `HelperClient::try_connect` wraps its own status
+    /// probe in a 3s timeout and reports the expiry as
+    /// `ConnectionFailed { source: TimedOut }` — a *helper that is up and
+    /// wedged*, wearing the error name of one that is absent. Reading the
+    /// variant alone made the row vanish for a running helper, which is the
+    /// failure the `Unreadable` state was introduced to prevent, arriving
+    /// through the likelier door.
+    #[test]
+    fn only_an_absent_helper_silences_the_gate_row() {
+        use super::{GateReport, gate_report_for_error};
+        use std::io::{Error, ErrorKind};
+        use veld_core::helper::HelperError;
+
+        let connection_failed = |kind: ErrorKind| HelperError::ConnectionFailed {
+            path: std::path::PathBuf::from("/var/run/veld-helper.sock"),
+            source: Error::new(kind, "test"),
+        };
+
+        // Nothing is listening: the socket row already says so.
+        assert!(gate_report_for_error(&connection_failed(ErrorKind::NotFound)).is_none());
+        assert!(gate_report_for_error(&connection_failed(ErrorKind::ConnectionRefused)).is_none());
+
+        // Up, but wedged — `try_connect`'s synthesised timeout. Must NOT be
+        // mistaken for absent.
+        assert!(matches!(
+            gate_report_for_error(&connection_failed(ErrorKind::TimedOut)),
+            Some(GateReport::Unreadable)
+        ));
+
+        // The refusal arriving without its best-effort message.
+        assert!(matches!(
+            gate_report_for_error(&HelperError::SendFailed(Error::new(
+                ErrorKind::BrokenPipe,
+                "test"
+            ))),
+            Some(GateReport::Unreadable)
+        ));
+        assert!(matches!(
+            gate_report_for_error(&HelperError::ReadFailed(Error::new(
+                ErrorKind::UnexpectedEof,
+                "test"
+            ))),
+            Some(GateReport::Unreadable)
+        ));
+
+        // A helper that answered with something unexpected is still a helper.
+        assert!(matches!(
+            gate_report_for_error(&HelperError::CommandError("unknown command".into())),
+            Some(GateReport::Unreadable)
+        ));
     }
 
     /// No failing gate row may hand a reader a remedy without saying it might

--- a/crates/veld/src/commands/doctor.rs
+++ b/crates/veld/src/commands/doctor.rs
@@ -543,7 +543,7 @@ impl Diagnostics {
             // (every other uid is refused before it can ask), which is exactly
             // when it is worth saying: `sudo veld doctor` is where somebody
             // investigating a locked-out CLI ends up.
-            Some(uid) if invoking_uid().is_some_and(|me| me != 0 && me != uid) => Check {
+            Some(uid) if gate_locks_out(uid, invoking_uid()) => Check {
                 pass: false,
                 label: format!(
                     "Helper socket gated to uid {uid}, but you are uid {} — your `veld` commands \
@@ -1556,10 +1556,31 @@ fn gate_source_label(source: Option<GateSource>) -> &'static str {
     match source {
         Some(GateSource::Flag) => "from the service definition",
         Some(GateSource::LibDirOwner) => "derived from the install directory's owner",
-        // The other variants cannot accompany a uid, and `None` is a helper
-        // newer than this CLI. Say nothing rather than guess.
-        _ => "source unknown",
+        // Spelled out rather than a `_` arm, so a new `GateSource` fails to
+        // build here until somebody decides how a gated helper reporting it
+        // should read. The three below cannot accompany a uid, and `None` is a
+        // source only a newer helper knows — both say nothing rather than guess.
+        Some(
+            GateSource::RefusedRootLibDir | GateSource::UnreadableLibDir | GateSource::Unprivileged,
+        )
+        | None => "source unknown",
     }
+}
+
+/// Whether a helper gated to `reported` locks out the user running this CLI.
+///
+/// A free function with its own test because the `invoking == Some(0)` escape is
+/// the part somebody will "simplify". A **plain root shell** answers 0 here and
+/// is not a claim about which user the install belongs to — root is admitted by
+/// every gate anyway (`peer_allowed`), so treating 0 as a uid to match against
+/// would have bare `sudo veld doctor` report itself locked out of a perfectly
+/// healthy helper. `SUDO_UID` is what lets a root invocation know who it stands
+/// in for, and [`invoking_uid`] prefers it.
+///
+/// A `reported` of 0 is not this function's business — it fails the row on its
+/// own, before this is reached.
+fn gate_locks_out(reported: u64, invoking: Option<u64>) -> bool {
+    invoking.is_some_and(|me| me != 0 && me != reported)
 }
 
 /// Why an *ungated* privileged helper has no uid, and what to do about it.
@@ -2469,6 +2490,31 @@ mod tests {
     /// can actually run. A red row with no exit is a row people learn to skip —
     /// and this particular row is the only place an exposed root socket shows up
     /// at all.
+    /// The uid-match rule, isolated from the socket call so the `root` escape
+    /// cannot be "simplified" away without a red test.
+    ///
+    /// Dropping `me != 0` is the natural edit — the guard looks redundant — and
+    /// it silently makes bare `sudo veld doctor` (uid 0, no `SUDO_UID`) accuse a
+    /// perfectly healthy helper of locking the user out.
+    #[test]
+    fn a_gate_only_locks_out_a_user_it_could_actually_refuse() {
+        use super::gate_locks_out;
+
+        // The ordinary healthy case.
+        assert!(!gate_locks_out(501, Some(501)));
+
+        // A real mismatch. Only ever visible to root, because every other uid is
+        // refused before it can ask — which is exactly why the row matters.
+        assert!(gate_locks_out(999, Some(501)));
+
+        // A plain root shell has no opinion about which user the install belongs
+        // to, and root is admitted by every gate. Not a lockout.
+        assert!(!gate_locks_out(501, Some(0)));
+
+        // Uid unresolvable — say nothing rather than accuse.
+        assert!(!gate_locks_out(501, None));
+    }
+
     #[test]
     fn every_ungated_state_names_a_remedy() {
         use super::{GateSource, gate_source_label, ungated_reason, unreportable_gate_reason};

--- a/crates/veld/src/commands/doctor.rs
+++ b/crates/veld/src/commands/doctor.rs
@@ -481,9 +481,9 @@ impl Diagnostics {
     /// refusal row names both readings and tells the second one to do nothing.
     async fn check_helper_uid_gate(&mut self) {
         let socket = veld_core::helper::system_socket_path();
-        let data = match veld_core::helper::HelperClient::connect_to(&socket).await {
+        let reported = match veld_core::helper::HelperClient::connect_to(&socket).await {
             Ok(client) => match client.status().await.ok().and_then(|r| r.data) {
-                Some(data) => data,
+                Some(data) => GateReport::Status(data),
                 None => return,
             },
             // The gate refused *us*. `connect_to` probes with a `status`, and a
@@ -496,107 +496,14 @@ impl Diagnostics {
             Err(veld_core::helper::HelperError::CommandError(e))
                 if e.contains(veld_core::helper_gate::REJECTED_PEER_ERROR) =>
             {
-                let me = invoking_uid()
-                    .map(|u| format!("uid {u}"))
-                    .unwrap_or_else(|| "this user".into());
-                self.checks.push(Check {
-                    pass: false,
-                    label: format!(
-                        "Helper socket is gated to a DIFFERENT uid — it refused {me}, so no \
-                         `veld` command of yours can drive it. If this machine's privileged \
-                         veld belongs to another account, that is working as intended and \
-                         there is nothing for you to fix here — do NOT run `veld setup \
-                         privileged`, which would repoint the system service at your install \
-                         and lock the owner out. If the install IS yours, its directory is \
-                         owned by another account (a restored backup, or a renumbered user); \
-                         `veld setup privileged` writes the correct uid explicitly."
-                    ),
-                });
-                return;
+                GateReport::Refused
             }
             Err(_) => return, // helper down — already reported by the socket check
         };
 
-        // Three states, and conflating any two of them tells somebody something
-        // false. `None` is the field being ABSENT — a helper predating #337,
-        // which may still be gated by an `--allow-uid` its plist carries, so it
-        // is "cannot tell", never "not gated". `Some(Null)` is a current helper
-        // reporting no gate. `Some(n)` is a gate.
-        let Some(reported) = data.get(veld_core::helper_gate::ALLOW_UID_FIELD) else {
-            self.checks.push(Check {
-                pass: false,
-                label: format!(
-                    "Helper socket uid gate cannot be confirmed — {}",
-                    unreportable_gate_reason()
-                ),
-            });
-            return;
-        };
-        let source = data
-            .get(veld_core::helper_gate::ALLOW_UID_SOURCE_FIELD)
-            .and_then(|v| v.as_str())
-            .and_then(GateSource::from_wire);
-
-        // `null` is the only shape that means "ungated". Anything else that is
-        // not a number — a uid emitted as a string by some future helper, say —
-        // is a response this build cannot read, and the field-absent case above
-        // already established that "cannot read" must never become the definite
-        // claim that the socket is open. `as_u64()` alone would collapse the two.
-        if !reported.is_null() && reported.as_u64().is_none() {
-            self.checks.push(Check {
-                pass: false,
-                label: format!(
-                    "Helper socket uid gate cannot be confirmed — the helper reported \
-                     `{}` as its allowed uid, which this version of `veld` cannot read. \
-                     Run `veld update` so the CLI and the helper match.",
-                    veld_core::helper_gate::ALLOW_UID_FIELD
-                ),
-            });
-            return;
+        if let Some(check) = gate_check(&reported, invoking_uid()) {
+            self.checks.push(check);
         }
-
-        let check = match reported.as_u64() {
-            // Gated to root only. Reachable solely from a hand-written
-            // `--allow-uid 0`, which the helper honours as the deliberate
-            // instruction it is — but it means no `veld` command can drive the
-            // helper, and only a root reader ever gets far enough to see this.
-            Some(0) => Check {
-                pass: false,
-                label: "Helper socket gated to uid 0 — that admits only root, so the `veld` CLI \
-                        cannot drive its own helper. Run `veld setup privileged` to write the \
-                        installing user's uid."
-                    .into(),
-            },
-            // Gated, but not to the user reading this. Only reachable as root
-            // (every other uid is refused before it can ask), which is exactly
-            // when it is worth saying: `sudo veld doctor` is where somebody
-            // investigating a locked-out CLI ends up.
-            Some(uid) if gate_locks_out(uid, invoking_uid()) => Check {
-                pass: false,
-                label: format!(
-                    "Helper socket gated to uid {uid}, but you are uid {} — your `veld` commands \
-                     cannot drive it. Run `veld setup privileged` to write the correct uid.",
-                    invoking_uid().unwrap_or(0)
-                ),
-            },
-            Some(uid) => Check {
-                pass: true,
-                label: format!(
-                    "Helper socket gated to uid {uid} ({})",
-                    gate_source_label(source)
-                ),
-            },
-            None => Check {
-                pass: false,
-                label: format!(
-                    "Helper socket NOT gated to a uid — any local process can drive the root \
-                     helper, including `shutdown`, which stops Caddy and drops every live \
-                     URL. {}",
-                    ungated_reason(source)
-                ),
-            },
-        };
-        self.checks.push(check);
     }
 
     async fn gather_checks(&mut self) {
@@ -1595,6 +1502,129 @@ fn gate_source_label(source: Option<GateSource>) -> &'static str {
     }
 }
 
+/// What the privileged helper told `veld doctor` about its gate.
+///
+/// A type rather than a bare `Option<Value>` so the *refused* answer — which
+/// arrives as a connection error, not as data — travels the same path as every
+/// other outcome and cannot be forgotten by a future branch.
+enum GateReport {
+    /// The gate rejected this caller before it could ask anything.
+    Refused,
+    /// The helper's `status` payload.
+    Status(serde_json::Value),
+}
+
+/// The gate row, decided purely from what the helper reported.
+///
+/// Split from [`Diagnostics::check_helper_uid_gate`] so every outcome is
+/// reachable in a test without a root helper and a socket. That matters more
+/// here than in most rows: this one is the only place an exposed root socket is
+/// reported at all, and its failure mode is a *confident wrong sentence* rather
+/// than a crash — which no amount of running `veld doctor` on a healthy machine
+/// would reveal.
+///
+/// `None` means "say nothing", reserved for a report this build cannot make any
+/// honest statement about.
+fn gate_check(report: &GateReport, invoking: Option<u64>) -> Option<Check> {
+    let data = match report {
+        GateReport::Refused => {
+            let me = invoking
+                .map(|u| format!("uid {u}"))
+                .unwrap_or_else(|| "this user".into());
+            return Some(Check {
+                pass: false,
+                label: format!(
+                    "Helper socket is gated to a DIFFERENT uid — it refused {me}, so no \
+                     `veld` command of yours can drive it. If this machine's privileged \
+                     veld belongs to another account, that is working as intended and \
+                     there is nothing for you to fix here — do NOT run `veld setup \
+                     privileged`, which would repoint the system service at your install \
+                     and lock the owner out. If the install IS yours, its directory is \
+                     owned by another account (a restored backup, or a renumbered user); \
+                     `veld setup privileged` writes the correct uid explicitly."
+                ),
+            });
+        }
+        GateReport::Status(data) => data,
+    };
+
+    // Three states, and conflating any two of them tells somebody something
+    // false. Absent is a helper predating #337, which may still be gated by an
+    // `--allow-uid` its plist carries, so it is "cannot tell", never "not
+    // gated". `Null` is a current helper reporting no gate. A number is a gate.
+    let Some(reported) = data.get(veld_core::helper_gate::ALLOW_UID_FIELD) else {
+        return Some(Check {
+            pass: false,
+            label: format!(
+                "Helper socket uid gate cannot be confirmed — {}",
+                unreportable_gate_reason()
+            ),
+        });
+    };
+    let source = data
+        .get(veld_core::helper_gate::ALLOW_UID_SOURCE_FIELD)
+        .and_then(|v| v.as_str())
+        .and_then(GateSource::from_wire);
+
+    // `null` is the only shape that means "ungated". Anything else that is not a
+    // number — a uid emitted as a string by some future helper, say — is a
+    // response this build cannot read, and the field-absent case above already
+    // established that "cannot read" must never become the definite claim that
+    // the socket is open. `as_u64()` alone would collapse the two.
+    if !reported.is_null() && reported.as_u64().is_none() {
+        return Some(Check {
+            pass: false,
+            label: format!(
+                "Helper socket uid gate cannot be confirmed — the helper reported `{}` as its \
+                 allowed uid, which this version of `veld` cannot read. Run `veld update` so \
+                 the CLI and the helper match.",
+                veld_core::helper_gate::ALLOW_UID_FIELD
+            ),
+        });
+    }
+
+    Some(match reported.as_u64() {
+        // Gated to root only. Reachable solely from a hand-written
+        // `--allow-uid 0`, which the helper honours as the deliberate
+        // instruction it is — but it means no `veld` command can drive the
+        // helper, and only a root reader ever gets far enough to see this.
+        Some(0) => Check {
+            pass: false,
+            label: "Helper socket gated to uid 0 — that admits only root, so the `veld` CLI \
+                    cannot drive its own helper. Run `veld setup privileged` to write the \
+                    installing user's uid."
+                .into(),
+        },
+        // Gated, but not to the user reading this. Only reachable as root
+        // (every other uid is refused before it can ask), which is exactly
+        // when it is worth saying: `sudo veld doctor` is where somebody
+        // investigating a locked-out CLI ends up.
+        Some(uid) if gate_locks_out(uid, invoking) => Check {
+            pass: false,
+            label: format!(
+                "Helper socket gated to uid {uid}, but you are uid {} — your `veld` commands \
+                 cannot drive it. Run `veld setup privileged` to write the correct uid.",
+                invoking.unwrap_or(0)
+            ),
+        },
+        Some(uid) => Check {
+            pass: true,
+            label: format!(
+                "Helper socket gated to uid {uid} ({})",
+                gate_source_label(source)
+            ),
+        },
+        None => Check {
+            pass: false,
+            label: format!(
+                "Helper socket NOT gated to a uid — any local process can drive the root \
+                 helper, including `shutdown`, which stops Caddy and drops every live URL. {}",
+                ungated_reason(source)
+            ),
+        },
+    })
+}
+
 /// Whether a helper gated to `reported` locks out the user running this CLI.
 ///
 /// A free function with its own test because the `invoking == Some(0)` escape is
@@ -2518,6 +2548,110 @@ mod tests {
     /// can actually run. A red row with no exit is a row people learn to skip —
     /// and this particular row is the only place an exposed root socket shows up
     /// at all.
+    /// Every outcome of the gate row, decided without a socket.
+    ///
+    /// The row is the only place an exposed root socket is reported anywhere, and
+    /// its failure mode is a confident wrong sentence rather than a crash — so
+    /// running `veld doctor` on a healthy machine proves nothing about the seven
+    /// other branches. Each assertion below pins the one thing that must not
+    /// drift: whether the row passes, and whether it makes a claim it cannot
+    /// support.
+    #[test]
+    fn the_gate_row_states_only_what_the_helper_actually_reported() {
+        use super::{GateReport, gate_check};
+
+        let status = |v: serde_json::Value| GateReport::Status(v);
+        let row = |report: &GateReport, me: Option<u64>| gate_check(report, me).unwrap();
+
+        // Gated to the reader: the only green outcome there is.
+        let c = row(
+            &status(serde_json::json!({ "allow_uid": 501, "allow_uid_source": "lib-dir-owner" })),
+            Some(501),
+        );
+        assert!(c.pass);
+        assert!(c.label.contains("gated to uid 501"));
+        assert!(
+            c.label
+                .contains("derived from the install directory's owner")
+        );
+
+        // Explicitly ungated: the state #337 exists to remove. A definite claim
+        // is correct HERE and nowhere else.
+        let c = row(
+            &status(serde_json::json!({
+                "allow_uid": serde_json::Value::Null,
+                "allow_uid_source": "refused-root-lib-dir",
+            })),
+            Some(501),
+        );
+        assert!(!c.pass);
+        assert!(c.label.contains("NOT gated"));
+        assert!(c.label.contains("root-owned"));
+
+        // Field absent — a helper predating the report. It may well be gated by
+        // its plist, so this must NOT read as an open socket.
+        let c = row(
+            &status(serde_json::json!({ "version": "16.58.1" })),
+            Some(501),
+        );
+        assert!(!c.pass);
+        assert!(!c.label.contains("NOT gated"));
+        assert!(c.label.contains("cannot be confirmed"));
+        assert!(c.label.contains("`veld update`"));
+
+        // A shape this build cannot read is also "cannot confirm", never "open".
+        let c = row(
+            &status(serde_json::json!({ "allow_uid": "501", "allow_uid_source": "flag" })),
+            Some(501),
+        );
+        assert!(!c.pass);
+        assert!(!c.label.contains("NOT gated"));
+        assert!(c.label.contains("cannot be confirmed"));
+
+        // Gated to root only: honoured, but the CLI cannot drive it.
+        let c = row(
+            &status(serde_json::json!({ "allow_uid": 0, "allow_uid_source": "flag" })),
+            Some(0),
+        );
+        assert!(
+            !c.pass,
+            "uid 0 admits only root and must never read as green"
+        );
+        assert!(c.label.contains("uid 0"));
+
+        // Gated to somebody else. Only a root reader gets this far.
+        let c = row(
+            &status(serde_json::json!({ "allow_uid": 999, "allow_uid_source": "flag" })),
+            Some(501),
+        );
+        assert!(!c.pass);
+        assert!(c.label.contains("gated to uid 999"));
+        assert!(c.label.contains("you are uid 501"));
+
+        // Refused outright — the one failure mode deriving the uid introduces.
+        // It must not send a shared machine's non-owner to rewrite the service.
+        let c = row(&GateReport::Refused, Some(501));
+        assert!(!c.pass);
+        assert!(c.label.contains("refused uid 501"));
+        assert!(
+            c.label.contains("do NOT run `veld setup privileged`"),
+            "a reader who is not the install's owner must be told to leave it alone"
+        );
+
+        // An unresolvable invoking uid still produces a usable sentence.
+        let c = row(&GateReport::Refused, None);
+        assert!(c.label.contains("refused this user"));
+
+        // A source only a newer helper knows: gated is still gated, and the
+        // provenance simply goes unnamed rather than being invented.
+        let c = row(
+            &status(serde_json::json!({ "allow_uid": 501, "allow_uid_source": "invented-later" })),
+            Some(501),
+        );
+        assert!(c.pass);
+        assert!(c.label.contains("source unknown"));
+    }
+
     /// The uid-match rule, isolated from the socket call so the `root` escape
     /// cannot be "simplified" away without a red test.
     ///

--- a/crates/veld/src/commands/doctor.rs
+++ b/crates/veld/src/commands/doctor.rs
@@ -472,6 +472,13 @@ impl Diagnostics {
     /// newly-derived gate locks out is by construction *not* the installing
     /// user and has no such file, so keying on the mode marker would silence
     /// this row for exactly the reader who needs it.
+    ///
+    /// The cost of that choice is a second reader it cannot tell apart: a user
+    /// on a shared machine whose privileged veld legitimately belongs to
+    /// somebody else. They reach the 0o777 socket, are refused, and are equally
+    /// entitled to an explanation — but the remedy that fits the first reader
+    /// would have them rewrite a system service that is not theirs. So the
+    /// refusal row names both readings and tells the second one to do nothing.
     async fn check_helper_uid_gate(&mut self) {
         let socket = veld_core::helper::system_socket_path();
         let data = match veld_core::helper::HelperClient::connect_to(&socket).await {
@@ -496,10 +503,13 @@ impl Diagnostics {
                     pass: false,
                     label: format!(
                         "Helper socket is gated to a DIFFERENT uid — it refused {me}, so no \
-                         `veld` command can drive it. The helper derives the uid from the owner \
-                         of its install directory when the service definition carries none, so \
-                         this is an install owned by another account. Run `veld setup \
-                         privileged` to write the correct uid explicitly."
+                         `veld` command of yours can drive it. If this machine's privileged \
+                         veld belongs to another account, that is working as intended and \
+                         there is nothing for you to fix here — do NOT run `veld setup \
+                         privileged`, which would repoint the system service at your install \
+                         and lock the owner out. If the install IS yours, its directory is \
+                         owned by another account (a restored backup, or a renumbered user); \
+                         `veld setup privileged` writes the correct uid explicitly."
                     ),
                 });
                 return;

--- a/crates/veld/src/commands/doctor.rs
+++ b/crates/veld/src/commands/doctor.rs
@@ -118,6 +118,16 @@ fn current_uid() -> Option<String> {
     (!uid.is_empty()).then_some(uid)
 }
 
+/// [`current_uid`] as a number, for comparing against a uid the helper reports.
+///
+/// `None` when it cannot be resolved. Note that a plain root shell answers `0`
+/// here, which callers must read as "no opinion about which user this is for"
+/// rather than as a uid to match against — `SUDO_UID` is what makes a root
+/// invocation know who it is standing in for.
+fn invoking_uid() -> Option<u64> {
+    current_uid()?.parse().ok()
+}
+
 impl Diagnostics {
     async fn gather(&mut self) {
         self.update_in_progress = veld_core::update_lock::current();
@@ -442,7 +452,8 @@ impl Diagnostics {
         });
     }
 
-    /// Whether the privileged helper's socket is actually gated to one uid.
+    /// Whether the privileged helper's socket is actually gated to one uid, and
+    /// to the *right* one.
     ///
     /// The socket is world-writable (`0o777`) so the unprivileged CLI can reach
     /// it, so an ungated privileged helper takes `shutdown` — which stops Caddy
@@ -455,29 +466,99 @@ impl Diagnostics {
     /// directory at startup, so the plist and the truth routinely disagree —
     /// and the direction they disagree in is the one that would report a gated
     /// helper as exposed.
+    ///
+    /// Keyed on the socket answering rather than on `setup.json` saying
+    /// "privileged", because `setup.json` is per-user: the person a
+    /// newly-derived gate locks out is by construction *not* the installing
+    /// user and has no such file, so keying on the mode marker would silence
+    /// this row for exactly the reader who needs it.
     async fn check_helper_uid_gate(&mut self) {
         let socket = veld_core::helper::system_socket_path();
-        let Ok(client) = veld_core::helper::HelperClient::connect_to(&socket).await else {
-            return; // helper down — already reported by the socket check
+        let data = match veld_core::helper::HelperClient::connect_to(&socket).await {
+            Ok(client) => match client.status().await.ok().and_then(|r| r.data) {
+                Some(data) => data,
+                None => return,
+            },
+            // The gate refused *us*. `connect_to` probes with a `status`, and a
+            // rejected peer gets an `ok:false` reply, so a live-but-refusing
+            // helper is indistinguishable from a dead one by the error *kind* —
+            // which is why the socket row above says "not reachable" and
+            // `veld start` spends 20s waiting for a helper that is already up.
+            // This is the one failure mode deriving the uid can introduce, so it
+            // is the one this row most has to name.
+            Err(veld_core::helper::HelperError::CommandError(e))
+                if e.contains(veld_core::helper_gate::REJECTED_PEER_ERROR) =>
+            {
+                let me = invoking_uid()
+                    .map(|u| format!("uid {u}"))
+                    .unwrap_or_else(|| "this user".into());
+                self.checks.push(Check {
+                    pass: false,
+                    label: format!(
+                        "Helper socket is gated to a DIFFERENT uid — it refused {me}, so no \
+                         `veld` command can drive it. The helper derives the uid from the owner \
+                         of its install directory when the service definition carries none, so \
+                         this is an install owned by another account. Run `veld setup \
+                         privileged` to write the correct uid explicitly."
+                    ),
+                });
+                return;
+            }
+            Err(_) => return, // helper down — already reported by the socket check
         };
-        let Some(data) = client.status().await.ok().and_then(|r| r.data) else {
+
+        // Three states, and conflating any two of them tells somebody something
+        // false. `None` is the field being ABSENT — a helper predating #337,
+        // which may still be gated by an `--allow-uid` its plist carries, so it
+        // is "cannot tell", never "not gated". `Some(Null)` is a current helper
+        // reporting no gate. `Some(n)` is a gate.
+        let Some(reported) = data.get(veld_core::helper_gate::ALLOW_UID_FIELD) else {
+            self.checks.push(Check {
+                pass: false,
+                label: format!(
+                    "Helper socket uid gate cannot be confirmed — {}",
+                    ungated_reason(None)
+                ),
+            });
             return;
         };
         let source = data
-            .get("allow_uid_source")
+            .get(veld_core::helper_gate::ALLOW_UID_SOURCE_FIELD)
             .and_then(|v| v.as_str())
             .and_then(GateSource::from_wire);
-        let uid = data.get("allow_uid").and_then(|v| v.as_u64());
 
-        let check = match (uid, source) {
-            (Some(uid), source) => Check {
+        let check = match reported.as_u64() {
+            // Gated to root only. Reachable solely from a hand-written
+            // `--allow-uid 0`, which the helper honours as the deliberate
+            // instruction it is — but it means no `veld` command can drive the
+            // helper, and only a root reader ever gets far enough to see this.
+            Some(0) => Check {
+                pass: false,
+                label: "Helper socket gated to uid 0 — that admits only root, so the `veld` CLI \
+                        cannot drive its own helper. Run `veld setup privileged` to write the \
+                        installing user's uid."
+                    .into(),
+            },
+            // Gated, but not to the user reading this. Only reachable as root
+            // (every other uid is refused before it can ask), which is exactly
+            // when it is worth saying: `sudo veld doctor` is where somebody
+            // investigating a locked-out CLI ends up.
+            Some(uid) if invoking_uid().is_some_and(|me| me != 0 && me != uid) => Check {
+                pass: false,
+                label: format!(
+                    "Helper socket gated to uid {uid}, but you are uid {} — your `veld` commands \
+                     cannot drive it. Run `veld setup privileged` to write the correct uid.",
+                    invoking_uid().unwrap_or(0)
+                ),
+            },
+            Some(uid) => Check {
                 pass: true,
                 label: format!(
                     "Helper socket gated to uid {uid} ({})",
                     gate_source_label(source)
                 ),
             },
-            (None, source) => Check {
+            None => Check {
                 pass: false,
                 label: format!(
                     "Helper socket NOT gated to a uid — any local process can drive the root \
@@ -633,12 +714,13 @@ impl Diagnostics {
                     ),
                 }),
             }
-
-            // Same gate as the row above in spirit, opposite direction: signing
-            // protects the *update* path, this protects the socket the CLI
-            // drives the helper through.
-            self.check_helper_uid_gate().await;
         }
+
+        // Deliberately outside the `mode == privileged` branch above: see
+        // `check_helper_uid_gate`. The row emits nothing at all when no
+        // privileged helper answers the system socket, so an unprivileged or
+        // auto install stays silent without needing the marker to say so.
+        self.check_helper_uid_gate().await;
 
         // Determine HTTPS port for later checks. When the helper is down we
         // can't ask it, so fall back based on the configured mode — privileged
@@ -1491,16 +1573,20 @@ fn ungated_reason(source: Option<GateSource>) -> &'static str {
         // The helper predates the derivation *and* the field, so it can only be
         // gated by a plist that was never rewritten. Its own uid is unknowable
         // from here; updating replaces it with one that gates itself.
-        None => "This helper is too old to gate itself or to report the gate — run `veld update`.",
+        // The FIELD was absent, so this helper predates #337 entirely. It may
+        // still be gated by an `--allow-uid` its plist carries (every install
+        // that ran `veld setup privileged` on v16.58.x has one), so this must
+        // not claim the socket is open — only that the answer is unavailable.
+        // Updating replaces it with a helper that gates itself and says so.
+        None => {
+            "this helper predates the check and cannot report it. Its socket may or may not be \
+             gated by an `--allow-uid` in its service definition. Run `veld update`; the new \
+             helper gates itself and reports it."
+        }
         Some(GateSource::RefusedRootLibDir) => {
             "The helper's install directory is root-owned (a system-paths install), so the \
              installing user cannot be derived — gating to root would admit only root and \
              lock your own CLI out. Run `veld setup privileged` to write the uid explicitly."
-        }
-        Some(GateSource::RefusedRootFlag) => {
-            "The service definition says `--allow-uid 0`, which would admit only root and \
-             lock your own CLI out, so it was ignored. Run `veld setup privileged` to \
-             rewrite it."
         }
         Some(GateSource::UnreadableLibDir) => {
             "The helper's install directory could not be read, so the installing user could \
@@ -2374,14 +2460,21 @@ mod tests {
     fn every_ungated_state_names_a_remedy() {
         use super::{GateSource, gate_source_label, ungated_reason};
 
-        // The case that matters: a helper too old to gate itself. `veld update`
-        // alone fixes it — no sudo, nothing to configure. That is #338's bar.
-        assert!(ungated_reason(None).contains("`veld update`"));
-        assert!(!ungated_reason(None).contains("sudo"));
+        // The case that matters: a helper too old to report the gate. `veld
+        // update` alone fixes it — no sudo, nothing to configure. That is #338's
+        // bar. It must NOT claim the socket is open: an install that ran
+        // `veld setup privileged` on v16.58.x carries `--allow-uid` in its plist
+        // and is genuinely gated, it just cannot say so.
+        let unknown = ungated_reason(None);
+        assert!(unknown.contains("`veld update`"));
+        assert!(!unknown.contains("sudo"));
+        assert!(
+            unknown.contains("may or may not be"),
+            "the unknown state must not be reported as a known-open socket: {unknown}"
+        );
 
         for source in [
             GateSource::RefusedRootLibDir,
-            GateSource::RefusedRootFlag,
             GateSource::UnreadableLibDir,
             GateSource::Unprivileged,
         ] {

--- a/crates/veld/src/commands/doctor.rs
+++ b/crates/veld/src/commands/doctor.rs
@@ -498,12 +498,24 @@ impl Diagnostics {
             {
                 GateReport::Refused
             }
-            Err(_) => return, // helper down — already reported by the socket check
+            // Nothing is listening. The socket row above already says so, and a
+            // helper that is down has no gate to report.
+            Err(veld_core::helper::HelperError::ConnectionFailed { .. }) => return,
+            // Something accepted the connection and then the exchange broke.
+            //
+            // This is the refusal above arriving by its other route, and the
+            // reason this arm exists at all: `reject_connection` writes its
+            // refusal and drops the stream **without reading the request**, so
+            // if that close wins the race against our own write we get
+            // `SendFailed(EPIPE)` instead of the message. Both `reject_connection`
+            // and `REJECTED_PEER_ERROR` are explicit that the reply is
+            // best-effort and must never be depended on — so this row does not
+            // depend on it. It claims only what is certain in both cases: a
+            // helper answered, and the gate could not be read.
+            Err(_) => GateReport::Unreadable,
         };
 
-        if let Some(check) = gate_check(&reported, invoking_uid()) {
-            self.checks.push(check);
-        }
+        self.checks.push(gate_check(&reported, invoking_uid()));
     }
 
     async fn gather_checks(&mut self) {
@@ -1527,8 +1539,12 @@ const NOT_YOUR_INSTALL: &str = " If this machine's privileged veld belongs to an
 /// arrives as a connection error, not as data — travels the same path as every
 /// other outcome and cannot be forgotten by a future branch.
 enum GateReport {
-    /// The gate rejected this caller before it could ask anything.
+    /// The gate rejected this caller before it could ask anything, and said so.
     Refused,
+    /// Something answered on the system socket but the exchange did not
+    /// complete. Indistinguishable from [`Self::Refused`] arriving without its
+    /// (deliberately best-effort) message, so the row must not assert either.
+    Unreadable,
     /// The helper's `status` payload.
     Status(serde_json::Value),
 }
@@ -1542,15 +1558,17 @@ enum GateReport {
 /// than a crash — which no amount of running `veld doctor` on a healthy machine
 /// would reveal.
 ///
-/// `None` means "say nothing", reserved for a report this build cannot make any
-/// honest statement about.
-fn gate_check(report: &GateReport, invoking: Option<u64>) -> Option<Check> {
+/// Always produces a row: by the time a [`GateReport`] exists, the helper has
+/// said something, and every something has an honest rendering. The decision to
+/// stay silent belongs to the caller, which makes it before it has a report at
+/// all — see [`Diagnostics::check_helper_uid_gate`].
+fn gate_check(report: &GateReport, invoking: Option<u64>) -> Check {
     let data = match report {
         GateReport::Refused => {
             let me = invoking
                 .map(|u| format!("uid {u}"))
                 .unwrap_or_else(|| "this user".into());
-            return Some(Check {
+            return Check {
                 pass: false,
                 label: format!(
                     "Helper socket is gated to a DIFFERENT uid — it refused {me}, so no \
@@ -1562,7 +1580,19 @@ fn gate_check(report: &GateReport, invoking: Option<u64>) -> Option<Check> {
                      owned by another account (a restored backup, or a renumbered user); \
                      `veld setup privileged` writes the correct uid explicitly."
                 ),
-            });
+            };
+        }
+        GateReport::Unreadable => {
+            return Check {
+                pass: false,
+                label: format!(
+                    "Helper socket uid gate cannot be confirmed — something is listening on \
+                     the privileged helper's socket but the check did not complete. If the \
+                     gate refused this connection, no `veld` command of yours can drive that \
+                     helper; run `veld doctor` again to tell a refusal from a restart.\
+                     {NOT_YOUR_INSTALL}"
+                ),
+            };
         }
         GateReport::Status(data) => data,
     };
@@ -1572,13 +1602,13 @@ fn gate_check(report: &GateReport, invoking: Option<u64>) -> Option<Check> {
     // `--allow-uid` its plist carries, so it is "cannot tell", never "not
     // gated". `Null` is a current helper reporting no gate. A number is a gate.
     let Some(reported) = data.get(veld_core::helper_gate::ALLOW_UID_FIELD) else {
-        return Some(Check {
+        return Check {
             pass: false,
             label: format!(
                 "Helper socket uid gate cannot be confirmed — {}{NOT_YOUR_INSTALL}",
                 unreportable_gate_reason()
             ),
-        });
+        };
     };
     let source = data
         .get(veld_core::helper_gate::ALLOW_UID_SOURCE_FIELD)
@@ -1591,7 +1621,7 @@ fn gate_check(report: &GateReport, invoking: Option<u64>) -> Option<Check> {
     // established that "cannot read" must never become the definite claim that
     // the socket is open. `as_u64()` alone would collapse the two.
     if !reported.is_null() && reported.as_u64().is_none() {
-        return Some(Check {
+        return Check {
             pass: false,
             label: format!(
                 "Helper socket uid gate cannot be confirmed — the helper reported `{}` as its \
@@ -1599,10 +1629,10 @@ fn gate_check(report: &GateReport, invoking: Option<u64>) -> Option<Check> {
                  the CLI and the helper match.{NOT_YOUR_INSTALL}",
                 veld_core::helper_gate::ALLOW_UID_FIELD
             ),
-        });
+        };
     }
 
-    Some(match reported.as_u64() {
+    match reported.as_u64() {
         // Gated to root only. Reachable solely from a hand-written
         // `--allow-uid 0`, which the helper honours as the deliberate
         // instruction it is — but it means no `veld` command can drive the
@@ -1644,7 +1674,7 @@ fn gate_check(report: &GateReport, invoking: Option<u64>) -> Option<Check> {
                 ungated_reason(source)
             ),
         },
-    })
+    }
 }
 
 /// Whether a helper gated to `reported` locks out the user running this CLI.
@@ -2566,10 +2596,6 @@ mod tests {
         );
     }
 
-    /// Every way the helper can report "no gate" must produce a remedy the user
-    /// can actually run. A red row with no exit is a row people learn to skip —
-    /// and this particular row is the only place an exposed root socket shows up
-    /// at all.
     /// Every outcome of the gate row, decided without a socket.
     ///
     /// The row is the only place an exposed root socket is reported anywhere, and
@@ -2583,7 +2609,7 @@ mod tests {
         use super::{GateReport, gate_check};
 
         let status = |v: serde_json::Value| GateReport::Status(v);
-        let row = |report: &GateReport, me: Option<u64>| gate_check(report, me).unwrap();
+        let row = gate_check;
 
         // Gated to the reader: the only green outcome there is.
         let c = row(
@@ -2664,6 +2690,15 @@ mod tests {
         let c = row(&GateReport::Refused, None);
         assert!(c.label.contains("refused this user"));
 
+        // A refusal whose (best-effort) message lost the race arrives as a
+        // broken exchange. It must not assert a refusal it cannot prove, and it
+        // must not stay silent either — silence is how the one failure mode this
+        // gate introduces would go unreported.
+        let c = row(&GateReport::Unreadable, Some(501));
+        assert!(!c.pass);
+        assert!(c.label.contains("cannot be confirmed"));
+        assert!(!c.label.contains("NOT gated"));
+
         // A source only a newer helper knows: gated is still gated, and the
         // provenance simply goes unnamed rather than being invented.
         let c = row(
@@ -2692,6 +2727,7 @@ mod tests {
 
         let reports = [
             GateReport::Refused,
+            GateReport::Unreadable,
             GateReport::Status(serde_json::json!({ "version": "16.58.1" })),
             GateReport::Status(serde_json::json!({ "allow_uid": "501" })),
             GateReport::Status(serde_json::json!({ "allow_uid": 0 })),
@@ -2704,9 +2740,7 @@ mod tests {
 
         for report in &reports {
             for me in [Some(501u64), Some(0), None] {
-                let Some(check) = gate_check(report, me) else {
-                    continue;
-                };
+                let check = gate_check(report, me);
                 if check.pass {
                     continue;
                 }

--- a/crates/veld/src/commands/doctor.rs
+++ b/crates/veld/src/commands/doctor.rs
@@ -3,6 +3,7 @@ use std::net::ToSocketAddrs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
+use veld_core::helper_gate::GateSource;
 
 /// `veld doctor` — comprehensive system diagnostics.
 pub async fn run(json: bool) -> i32 {
@@ -441,6 +442,54 @@ impl Diagnostics {
         });
     }
 
+    /// Whether the privileged helper's socket is actually gated to one uid.
+    ///
+    /// The socket is world-writable (`0o777`) so the unprivileged CLI can reach
+    /// it, so an ungated privileged helper takes `shutdown` — which stops Caddy
+    /// and drops every live URL — from *any* local process. Until #337 that
+    /// state passed every other row in this command: green-but-unprotected, the
+    /// worst thing a diagnostic can say.
+    ///
+    /// Asked of the running helper, never of the service definition. A helper
+    /// with no `--allow-uid` in its plist derives the uid from its own install
+    /// directory at startup, so the plist and the truth routinely disagree —
+    /// and the direction they disagree in is the one that would report a gated
+    /// helper as exposed.
+    async fn check_helper_uid_gate(&mut self) {
+        let socket = veld_core::helper::system_socket_path();
+        let Ok(client) = veld_core::helper::HelperClient::connect_to(&socket).await else {
+            return; // helper down — already reported by the socket check
+        };
+        let Some(data) = client.status().await.ok().and_then(|r| r.data) else {
+            return;
+        };
+        let source = data
+            .get("allow_uid_source")
+            .and_then(|v| v.as_str())
+            .and_then(GateSource::from_wire);
+        let uid = data.get("allow_uid").and_then(|v| v.as_u64());
+
+        let check = match (uid, source) {
+            (Some(uid), source) => Check {
+                pass: true,
+                label: format!(
+                    "Helper socket gated to uid {uid} ({})",
+                    gate_source_label(source)
+                ),
+            },
+            (None, source) => Check {
+                pass: false,
+                label: format!(
+                    "Helper socket NOT gated to a uid — any local process can drive the root \
+                     helper, including `shutdown`, which stops Caddy and drops every live \
+                     URL. {}",
+                    ungated_reason(source)
+                ),
+            },
+        };
+        self.checks.push(check);
+    }
+
     async fn gather_checks(&mut self) {
         // 0. Central database opens and is at a supported schema version.
         // Everything (run state, logs, feedback, tokens) lives here now, so a
@@ -584,6 +633,11 @@ impl Diagnostics {
                     ),
                 }),
             }
+
+            // Same gate as the row above in spirit, opposite direction: signing
+            // protects the *update* path, this protects the socket the CLI
+            // drives the helper through.
+            self.check_helper_uid_gate().await;
         }
 
         // Determine HTTPS port for later checks. When the helper is down we
@@ -1414,6 +1468,54 @@ fn launchd_string_after_key(xml: &str, key: &str) -> Option<String> {
 }
 
 /// Replace the home directory prefix with `~`.
+/// How a *gated* helper says where its uid came from. Kept short — the row is
+/// already a pass, and the interesting half is the uid.
+fn gate_source_label(source: Option<GateSource>) -> &'static str {
+    match source {
+        Some(GateSource::Flag) => "from the service definition",
+        Some(GateSource::LibDirOwner) => "derived from the install directory's owner",
+        // The other variants cannot accompany a uid, and `None` is a helper
+        // newer than this CLI. Say nothing rather than guess.
+        _ => "source unknown",
+    }
+}
+
+/// Why an *ungated* privileged helper has no uid, and what to do about it.
+///
+/// Every branch names a remedy that actually works, because a red row with no
+/// exit is a row users learn to ignore. The common case — a pre-#337 helper —
+/// is fixed by `veld update` alone, with no sudo and nothing to configure; that
+/// is the bar #338 sets, and this row exists to prove it was met.
+fn ungated_reason(source: Option<GateSource>) -> &'static str {
+    match source {
+        // The helper predates the derivation *and* the field, so it can only be
+        // gated by a plist that was never rewritten. Its own uid is unknowable
+        // from here; updating replaces it with one that gates itself.
+        None => "This helper is too old to gate itself or to report the gate — run `veld update`.",
+        Some(GateSource::RefusedRootLibDir) => {
+            "The helper's install directory is root-owned (a system-paths install), so the \
+             installing user cannot be derived — gating to root would admit only root and \
+             lock your own CLI out. Run `veld setup privileged` to write the uid explicitly."
+        }
+        Some(GateSource::RefusedRootFlag) => {
+            "The service definition says `--allow-uid 0`, which would admit only root and \
+             lock your own CLI out, so it was ignored. Run `veld setup privileged` to \
+             rewrite it."
+        }
+        Some(GateSource::UnreadableLibDir) => {
+            "The helper's install directory could not be read, so the installing user could \
+             not be derived. Run `veld setup privileged` to write the uid explicitly."
+        }
+        // `Unprivileged` here means this helper does not consider itself the
+        // system daemon while setup mode says it is — a socket-path mismatch,
+        // which re-running setup is also the fix for. `Flag`/`LibDirOwner`
+        // cannot reach this branch: both carry a uid.
+        Some(GateSource::Flag | GateSource::LibDirOwner | GateSource::Unprivileged) => {
+            "Run `veld setup privileged` to write the uid explicitly."
+        }
+    }
+}
+
 fn tilde_path(path: &Path) -> String {
     if let Some(home) = dirs::home_dir() {
         if let Ok(suffix) = path.strip_prefix(&home) {
@@ -2261,6 +2363,49 @@ mod tests {
             ),
             None,
             "an unterminated element is unreadable, not a path"
+        );
+    }
+
+    /// Every way the helper can report "no gate" must produce a remedy the user
+    /// can actually run. A red row with no exit is a row people learn to skip —
+    /// and this particular row is the only place an exposed root socket shows up
+    /// at all.
+    #[test]
+    fn every_ungated_state_names_a_remedy() {
+        use super::{GateSource, gate_source_label, ungated_reason};
+
+        // The case that matters: a helper too old to gate itself. `veld update`
+        // alone fixes it — no sudo, nothing to configure. That is #338's bar.
+        assert!(ungated_reason(None).contains("`veld update`"));
+        assert!(!ungated_reason(None).contains("sudo"));
+
+        for source in [
+            GateSource::RefusedRootLibDir,
+            GateSource::RefusedRootFlag,
+            GateSource::UnreadableLibDir,
+            GateSource::Unprivileged,
+        ] {
+            let reason = ungated_reason(Some(source));
+            assert!(
+                reason.contains("`veld setup privileged`"),
+                "{source:?} left the user with no remedy: {reason}"
+            );
+        }
+
+        // A gated helper says where the uid came from; anything else — including
+        // a source only a newer helper knows — says nothing rather than guessing.
+        assert_eq!(
+            gate_source_label(Some(GateSource::Flag)),
+            "from the service definition"
+        );
+        assert_eq!(
+            gate_source_label(Some(GateSource::LibDirOwner)),
+            "derived from the install directory's owner"
+        );
+        assert_eq!(gate_source_label(None), "source unknown");
+        assert_eq!(
+            gate_source_label(Some(GateSource::RefusedRootLibDir)),
+            "source unknown"
         );
     }
 }


### PR DESCRIPTION
## What & why

`v16.58.1` shipped the peer-uid gate on the privileged helper's world-writable
socket (#253). On a live install, it is not active:

```
$ plutil -p /Library/LaunchDaemons/dev.veld.helper.plist
  "ProgramArguments" => [
    0 => ".../veld-helper"
    1 => "--caddy-bin"
    2 => ".../caddy"
  ]
```

No `--allow-uid`. It is a launchd/systemd **argument**, and only
`veld setup privileged` writes the service definition — `install.sh` and
`veld update` swap the binary and leave the plist alone. So every existing
privileged install still lets any local process drive the root helper,
including `shutdown`, which stops Caddy and drops every live URL. The signing
half of #253 activated on the same update because it is code-only.

#338's rule 1: **no PR in this chain may require a user to run anything.**
"There is a security fix, now go run a sudo command" reaches almost nobody.
This closes that debt.

## The mechanism

The privileged helper works the uid out for itself when the service definition
carries none, from **the owner of the directory its own binary lives in** —
`$HOME/.local/lib/veld` on the default privileged install, created by
`install.sh` as the installing user. That needs no service-definition change at
all, so the gate goes live the moment `veld update` bounces the helper over its
own socket (`update.rs::restart_services`, no sudo). Precedence:

| Service definition | Install dir owner | Result |
|---|---|---|
| `--allow-uid N` | anything | gated to N (explicit wins) |
| `--allow-uid 0` | anything | gated to root only — an operator's deliberate choice, honoured |
| absent | user | **gated to that user** ← the #337 case |
| absent | root | **ungated**, reported by `veld doctor` |
| absent | unreadable | ungated, reported by `veld doctor` |

The uid is never taken from the socket caller. The derived owner is not
attacker-controllable: giving a file away to another uid requires root on both
platforms (`_POSIX_CHOWN_RESTRICTED`, `CAP_CHOWN`) — verified on macOS, a
non-root `chown` to another uid is `Operation not permitted`.

**A derived uid 0 is refused.** A system-paths install (`/usr/local/lib/veld`,
created under sudo) is root-owned; gating there would admit only root and lock
the user's own CLI out of its helper — the exact bug `resolve_real_uid()` was
fixed for in #253. Those installs stay ungated, which is their pre-existing
state.

## Why not the alternatives

- **Rewriting the plist from the daemon.** Much larger blast radius (a root
  daemon editing its own launchd job), and it does not even help the case that
  needs it: a system-paths install has no discoverable installing user, so
  there is nothing to write.
- **Deriving from the binary's owner rather than the directory's.** Under
  `sudo veld setup privileged` the file is copied as root while the directory
  keeps the user's ownership, so the directory is the stabler signal.
- **Taking the uid from the caller.** Forbidden: the caller nominating its own
  permissions.
- **The macOS console user (`stat -f%Su /dev/console`).** Wrong on a multi-user
  machine, and macOS-only.
- **Re-deriving per connection instead of once at startup.** The gate is a
  property of the install, and the install changes by replacing this binary,
  which restarts the process. `veld doctor` compares the reported uid against
  the invoking user's, so a stale gate is visible rather than mysterious.

## Acknowledged gap

A root-owned install directory stays ungated with no automatic remedy — an
explicit exception to #338's rule, documented in `Gate::resolve` and named by
the `veld doctor` row. Nothing on disk records who installed such a machine, so
there is nothing to derive; `veld setup privileged` is the only answer, and the
row says so.

## `veld doctor`

A machine passing all 14 checks while unprotected is the worst state a
diagnostic can produce. New row, also in `--json`, three-state and truthful:

- gated to the invoking user → pass, naming the uid and where it came from
- ungated → fail, naming why and the remedy
- **cannot be confirmed** (a helper predating the report — it may still be
  gated by an `--allow-uid` in its plist) → fail, `veld update`
- gated to uid 0, or to a uid that is not yours → fail
- the gate refused this caller → fail, naming the gate rather than "helper down"

## Review

Four rounds, seven angles, eleven subagents (6 opus / 5 sonnet). It found real
defects in the first cut and in three successive fixes — the summary is in the
PR discussion. The one worth stating here, because it shaped the final design:

**One bug class recurred four times — the `veld doctor` row silently
disappearing in the states it exists for.** First it returned early when the gate
refused the caller (`connect_to` probes with `status`, so a refused peer arrives
as a `CommandError`, indistinguishable from a dead helper by error *kind*). Then
it depended on a refusal message that `reject_connection` explicitly documents as
best-effort — reproduced at 300/300 EPIPE when the helper's close wins the race.
Then `try_connect`'s own 3s timeout surfaced as `ConnectionFailed`, so a wedged
helper read as an absent one. Then the success arm's second `status` call failed
silently. The row now treats "say nothing" as a named, two-case decision rather
than a default, and `gate_check` is a pure function with every outcome tested.

## Test evidence

Unit: gate policy over every input combination; wire-value round-trip; wire
*key* + payload shape from a real `handle_status()`; derivation against a real
directory's owner; `is_system_socket` over the real socket paths.

Decision logic is pure and socket-free (`gate_check`, `gate_report_for_error`,
`gate_locks_out`), so all eight row outcomes and every probe-failure mapping are
tested. One test asserts across *all* branches that no failing row offers a
remedy without saying it may not be the reader's to run.

**Activation, proven on a live macOS machine** — a root helper on a throwaway
socket, real install untouched:

| case | service definition | lib dir owner | result |
|---|---|---|---|
| A | none | 501 | `allow_uid=501 source=lib-dir-owner`; `nobody` → `permission denied: untrusted peer uid` |
| B | none | root | `allow_uid=null source=refused-root-lib-dir`; uid 501 still served (CLI not locked out) |
| C | `--allow-uid 501` | root | `allow_uid=501 source=flag`; `nobody` rejected |
| D | none, exec'd via a symlink in root-owned `/tmp` | 501 | `allow_uid=501 source=lib-dir-owner` (canonicalised) |

`veld doctor` run against the machine's real, older helper prints the new
failing row.

## Not in scope

Unprivileged and auto-bootstrap helpers are untouched: they bind
`$HOME/.veld/helper.sock`, never `/var/run` or `/run`, so they resolve to
`Gate::unprivileged()` and keep relying on their 0o700 owner-only socket. The
signing gate stays privileged-only — the `is_system_socket` call it shares was
hoisted into one `privileged` binding used by all three sites, with tests.

Per #338, nothing is announced to users until the whole chain closes.
