### PR TITLE
fix(ci): diagnose bad signing keys, and run the signing path on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,129 @@ jobs:
         run: |
           chmod +x tests/validate-topbar-height.sh
           ./tests/validate-topbar-height.sh
+      # The macOS half of the signing smoke test (issue #339) has exactly one
+      # executing home: the `signing-smoke` job. Its ad-hoc-resign case is
+      # `#[cfg(target_os = "macos")]`, and `signing-smoke` is the only job in
+      # this workflow that runs `cargo test` on macOS — `integration`,
+      # `injection-test` and `release-build`'s darwin legs are Rust jobs on
+      # macOS too, but they build and run the CLI rather than the test suite.
+      # So deleting or renaming `signing-smoke` leaves CI fully green with zero
+      # coverage of the ordering install.sh's re-sign depends on — a silent
+      # reopening of the exact gap this issue closed. Nothing else notices:
+      # `validate-workflow-gates.py` reads jobs only to check their draft guard,
+      # never that a given job exists.
+      # Structural rather than grep: `grep runs-on: macos-latest` over the whole
+      # file passes on `integration` and `injection-test` too, so it would stay
+      # green with `signing-smoke` deleted — a gate that cannot fail.
+      - name: The macOS signing smoke job still exists
+        run: |
+          python3 - <<'PY'
+          import pathlib, sys, yaml
+          ci = yaml.safe_load(open(".github/workflows/ci.yml"))
+          job = ci["jobs"].get("signing-smoke")
+          if job is None:
+              sys.exit("ci.yml: the `signing-smoke` job is gone; the macOS "
+                       "ad-hoc-resign test has no other executing home (issue #339)")
+          if job.get("runs-on") != "macos-latest":
+              sys.exit(f"ci.yml: signing-smoke runs on {job.get('runs-on')!r}; the "
+                       "test it exists for is #[cfg(target_os = \"macos\")]")
+          runs = " ".join(str(s.get("run", "")) for s in job["steps"])
+          if "cargo test -p veld-sign" not in runs:
+              sys.exit("ci.yml: signing-smoke no longer runs `cargo test -p veld-sign`")
+          smoke = open("crates/veld-sign/tests/smoke.rs").read()
+          if "fn adhoc_resign_after_ed25519_signing_is_byte_idempotent" not in smoke:
+              sys.exit("crates/veld-sign/tests/smoke.rs: the ad-hoc resign "
+                       "idempotency test is gone; install.sh's re-sign assumption "
+                       "would be unverified again (issue #339)")
+          # A name-only check would still pass with the case marked `#[ignore]`,
+          # which is the normal reaction to a flake and leaves the ordering
+          # unexercised with every check green.
+          if "#[ignore]" in smoke:
+              sys.exit("crates/veld-sign/tests/smoke.rs: an #[ignore] here means a "
+                       "signing case silently stops running; delete the test or fix "
+                       "it rather than skipping it (issue #339)")
+
+          # No job that a pull request can start may reach the org signing
+          # secret. Checking every workflow, and checking the *guard* rather than
+          # the filename, because release.yml is itself `pull_request`-triggered
+          # (it previews the next version on a PR) — the only thing keeping the
+          # key off those runs is the `push`-only `if:` on its `build` job, and
+          # exempting the file by name would leave exactly that guard unchecked.
+          #
+          # Walking the parsed YAML rather than grepping means the comments above
+          # — which do name the secret — are already gone, and dict keys are
+          # walked too, so naming it as a bare `env:` key is caught as well.
+          # Two forms never spell the name and so must be refused by shape: a
+          # bulk reference to the whole secrets context, and a dynamic index into
+          # it. Neither has a legitimate use here.
+          #
+          # All three needles are assembled at runtime so this check cannot match
+          # itself: its own `run:` block is a string in the very documents it
+          # walks. (Writing them literally made the gate fail on a clean tree —
+          # once per needle.)
+          secret = "SIGNING_" + "PRIVATE_KEY"
+          bulk_ref = "toJSON(" + "secrets)"
+          dynamic_ref = "secrets" + "["
+          def strings(node):
+              if isinstance(node, dict):
+                  for k, v in node.items():
+                      yield from strings(k)
+                      yield from strings(v)
+              elif isinstance(node, list):
+                  for v in node:
+                      yield from strings(v)
+              elif isinstance(node, str):
+                  yield node
+          def uses_secret(node):
+              for s in strings(node):
+                  packed = s.replace(" ", "")
+                  if secret in s:
+                      return secret
+                  if bulk_ref in packed:
+                      return "the whole secrets context"
+                  if dynamic_ref in packed:
+                      return "a dynamic index into the secrets context"
+              return None
+          # `on:` parses as the boolean True under YAML 1.1, so accept both keys.
+          for path in sorted(pathlib.Path(".github/workflows").glob("*.y*ml")):
+              doc = yaml.safe_load(path.read_text())
+              triggers = doc.get("on", doc.get(True)) or {}
+              if isinstance(triggers, str):
+                  triggers = {triggers: None}
+              if isinstance(triggers, list):
+                  triggers = dict.fromkeys(triggers)
+              # `workflow_call` counts as PR-reachable: a reusable workflow
+              # never carries `pull_request` in its own `on:`, but a caller that
+              # does can invoke it, so judging it by its own triggers alone is a
+              # blind spot rather than an exemption.
+              pr_triggered = any(
+                  t in triggers
+                  for t in ("pull_request", "pull_request_target", "workflow_call")
+              )
+              for job_name, job in (doc.get("jobs") or {}).items():
+                  what = uses_secret(job)
+                  # `secrets: inherit` hands the callee every secret this repo
+                  # has without naming one, so it reaches the signing key just
+                  # as surely as spelling it out.
+                  if what is None and str(job.get("secrets", "")).strip() == "inherit":
+                      what = "every secret, via `secrets: inherit`"
+                  if what is None:
+                      continue
+                  # Quote style is not meaning: `== 'push'` and `== "push"` are
+                  # the same guard, and matching only one spelling would fail a
+                  # legitimate reformat of release.yml.
+                  guard = str(job.get("if", "")).replace(" ", "").replace('"', "'")
+                  push_only = "github.event_name=='push'" in guard
+                  if pr_triggered and not push_only:
+                      sys.exit(
+                          f"{path}: job {job_name!r} references {what}, but a "
+                          "pull request can start that workflow and the job is "
+                          "not guarded `github.event_name == 'push'`. The signing "
+                          "key must never be reachable from a PR run (issue #339)"
+                      )
+          print("signing-smoke intact")
+          PY
+
       # `install.sh` is the largest program in this repo that nothing checked.
       # It is what `curl | bash` runs, what `veld update` runs, and now what
       # Veld Desktop's own updater ends up in — and until this step it was
@@ -1091,3 +1214,45 @@ jobs:
           launchctl bootout "gui/$(id -u)/dev.veld.helper" 2>/dev/null || true
           launchctl bootout "gui/$(id -u)/dev.veld.daemon" 2>/dev/null || true
 
+
+  # ── Helper signing smoke test (issue #339) ────────────────────────
+  #
+  # `release.yml`'s `Package client binaries` step is the only place `veld-sign`
+  # and the macOS ad-hoc-then-ed25519 ordering ever run — and it runs only on a
+  # tagged release, so the first execution of a change to that path used to be
+  # the release itself. v16.58.1 failed there because the `SIGNING_PRIVATE_KEY`
+  # secret held a PEM of the wrong kind, and nothing before the release could
+  # have said so. `release-build` above compiles the workspace; it never
+  # packages, which is the same gap that hid the `veld-sign` cross-compile bug
+  # found in #253's review.
+  #
+  # Linux coverage is already free: `check` runs `cargo test --workspace` on
+  # ubuntu, which includes `crates/veld-sign/tests/smoke.rs`. This job exists
+  # for the macOS half — `codesign` is what install.sh's re-sign idempotency
+  # rests on, and nothing else in CI can exercise it.
+  #
+  # The test generates a throwaway ed25519 key per run from /dev/urandom and
+  # hands it over as `VELD_SIGN_SMOKE_KEY`. `SIGNING_PRIVATE_KEY` is never
+  # referenced here, so the org key stays out of PR-triggered jobs entirely.
+  #
+  # What this still does NOT cover, so nobody reads the job name as more than it
+  # is. Both are in `Package client binaries` and both first run at a release:
+  #
+  #   * The `macos-amd64` leg ad-hoc signs a **cross-compiled** `x86_64-apple-darwin`
+  #     binary on an arm64 runner. The idempotency test signs a host-native
+  #     Mach-O, so the cross-arch case is unexercised.
+  #   * Nothing asserts `veld-helper.sig` actually lands in the tarball that
+  #     `tar -czf ... -C dist .` produces.
+  signing-smoke:
+    permissions:
+      contents: read
+    name: Helper Signing Smoke (macOS)
+    runs-on: macos-latest
+    needs: check
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c
+      - name: Sign a dummy binary end to end
+        run: cargo test -p veld-sign

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4773,7 +4773,9 @@ dependencies = [
 name = "veld-sign"
 version = "16.58.2"
 dependencies = [
+ "base64",
  "ed25519-dalek 2.2.0",
+ "veld-core",
 ]
 
 [[package]]

--- a/crates/veld-sign/Cargo.toml
+++ b/crates/veld-sign/Cargo.toml
@@ -13,3 +13,20 @@ path = "src/main.rs"
 
 [dependencies]
 ed25519-dalek = { workspace = true, features = ["pkcs8", "pem"] }
+
+# `tests/smoke.rs` drives the built binary as a subprocess, so it links
+# against nothing in this crate and needs the key types in its own right:
+# it generates a throwaway key, encodes it as PKCS#8/SPKI PEM, and verifies
+# the detached signature the tool wrote.
+[dev-dependencies]
+ed25519-dalek = { workspace = true, features = ["pkcs8", "pem"] }
+# The smoke test verifies with the SAME code the root helper's fail-closed
+# relaunch gate uses, rather than a second hand-rolled ed25519 check. The `.sig`
+# path rule and the accepted signature shape are a cross-crate contract with no
+# compiler tie: veld-sign writes, veld-core reads, and drift between them ships a
+# helper that refuses to relaunch. This dependency is what makes that drift fail
+# a PR instead of a release.
+veld-core = { path = "../veld-core" }
+# Only to build the "right label, body is not PKCS#8" fixture — the shape that
+# used to leak a key byte into the error message.
+base64 = { workspace = true }

--- a/crates/veld-sign/src/main.rs
+++ b/crates/veld-sign/src/main.rs
@@ -9,7 +9,37 @@
 //! (see `crates/veld-helper/src/signing.rs`). CI runs this over the *final*
 //! shipped bytes — on macOS that is the ad-hoc re-signed binary, so install.sh's
 //! later re-sign is a byte-idempotent no-op and the `.sig` still matches.
+//!
+//! Diagnosis is a feature here, not a nicety. This tool runs in exactly one
+//! place — `release.yml`'s `Package client binaries` — and only on a tagged
+//! release, so a bad key is discovered at the most expensive possible moment.
+//! v16.58.1 failed with a raw RustCrypto ASN.1 string that named the label it
+//! wanted and never the one it got, reading like a corrupt key when the actual
+//! mistake was the wrong *file* in the secret. Every failure below therefore
+//! names the label found, the label expected, and the source read — and never
+//! any part of the key itself.
+//!
+//! **That last rule is load-bearing, and every way it broke while this was
+//! written looked like careful code.** All four were found by review, not by
+//! the compiler, and each has a named guard now:
+//!
+//!   * interpolating an upstream `Display` (`{e}`) — `der` quotes the input it
+//!     rejected, both as a byte and as a length → [`key_parse_problem`];
+//!   * reading the variable with `std::env::var`, whose `NotUnicode` error
+//!     Debug-formats the entire value → [`read_key`];
+//!   * echoing anything from `argv`, because a key pasted where a *path* or a
+//!     *variable name* belongs — or passed positionally, since a PEM starts
+//!     with `-` — is one slip away in a workflow edit → [`echoable`];
+//!   * quoting the PEM label without bounding it → [`pem_header`].
+//!
+//! The shape of the rule: **a message is assembled only from fixed strings, a
+//! filtered label, and a redacted source.** Anything else that reaches stderr
+//! should be assumed to quote its input until proven otherwise.
+//!
+//! `tests/smoke.rs` drives the whole path through the process boundary on every
+//! PR, so a break lands there instead of in a release.
 
+use std::fmt;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
@@ -18,16 +48,494 @@ use ed25519_dalek::pkcs8::DecodePrivateKey;
 
 const USAGE: &str = "usage: veld-sign --key-env <VAR> | --key-file <path> <binary>";
 
+/// Exit codes. The split is for whoever is reading a failed workflow log —
+/// `release.yml` runs this under `bash -e` and only sees zero vs non-zero.
+///
+/// `EXIT_BAD_INPUT` is "I ran, and could not produce a signature from what you
+/// gave me": a key that is missing, wrongly encoded, or not ed25519, or a
+/// binary that cannot be read or whose `.sig` cannot be written.
+/// `EXIT_USAGE` is "the command line itself is wrong", before any input is
+/// touched. Nothing downstream branches on these, but they are asserted in
+/// `tests/smoke.rs` so the split cannot drift unnoticed.
+const EXIT_BAD_INPUT: u8 = 1;
+const EXIT_USAGE: u8 = 2;
+
+/// The one PEM label this tool accepts. Deliberately not widened (#339): one
+/// format with a clear error is easier to reason about for a signing tool than
+/// several with a vague one.
+const EXPECTED_LABEL: &str = "PRIVATE KEY";
+
+/// Longest PEM label ever quoted back in an error. Real labels are far shorter
+/// (`ENCRYPTED PRIVATE KEY` is 21 characters), so anything longer is not a
+/// label and is not something we are willing to echo.
+const MAX_LABEL_LEN: usize = 40;
+
+/// Stand-in for an argument that is not clearly a name, a path, or a flag.
+const REDACTED: &str = "<redacted: that is not a name or a path this tool would accept>";
+
+/// Longest name — a variable, a path segment — this tool will echo.
+/// `SIGNING_PRIVATE_KEY` is 19 and `veld-helper` is 11; the shortest encoding of
+/// the key it must never echo is 64 characters.
+const MAX_NAME_LEN: usize = 40;
+
+/// Most alphanumeric characters a single path segment may carry and still be
+/// printed. Real filenames are modest — `veld-helper` has 10,
+/// `validate-workflow-gates.py` 22 — while an encoded key packs the maximum it
+/// can into every character.
+///
+/// This exists for **URL-safe** base64, whose alphabet — unlike standard
+/// base64, base32 and hex — does contain `-` and `_`, so it is the one encoding
+/// that can satisfy the separator rule below. Unchunked it is far too long, but
+/// split across `/` its pieces would otherwise read as filenames.
+const MAX_SEGMENT_ALNUM: usize = 24;
+
+/// A path segment safe to print.
+///
+/// **The load-bearing clause is that the segment must contain a `.`, `-` or
+/// `_`.** Standard base64, base32 and hex use none of those characters, so no
+/// key in any of those encodings can satisfy it. The rule holds by construction
+/// rather than by calibration, which is what the four earlier versions lacked:
+/// each judged some *property* of key material — does it contain a slash, is it
+/// long, does it mix case, is it one long run — and each was defeated by an
+/// encoding that happened not to have it. Judging what a *filename* has instead
+/// cannot be dodged by re-encoding.
+///
+/// There is deliberately no allowance for short separator-free names like
+/// `dist` or `tmp`: permitting them let a key chunked into eight-character
+/// pieces pass as a directory tree. That was found by the randomised sweep
+/// rather than by reasoning about it, which is the argument for having one.
+///
+/// **The residual, stated rather than implied.** URL-safe base64 *is* an
+/// alphabet containing `-` and `_`. A key in it is far too long to print whole,
+/// but split on `/` into filename-sized pieces, one piece could surface. That
+/// takes a `/` placed by hand: no encoding produces both a `/` and a `.`/`-`/`_`
+/// — standard base64 has the slash and none of the others, URL-safe has the
+/// others and never a slash — which is what
+/// `no_encoding_supplies_both_a_slash_and_a_name_character` checks, and what
+/// makes this unreachable by the pasted-secret accidents this tool exists to
+/// diagnose. `url_safe_base64_is_bounded_even_when_chunked_to_look_like_a_path`
+/// pins how much a hand-built input could ever surface.
+fn is_named_segment(segment: &str) -> bool {
+    !segment.is_empty()
+        && segment.len() <= MAX_NAME_LEN
+        && segment
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_'))
+        && segment.chars().any(|c| matches!(c, '.' | '-' | '_'))
+        && segment
+            .chars()
+            .filter(|c| c.is_ascii_alphanumeric())
+            .count()
+            <= MAX_SEGMENT_ALNUM
+}
+
+// Text from `argv` is rendered for an error message only when it is clearly the
+// *kind of thing* the flag it followed is supposed to be — a name, a path, or a
+// flag. Everything else becomes [`REDACTED`].
+//
+// **`argv` is as untrusted as the key here.** This tool takes the key by *name*
+// (`--key-env`) and by *path* (`--key-file`), and three slips put the key itself
+// on the command line:
+//
+//   * `--key-file "$SIGNING_PRIVATE_KEY"` — the key where a path belongs;
+//   * `--key-env "$SIGNING_PRIVATE_KEY"` — the key where a variable *name*
+//     belongs, which then reads as an unset variable;
+//   * the key as a bare argument, which parses as an unknown flag because a PEM
+//     begins with `-`, or as the `<binary>` to sign if it does not.
+//
+// Each is one character away from the correct invocation, and each put the whole
+// key into a message bound for a public workflow log.
+
+/// An environment variable name, echoed only if it is actually an identifier.
+fn echoable_name(value: &str) -> &str {
+    let ok = !value.is_empty()
+        && value.len() <= MAX_NAME_LEN
+        && !value.starts_with(|c: char| c.is_ascii_digit())
+        && value.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
+    if ok { value } else { REDACTED }
+}
+
+/// A filesystem path, echoed whole when every segment is one this tool would
+/// print, and otherwise narrowed to the file's own name.
+///
+/// **Narrowing is the normal outcome, not the exception.** Ordinary directory
+/// names — `dist`, `target`, `release`, `runner`, and macOS `$TMPDIR`'s
+/// 30-character random component — carry no `.`, `-` or `_`, so `dist/veld-helper`
+/// renders as `…/veld-helper`. That is the deliberate trade: no rule can tell a
+/// directory name from encoded bytes without being beaten by some encoding, and
+/// a key chunked into short pieces looks exactly like a directory tree. The flag
+/// and the filename — what an operator acts on — survive; the directory does not.
+fn echoable_path(value: &str) -> std::borrow::Cow<'_, str> {
+    use std::borrow::Cow;
+    let segments: Vec<&str> = value.split('/').filter(|s| !s.is_empty()).collect();
+    // The whole value is bounded as well as each segment: a key chunked into
+    // filename-sized pieces can pass every segment individually and still
+    // reassemble the key across them, which is precisely what the randomised
+    // sweep produced. Bounding the total means at most one piece is ever shown.
+    let alnum = value.chars().filter(|c| c.is_ascii_alphanumeric()).count();
+    if !segments.is_empty()
+        && alnum <= MAX_SEGMENT_ALNUM
+        && segments.iter().all(|s| is_named_segment(s))
+    {
+        return Cow::Borrowed(value);
+    }
+    match segments.last() {
+        Some(name) if is_named_segment(name) => Cow::Owned(format!("…/{name}")),
+        _ => Cow::Borrowed(REDACTED),
+    }
+}
+
+/// An unrecognised flag, echoed so a typo is visible — but a PEM starts with
+/// `-`, so this is one of the three doors above.
+fn echoable_flag(value: &str) -> &str {
+    let ok = value.len() <= MAX_NAME_LEN
+        && value
+            .trim_start_matches('-')
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_');
+    if ok { value } else { REDACTED }
+}
+
+/// Where the key text came from, named with the flag the operator actually
+/// typed — so a failure says immediately whether to go look at a CI secret or
+/// at a file on disk.
+///
+/// Holds the *source* of the key, never the key — and renders even the source
+/// through [`echoable`], because the source itself comes from `argv`.
+enum KeySource {
+    Env(String),
+    File(PathBuf),
+}
+
+impl fmt::Display for KeySource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            KeySource::Env(var) => write!(f, "--key-env {}", echoable_name(var)),
+            KeySource::File(path) => {
+                write!(f, "--key-file {}", echoable_path(&path.to_string_lossy()))
+            }
+        }
+    }
+}
+
+/// A failure worth explaining: what went wrong, and — when the PEM label
+/// identifies which mistake this is — what to do about it.
+///
+/// Both fields are built only from the PEM label (filtered by [`pem_header`]),
+/// the [`KeySource`], and fixed strings. No key material ever reaches either
+/// one; `key_body_never_appears_in_an_error` is what holds that line.
+#[derive(Debug)]
+struct SignError {
+    problem: String,
+    hint: Option<&'static str>,
+}
+
+impl SignError {
+    fn new(problem: impl Into<String>) -> Self {
+        Self {
+            problem: problem.into(),
+            hint: None,
+        }
+    }
+
+    fn with_hint(problem: impl Into<String>, hint: &'static str) -> Self {
+        Self {
+            problem: problem.into(),
+            hint: Some(hint),
+        }
+    }
+
+    /// The operator-facing rendering, exactly as `main` prints it to stderr.
+    fn render(&self) -> String {
+        match self.hint {
+            Some(hint) => format!("error: {}\nhint: {hint}", self.problem),
+            None => format!("error: {}", self.problem),
+        }
+    }
+}
+
+/// What the first `-----BEGIN …-----` line in the input turned out to be.
+enum PemHeader<'a> {
+    /// A label safe to quote back in an error, e.g. `PRIVATE KEY`.
+    Label(&'a str),
+    /// A `-----BEGIN …-----` line whose label this tool will not repeat.
+    ///
+    /// RFC 7468 allows far more than the labels below — any printable ASCII bar
+    /// `-`, in any case — so this is *not* the same question as "is it valid
+    /// PEM". It is "would echoing this put attacker- or accident-chosen text
+    /// into a public CI log", and the answer is no only for the shape every
+    /// real key label has. The header is still reported as *present*: saying
+    /// there was none would be its own misleading message.
+    Unquotable,
+    /// A `-----BEGIN`/`-----END` boundary line that does not start at column 0.
+    ///
+    /// RFC 7468 boundaries are anchored, so `from_pkcs8_pem` rejects the whole
+    /// document — but the label and the body are both fine, and reporting this
+    /// as a corrupt body is exactly the misdiagnosis #339 exists to remove. A
+    /// key pasted into a YAML block scalar or an indented heredoc lands here.
+    ///
+    /// Only the *expected* label reaches this variant: an indented wrong label
+    /// comes back as `Label`, because which file you grabbed is the more useful
+    /// thing to be told. See `a_wrong_label_wins_over_indentation`.
+    Indented,
+    /// The value opens with a UTF-8 byte-order mark, so the first line is not a
+    /// boundary however much it looks like one in an editor. `U+FEFF` is not
+    /// `char::is_whitespace`, so nothing upstream trims it away.
+    ByteOrderMark,
+    /// No `-----BEGIN …-----` line anywhere in the input.
+    Missing,
+}
+
+/// Classify the first PEM block in `input` — `PRIVATE KEY` for a
+/// `-----BEGIN PRIVATE KEY-----` header.
+///
+/// The label is bounded and character-filtered *here* rather than at the print
+/// site, because this value is the one piece of the input that reaches an error
+/// message and the input is a private key. A permissive reader handed something
+/// that is not PEM would happily quote an arbitrary slice of it into a CI log.
+fn pem_header(input: &str) -> PemHeader<'_> {
+    if input.starts_with('\u{feff}') {
+        return PemHeader::ByteOrderMark;
+    }
+    let Some(line) = input
+        .lines()
+        .find(|line| line.trim_start().starts_with("-----BEGIN "))
+    else {
+        return PemHeader::Missing;
+    };
+    let Some(label) = line
+        .trim()
+        .strip_prefix("-----BEGIN ")
+        .and_then(|rest| rest.strip_suffix("-----"))
+    else {
+        // `-----BEGIN ` with no closing `-----`: a header in spirit only.
+        return PemHeader::Unquotable;
+    };
+    let quotable = !label.is_empty()
+        && label.len() <= MAX_LABEL_LEN
+        && label
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == ' ');
+    if !quotable {
+        return PemHeader::Unquotable;
+    }
+    // Indentation only matters once the label is the one we want: a wrong label
+    // is the more useful thing to report, indented or not.
+    //
+    // Checked across *every* boundary line, not just the first. A re-indent that
+    // caught the body and the END line but not BEGIN is still rejected by the
+    // parser, and reporting that as a corrupt body is the same misdiagnosis this
+    // variant exists to remove. Trimming the label first so that a boundary
+    // which is both indented and padded reports the indentation, whose fix
+    // ("start at column 0, no extra spaces") covers both — telling the operator
+    // only about the spaces would leave them failing again after doing exactly
+    // what they were told.
+    if label.trim() == EXPECTED_LABEL && input.lines().any(is_indented_boundary) {
+        return PemHeader::Indented;
+    }
+    PemHeader::Label(label)
+}
+
+/// A `-----BEGIN`/`-----END` line that does not start at column 0.
+fn is_indented_boundary(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    (trimmed.starts_with("-----BEGIN") || trimmed.starts_with("-----END"))
+        && line.starts_with(char::is_whitespace)
+}
+
+/// What to do about a label we recognise as one specific operator mistake.
+/// An unrecognised label still gets the expected/got/source message; it just
+/// has no advice to add.
+fn label_hint(label: &str) -> Option<&'static str> {
+    match label {
+        "PUBLIC KEY" => Some("this looks like the .pub, not the private key"),
+        "OPENSSH PRIVATE KEY" => {
+            Some("this is an OpenSSH key; convert it with `ssh-keygen -p -m PKCS8 -f <key>`")
+        }
+        "ENCRYPTED PRIVATE KEY" => Some("this key is passphrase-protected; decrypt it first"),
+        _ => None,
+    }
+}
+
+/// Why a correctly-labelled PKCS#8 body would not parse, as a fixed string.
+///
+/// The upstream `Display` is deliberately **not** interpolated here. It reaches
+/// stderr, stderr reaches a public workflow log, and `der`'s own renderings
+/// quote the input:
+///
+///   * `ErrorKind::TagUnknown` prints the offending byte —
+///     `unknown/unsupported ASN.1 DER tag: 0x11` — which for a bare 32-byte
+///     seed pasted under the right header is literally `seed[0]`;
+///   * `ErrorKind::Incomplete` prints the DER length and the decoded body
+///     length — `expected 48, actual 30`.
+///
+/// #339 forbids both: "not the body, not a prefix of it, not a length that
+/// narrows it". Classifying by variant keeps the diagnosis while saying only
+/// what *shape* the input had, never what was in it.
+fn key_parse_problem(e: &ed25519_dalek::pkcs8::Error) -> &'static str {
+    use ed25519_dalek::pkcs8::Error;
+    match e {
+        Error::Asn1(_) => "the body is not valid DER, so the key is truncated or corrupt",
+        Error::KeyMalformed => "the DER parsed, but the key inside it is not a usable ed25519 key",
+        Error::ParametersMalformed => "the DER parsed, but its algorithm parameters are malformed",
+        Error::PublicKey(_) => {
+            "the DER parsed, but names a different algorithm — a PKCS#8 key, but not an ed25519 one"
+        }
+        // `pkcs8::Error` is `#[non_exhaustive]`; a variant added upstream must
+        // still not reach stderr.
+        _ => "the body did not parse as a PKCS#8 ed25519 private key",
+    }
+}
+
+/// Turn PEM text into a signing key, diagnosing the wrong-file cases by label
+/// before the parser sees anything — the parser's own error names the label it
+/// wanted and never the one it got, which is what made v16.58.1 read as a
+/// corrupt key rather than the wrong file.
+fn parse_signing_key(
+    key_pem: &str,
+    source: &KeySource,
+) -> Result<ed25519_dalek::SigningKey, SignError> {
+    if key_pem.trim().is_empty() {
+        return Err(SignError::with_hint(
+            format!(
+                "no key read from {source}: expected a PKCS#8 private key \
+                 (\"BEGIN {EXPECTED_LABEL}\"), got an empty value"
+            ),
+            match source {
+                KeySource::Env(_) => "the variable is unset, or the secret was uploaded empty",
+                KeySource::File(_) => "the file is empty",
+            },
+        ));
+    }
+
+    let wrong_format = |got: &str| {
+        format!(
+            "wrong key format from {source}: expected a PKCS#8 private key \
+             (\"BEGIN {EXPECTED_LABEL}\"), {got}"
+        )
+    };
+    match pem_header(key_pem) {
+        PemHeader::Label(EXPECTED_LABEL) => {}
+        // A label that differs from the expected one only in whitespace renders
+        // as two visually identical quoted strings in a log — the operator reads
+        // `got "BEGIN PRIVATE KEY "` against `expected … "BEGIN PRIVATE KEY"`
+        // and concludes the tool is broken. Name the actual difference instead.
+        PemHeader::Label(found) if found.trim() == EXPECTED_LABEL => {
+            return Err(SignError::with_hint(
+                wrong_format("got the right label with stray whitespace around it"),
+                "remove the extra spaces from the `-----BEGIN PRIVATE KEY-----` line",
+            ));
+        }
+        PemHeader::Label(found) => {
+            let problem = wrong_format(&format!("got \"BEGIN {found}\""));
+            return Err(match label_hint(found) {
+                Some(hint) => SignError::with_hint(problem, hint),
+                None => SignError::new(problem),
+            });
+        }
+        PemHeader::Unquotable => {
+            return Err(SignError::with_hint(
+                wrong_format("got a PEM block with an unrecognised label"),
+                "the label is not repeated here because the input is a private key; \
+                 the value must start with a `-----BEGIN PRIVATE KEY-----` line",
+            ));
+        }
+        PemHeader::Indented => {
+            return Err(SignError::with_hint(
+                wrong_format("got the right label on an indented line"),
+                "PEM boundaries must start at column 0 with no extra spaces — strip \
+                 the leading whitespace a YAML block scalar or an indented heredoc adds",
+            ));
+        }
+        PemHeader::ByteOrderMark => {
+            return Err(SignError::with_hint(
+                wrong_format("got a byte-order mark before the first line"),
+                "re-save the key as UTF-8 without a BOM, or as plain ASCII",
+            ));
+        }
+        PemHeader::Missing => {
+            return Err(SignError::with_hint(
+                wrong_format("found no PEM header at all"),
+                "the value must start with a `-----BEGIN PRIVATE KEY-----` line",
+            ));
+        }
+    }
+
+    // Header is right, so this is a real attempt at the right kind of file.
+    // The upstream error is classified rather than interpolated — see
+    // `key_parse_problem`.
+    ed25519_dalek::SigningKey::from_pkcs8_pem(key_pem).map_err(|e| {
+        SignError::with_hint(
+            format!(
+                "invalid ed25519 private key from {source}: {}",
+                key_parse_problem(&e)
+            ),
+            "the PEM header is right, so the problem is inside the key body itself",
+        )
+    })
+}
+
+/// Read the key text named by `source`, without ever rendering the value.
+///
+/// **`std::env::var` must not be used here.** Its `VarError::NotUnicode`
+/// `Display` Debug-formats the whole `OsString`, so one stray non-UTF-8 byte in
+/// the secret — a Latin-1 or UTF-16 paste, a BOM, raw DER uploaded instead of
+/// PEM, a mangled copy made while *fixing* the v16.58.1 mistake — printed the
+/// entire private key into a public workflow log. GitHub's secret masking is no
+/// backstop: Debug escaping is exactly the value transformation that defeats it,
+/// and once a byte inside the base64 line is mangled the printed text no longer
+/// matches the registered secret at all. `var_os` + `into_string` keeps the bad
+/// value in an `OsString` that is dropped without ever being formatted.
+///
+/// `read_to_string`'s own non-UTF-8 error carries no content ("stream did not
+/// contain valid UTF-8"), but it routes to the same message so both sources
+/// read alike.
+fn read_key(source: &KeySource) -> Result<String, SignError> {
+    let not_utf8 = || {
+        SignError::with_hint(
+            format!(
+                "wrong key format from {source}: expected a PKCS#8 private key \
+                 (\"BEGIN {EXPECTED_LABEL}\"), got bytes that are not valid UTF-8"
+            ),
+            "a PKCS#8 PEM is ASCII text; this may be raw DER, or a file saved in another encoding",
+        )
+    };
+    match source {
+        // An absent variable is the same operator mistake as an empty one — the
+        // secret never reached the runner — so it takes the same diagnosis in
+        // `parse_signing_key` rather than a separate message that reads like a
+        // bug in the workflow.
+        KeySource::Env(var) => match std::env::var_os(var) {
+            None => Ok(String::new()),
+            Some(raw) => raw.into_string().map_err(|_| not_utf8()),
+        },
+        KeySource::File(path) => std::fs::read_to_string(path).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::InvalidData {
+                not_utf8()
+            } else {
+                SignError::new(format!("cannot read {source}: {e}"))
+            }
+        }),
+    }
+}
+
 /// Sign `binary` with `key_pem` (PKCS#8 PEM) and write `<binary>.sig`.
-fn sign_file(binary: &Path, key_pem: &str) -> Result<PathBuf, String> {
-    let signing_key = ed25519_dalek::SigningKey::from_pkcs8_pem(key_pem)
-        .map_err(|e| format!("invalid ed25519 private key: {e}"))?;
-    let data =
-        std::fs::read(binary).map_err(|e| format!("cannot read {}: {e}", binary.display()))?;
+fn sign_file(binary: &Path, key_pem: &str, source: &KeySource) -> Result<PathBuf, SignError> {
+    let signing_key = parse_signing_key(key_pem, source)?;
+    let data = std::fs::read(binary).map_err(|e| {
+        SignError::new(format!(
+            "cannot read {}: {e}",
+            echoable_path(&binary.to_string_lossy())
+        ))
+    })?;
     let sig = signing_key.sign(&data);
     let sig_path = sig_path_for(binary);
-    std::fs::write(&sig_path, sig.to_bytes())
-        .map_err(|e| format!("cannot write {}: {e}", sig_path.display()))?;
+    std::fs::write(&sig_path, sig.to_bytes()).map_err(|e| {
+        SignError::new(format!(
+            "cannot write {}: {e}",
+            echoable_path(&sig_path.to_string_lossy())
+        ))
+    })?;
     Ok(sig_path)
 }
 
@@ -54,7 +562,11 @@ fn main() -> ExitCode {
                 Some(v) => key_file = Some(PathBuf::from(v)),
                 None => return usage("--key-file requires a value"),
             },
-            other if other.starts_with('-') => return usage(&format!("unknown flag: {other}")),
+            // A PEM begins with `-`, so a key handed over positionally lands
+            // here rather than as the <binary> argument.
+            other if other.starts_with('-') => {
+                return usage(&format!("unknown flag: {}", echoable_flag(other)));
+            }
             other => binary = Some(PathBuf::from(other)),
         }
     }
@@ -64,45 +576,51 @@ fn main() -> ExitCode {
         None => return usage("missing <binary> path"),
     };
 
-    let key_pem = match (&key_env, &key_file) {
-        (Some(env), _) => match std::env::var(env) {
-            Ok(v) => v,
-            Err(e) => {
-                eprintln!("error: cannot read env {env}: {e}");
-                return ExitCode::from(2);
-            }
-        },
-        (None, Some(f)) => match std::fs::read_to_string(f) {
-            Ok(v) => v,
-            Err(e) => {
-                eprintln!("error: cannot read key file {}: {e}", f.display());
-                return ExitCode::from(2);
-            }
-        },
+    let source = match (key_env, key_file) {
+        (Some(_), Some(_)) => return usage("--key-env and --key-file are mutually exclusive"),
+        (Some(var), None) => KeySource::Env(var),
+        (None, Some(path)) => KeySource::File(path),
         (None, None) => return usage("provide --key-env or --key-file"),
     };
 
-    match sign_file(&binary, &key_pem) {
+    let key_pem = match read_key(&source) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("{}", e.render());
+            return ExitCode::from(EXIT_BAD_INPUT);
+        }
+    };
+
+    match sign_file(&binary, &key_pem, &source) {
         Ok(sig_path) => {
-            eprintln!("signed {} -> {}", binary.display(), sig_path.display());
+            eprintln!(
+                "signed {} -> {}",
+                echoable_path(&binary.to_string_lossy()),
+                echoable_path(&sig_path.to_string_lossy())
+            );
             ExitCode::SUCCESS
         }
         Err(e) => {
-            eprintln!("error: {e}");
-            ExitCode::from(1)
+            eprintln!("{}", e.render());
+            ExitCode::from(EXIT_BAD_INPUT)
         }
     }
 }
 
 fn usage(msg: &str) -> ExitCode {
     eprintln!("error: {msg}\n{USAGE}");
-    ExitCode::from(2)
+    ExitCode::from(EXIT_USAGE)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::Engine as _;
+    use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64_URL_SAFE_NO_PAD;
+    use ed25519_dalek::pkcs8::EncodePrivateKey;
     use ed25519_dalek::{Verifier, VerifyingKey};
+    use std::io::Read;
 
     // A throwaway ed25519 key (NOT the org key), generated with `openssl
     // genpkey -algorithm ED25519` — the exact format `veld update`/CI feed in
@@ -116,6 +634,20 @@ mod tests {
         0xf0, 0xc7,
     ];
 
+    fn env_source() -> KeySource {
+        KeySource::Env("SIGNING_PRIVATE_KEY".into())
+    }
+
+    /// The base64 body of `TEST_PRIVATE_PEM`, with no header lines — i.e. the
+    /// bytes that must never be echoed.
+    fn key_body() -> String {
+        TEST_PRIVATE_PEM
+            .lines()
+            .filter(|l| !l.trim_start().starts_with("-----"))
+            .map(str::trim)
+            .collect()
+    }
+
     #[test]
     fn sign_file_writes_a_verifiable_detached_signature() {
         let dir = std::env::temp_dir().join(format!("veld-sign-test-{}", std::process::id()));
@@ -123,7 +655,7 @@ mod tests {
         let binary = dir.join("veld-helper");
         std::fs::write(&binary, b"macho/elf payload bytes").unwrap();
 
-        let sig_path = sign_file(&binary, TEST_PRIVATE_PEM).unwrap();
+        let sig_path = sign_file(&binary, TEST_PRIVATE_PEM, &env_source()).unwrap();
         assert_eq!(sig_path, sig_path_for(&binary));
 
         let sig = std::fs::read(&sig_path).unwrap();
@@ -141,5 +673,597 @@ mod tests {
             sig_path_for(Path::new("/x/veld-helper")),
             PathBuf::from("/x/veld-helper.sig")
         );
+    }
+
+    /// `Label(l)` / `Unquotable` / `Missing` as a short string, for asserting.
+    fn header_of(input: &str) -> String {
+        match pem_header(input) {
+            PemHeader::Label(l) => l.to_string(),
+            PemHeader::Unquotable => "<unquotable>".into(),
+            PemHeader::Indented => "<indented>".into(),
+            PemHeader::ByteOrderMark => "<bom>".into(),
+            PemHeader::Missing => "<missing>".into(),
+        }
+    }
+
+    /// A legitimately-PEM value whose label this tool will not echo must still
+    /// be reported as *having* a header. Telling the operator there is no PEM
+    /// header in a file that plainly has one is the same wrong-file-reported-as-
+    /// something-else failure #339 exists to remove, pointed the other way.
+    #[test]
+    fn an_unquotable_label_is_reported_as_present_not_absent() {
+        let pem =
+            "-----BEGIN OpenVPN Static key V1-----\nabcdef\n-----END OpenVPN Static key V1-----\n";
+        let err = parse_signing_key(pem, &env_source()).unwrap_err().render();
+        assert!(
+            err.contains("got a PEM block with an unrecognised label"),
+            "{err}"
+        );
+        assert!(!err.contains("no PEM header at all"), "{err}");
+        assert!(
+            !err.contains("OpenVPN"),
+            "the label must not be echoed: {err}"
+        );
+    }
+
+    #[test]
+    fn pem_header_reads_the_first_block_and_rejects_non_labels() {
+        assert_eq!(header_of(TEST_PRIVATE_PEM), "PRIVATE KEY");
+        assert_eq!(
+            header_of("-----BEGIN OPENSSH PRIVATE KEY-----\nbody\n"),
+            "OPENSSH PRIVATE KEY"
+        );
+        // Leading noise before the block is still a readable label.
+        assert_eq!(
+            header_of("# comment\n\n-----BEGIN PUBLIC KEY-----\nbody\n"),
+            "PUBLIC KEY"
+        );
+        assert_eq!(header_of(""), "<missing>");
+        assert_eq!(header_of("MC4CAQAwBQYDK2Vw"), "<missing>");
+        // A "label" that is really a slice of some other file never escapes:
+        // lowercase and punctuation are rejected, and so is anything longer
+        // than a real label. RFC 7468 permits all of these as labels, so they
+        // are reported as a header that is present but unquotable — never as
+        // no header at all.
+        assert_eq!(header_of("-----BEGIN -----"), "<unquotable>");
+        assert_eq!(
+            header_of("-----BEGIN secret/value+here-----"),
+            "<unquotable>"
+        );
+        assert_eq!(
+            header_of("-----BEGIN OpenVPN Static key V1-----"),
+            "<unquotable>"
+        );
+        assert_eq!(
+            header_of(&format!(
+                "-----BEGIN {}-----",
+                "A".repeat(MAX_LABEL_LEN + 1)
+            )),
+            "<unquotable>"
+        );
+    }
+
+    #[test]
+    fn a_public_key_names_the_label_found_expected_and_source() {
+        let pem = "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAVxMGvCvahvk4Vafq2qchdBFnCWzqtwMR0vfUMwMK8Mc=\n-----END PUBLIC KEY-----\n";
+        let err = parse_signing_key(pem, &env_source()).unwrap_err().render();
+        assert!(err.contains("got \"BEGIN PUBLIC KEY\""), "{err}");
+        assert!(err.contains("\"BEGIN PRIVATE KEY\""), "{err}");
+        assert!(err.contains("--key-env SIGNING_PRIVATE_KEY"), "{err}");
+        assert!(err.contains("this looks like the .pub"), "{err}");
+    }
+
+    #[test]
+    fn an_openssh_key_is_told_how_to_convert() {
+        let pem = "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAA\n-----END OPENSSH PRIVATE KEY-----\n";
+        let err = parse_signing_key(pem, &env_source()).unwrap_err().render();
+        assert!(err.contains("got \"BEGIN OPENSSH PRIVATE KEY\""), "{err}");
+        assert!(err.contains("ssh-keygen -p -m PKCS8 -f <key>"), "{err}");
+    }
+
+    #[test]
+    fn an_encrypted_key_is_told_to_decrypt_first() {
+        let pem = "-----BEGIN ENCRYPTED PRIVATE KEY-----\nMIGbMFcGCSqGSIb3DQEFDT\n-----END ENCRYPTED PRIVATE KEY-----\n";
+        let err = parse_signing_key(pem, &env_source()).unwrap_err().render();
+        assert!(err.contains("got \"BEGIN ENCRYPTED PRIVATE KEY\""), "{err}");
+        assert!(err.contains("decrypt it first"), "{err}");
+    }
+
+    #[test]
+    fn an_unrecognised_label_still_names_what_it_got() {
+        let pem = "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n";
+        let err = parse_signing_key(pem, &env_source()).unwrap_err().render();
+        assert!(err.contains("got \"BEGIN CERTIFICATE\""), "{err}");
+        assert!(!err.contains("hint:"), "{err}");
+    }
+
+    #[test]
+    fn an_empty_value_is_diagnosed_as_empty_per_source() {
+        // The v16.58.1-adjacent case: the secret simply never reached the job.
+        let err = parse_signing_key("", &env_source()).unwrap_err().render();
+        assert!(err.contains("got an empty value"), "{err}");
+        assert!(err.contains("--key-env SIGNING_PRIVATE_KEY"), "{err}");
+        assert!(err.contains("unset"), "{err}");
+
+        let file = KeySource::File(PathBuf::from("/etc/veld/signing.pem"));
+        let err = parse_signing_key("   \n\n", &file).unwrap_err().render();
+        assert!(err.contains("got an empty value"), "{err}");
+        // Narrowed to the filename — see `echoable_allows_real_names_paths_and_flags`.
+        assert!(err.contains("--key-file …/signing.pem"), "{err}");
+        assert!(err.contains("the file is empty"), "{err}");
+    }
+
+    #[test]
+    fn a_value_with_no_pem_header_says_so() {
+        let err = parse_signing_key("MC4CAQAwBQYDK2Vw\n", &env_source())
+            .unwrap_err()
+            .render();
+        assert!(err.contains("found no PEM header at all"), "{err}");
+        assert!(err.contains("-----BEGIN PRIVATE KEY-----"), "{err}");
+    }
+
+    #[test]
+    fn a_correctly_labelled_but_broken_body_is_not_reported_as_the_wrong_file() {
+        let body = key_body();
+        let pem = format!(
+            "-----BEGIN PRIVATE KEY-----\n{}\n-----END PRIVATE KEY-----\n",
+            &body[..body.len() - 8]
+        );
+        let err = parse_signing_key(&pem, &env_source()).unwrap_err().render();
+        assert!(err.contains("invalid ed25519 private key"), "{err}");
+        assert!(err.contains("truncated or corrupt"), "{err}");
+        // The upstream renderer would have said `expected 48, actual 30` here.
+        assert!(!err.contains("0x") && !err.contains("48"), "{err}");
+    }
+
+    /// The whole private key uploaded, but the wrong one: a PKCS#8 key for a
+    /// different algorithm. The right label, valid DER, and still unusable —
+    /// so "corrupt or truncated" would send the operator hunting a transfer
+    /// problem that does not exist.
+    ///
+    /// The fixture is `TEST_PRIVATE_PEM` with one byte of its algorithm OID
+    /// changed (1.3.101.112 Ed25519 → 1.3.101.110 X25519), so no second key is
+    /// committed here. A real RSA PKCS#8 key produces the same message.
+    #[test]
+    fn a_pkcs8_key_for_another_algorithm_says_so() {
+        let x25519 = "-----BEGIN PRIVATE KEY-----\n\
+            MC4CAQAwBQYDK2VuBCIEIG6yQcLcN3khrsV3dAHJmX/loSUSEoU9FVYNd4mqV+S1\n\
+            -----END PRIVATE KEY-----\n";
+        let err = parse_signing_key(x25519, &env_source())
+            .unwrap_err()
+            .render();
+        assert!(err.contains("names a different algorithm"), "{err}");
+        assert!(!err.contains("truncated"), "{err}");
+    }
+
+    /// A byte-perfect key whose boundary lines are indented — a key pasted into
+    /// a YAML block scalar or an indented heredoc. `from_pkcs8_pem` rejects the
+    /// document because RFC 7468 boundaries are anchored, and before this branch
+    /// existed the operator was told the *body* was "truncated or corrupt" and
+    /// that "the PEM header is right". Both were false, which is the #339 bug
+    /// wearing a different hat.
+    #[test]
+    fn an_indented_pem_blames_the_indentation_not_the_body() {
+        let indented: String = TEST_PRIVATE_PEM
+            .lines()
+            .map(|l| format!("  {l}\n"))
+            .collect();
+        assert_eq!(header_of(&indented), "<indented>");
+        let err = parse_signing_key(&indented, &env_source())
+            .unwrap_err()
+            .render();
+        assert!(err.contains("indented line"), "{err}");
+        assert!(err.contains("column 0"), "{err}");
+        assert!(!err.contains("corrupt"), "{err}");
+        assert!(!err.contains("truncated"), "{err}");
+    }
+
+    /// A key saved by an editor that writes a UTF-8 BOM. `U+FEFF` is not
+    /// `char::is_whitespace`, so the first line stops looking like a boundary —
+    /// and the old message told the operator the value must start with a line
+    /// it already started with, byte for byte.
+    #[test]
+    fn a_byte_order_mark_is_named_rather_than_reported_as_no_header() {
+        let bom = format!("{}{TEST_PRIVATE_PEM}", '\u{feff}');
+        assert_eq!(header_of(&bom), "<bom>");
+        let err = parse_signing_key(&bom, &env_source()).unwrap_err().render();
+        assert!(err.contains("byte-order mark"), "{err}");
+        assert!(!err.contains("no PEM header at all"), "{err}");
+    }
+
+    /// Indentation is only the headline once the label is the one we want; a
+    /// wrong label is the more useful thing to say, indented or not.
+    #[test]
+    fn a_wrong_label_wins_over_indentation() {
+        let err = parse_signing_key("  -----BEGIN PUBLIC KEY-----\n  body\n", &env_source())
+            .unwrap_err()
+            .render();
+        assert!(err.contains("got \"BEGIN PUBLIC KEY\""), "{err}");
+        assert!(!err.contains("indented"), "{err}");
+    }
+
+    /// The three renderings a path can get, and when.
+    ///
+    /// Narrowing to `…/<filename>` is the common case, and it is a deliberate
+    /// trade: the directory is dropped because no rule can tell a directory
+    /// name from encoded bytes without being defeated by some encoding, and a
+    /// key chunked into short pieces looks exactly like a directory tree. What
+    /// the operator acts on — the flag, and which file — survives.
+    #[test]
+    fn echoable_allows_real_names_paths_and_flags() {
+        assert_eq!(echoable_name("SIGNING_PRIVATE_KEY"), "SIGNING_PRIVATE_KEY");
+        assert_eq!(echoable_flag("--kye-env"), "--kye-env");
+
+        // Whole value: every segment carries a `.`, `-` or `_`.
+        for path in ["signing.pem", "veld-helper", "id_ed25519/veld-helper"] {
+            assert_eq!(echoable_path(path), path, "should echo whole: {path}");
+        }
+
+        // Narrowed to the filename: some directory above it is separator-free.
+        for (path, shown) in [
+            ("dist/veld-helper", "…/veld-helper"),
+            ("/etc/veld/signing.pem", "…/signing.pem"),
+            (
+                "/Users/runner/work/veld/veld/dist/veld-helper",
+                "…/veld-helper",
+            ),
+            (
+                "/var/folders/0j/ccvfzg7j28l480jq1ydvmm340000gn/T/veld-helper",
+                "…/veld-helper",
+            ),
+        ] {
+            assert_eq!(echoable_path(path), shown, "should narrow: {path}");
+        }
+
+        // Redacted: nothing in it is a filename. The last is a key chunked to
+        // look like a directory tree, which an earlier rule echoed in full.
+        for path in [
+            "MC4CAQAwBQYDK2VwBCIEIG6yQcLcN3khrsV3dAHJmX/loSUSEoU9FVYNd4mqV1S1",
+            "3ef98423/c9fc3f18/b0cada12/7a41493a/106a9273/37ed5654/8f3ef07c",
+        ] {
+            assert_eq!(echoable_path(path), REDACTED, "should redact: {path}");
+        }
+    }
+
+    /// Every encoding of the key, through every one of the three functions.
+    ///
+    /// The assertions use the bare body deliberately: an earlier version of
+    /// this test used `key_body().repeat(4)` — 256 characters, just over a
+    /// 200-character bound — and so passed while the real 64-character body
+    /// leaked. Base32 is here because it is single-case, which is what defeated
+    /// the version of the rule that looked for mixed case.
+    #[test]
+    fn echoable_redacts_the_key_in_every_encoding_it_travels_in() {
+        let body = key_body();
+        assert_eq!(body.len(), 64, "the fixture must be the real body length");
+        let hex: String = "302e020100300506032b657004220420".repeat(3);
+
+        let seed_bytes: Vec<u8> = (0u8..48).collect();
+        let mut encoded_forms = vec![body.clone(), hex, TEST_PRIVATE_PEM.to_string()];
+        encoded_forms.push(base32(&seed_bytes));
+        encoded_forms.push(base32(&seed_bytes).to_lowercase());
+        for encoded in &encoded_forms {
+            assert_eq!(echoable_name(encoded), REDACTED, "name: {encoded}");
+            assert_eq!(echoable_path(encoded), REDACTED, "path: {encoded}");
+            assert_eq!(echoable_flag(encoded), REDACTED, "flag: {encoded}");
+        }
+        // A body split by base64's own `/` is still one long run per part.
+        assert_eq!(
+            echoable_path("MC4CAQAwBQYDK2VwBCIEIG6yQcLcN3khrsV3dAHJmX/loSUS"),
+            REDACTED
+        );
+        assert_eq!(echoable_path("two\nlines"), REDACTED);
+    }
+
+    /// A re-indent that caught the body and the END line but not BEGIN is still
+    /// rejected by the parser, and used to be blamed on the body.
+    #[test]
+    fn an_indented_body_counts_as_indentation_too() {
+        let mut lines = TEST_PRIVATE_PEM.lines();
+        let first = lines.next().unwrap();
+        let rest: String = lines.map(|l| format!("  {l}\n")).collect();
+        let pem = format!("{first}\n{rest}");
+        assert_eq!(header_of(&pem), "<indented>");
+        let err = parse_signing_key(&pem, &env_source()).unwrap_err().render();
+        assert!(err.contains("indented line"), "{err}");
+        assert!(!err.contains("corrupt"), "{err}");
+    }
+
+    /// Indented *and* padded: the hint must cover both, or an operator who does
+    /// exactly what it says fails again on the other half.
+    #[test]
+    fn indentation_outranks_stray_whitespace_in_the_label() {
+        let pem = "  -----BEGIN PRIVATE KEY -----\n  body\n  -----END PRIVATE KEY-----\n";
+        assert_eq!(header_of(pem), "<indented>");
+        let err = parse_signing_key(pem, &env_source()).unwrap_err().render();
+        assert!(err.contains("column 0"), "{err}");
+        assert!(err.contains("no extra spaces"), "{err}");
+    }
+
+    /// RFC 4648 base32 of `bytes` — uppercase, and single-case by spec, which
+    /// is exactly what defeated the alphabet-based version of the argv guard.
+    fn base32(bytes: &[u8]) -> String {
+        const ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+        let mut out = String::new();
+        let (mut acc, mut bits) = (0u32, 0u32);
+        for &b in bytes {
+            acc = (acc << 8) | u32::from(b);
+            bits += 8;
+            while bits >= 5 {
+                bits -= 5;
+                out.push(ALPHABET[((acc >> bits) & 31) as usize] as char);
+            }
+        }
+        if bits > 0 {
+            out.push(ALPHABET[((acc << (5 - bits)) & 31) as usize] as char);
+        }
+        out
+    }
+
+    /// Every encoding a mangled secret plausibly arrives in.
+    fn encodings_of(seed: &[u8], pem: &str) -> Vec<String> {
+        vec![
+            pem.to_string(),
+            pem.lines()
+                .filter(|l| !l.trim_start().starts_with("-----"))
+                .map(str::trim)
+                .collect(),
+            seed.iter().map(|b| format!("{b:02x}")).collect(),
+            seed.iter().map(|b| format!("{b:02X}")).collect(),
+            base32(seed),
+            base32(seed).to_lowercase(),
+        ]
+    }
+
+    /// Split `value` every `width` characters with `/`.
+    ///
+    /// A key body already contains `/` sometimes — base64's own alphabet — and
+    /// where those land decides whether every segment is short enough to look
+    /// like a path. Leaving that to chance is how the first version of this
+    /// sweep passed against a guard that leaked: it needed a slash to fall in a
+    /// particular window and usually none did. Chunking deliberately puts the
+    /// adversarial shape in every iteration instead of ~10% of them.
+    fn chunked(value: &str, width: usize) -> String {
+        value
+            .as_bytes()
+            .chunks(width)
+            .map(|c| std::str::from_utf8(c).unwrap())
+            .collect::<Vec<_>>()
+            .join("/")
+    }
+
+    /// Hand-picked fixtures are how the argv guard got this wrong four times:
+    /// base64 contains `/` so "has a slash" proved nothing; the key body is
+    /// shorter than the "too long" bound; base32 is single-case so an
+    /// alphabet-mixing test missed it. Every one of those rules judged a
+    /// *property of the key* and was beaten by an encoding that lacked it.
+    ///
+    /// The rule now judges what a filename has — a `.`, `-` or `_`, which no
+    /// base64, base32 or hex alphabet contains — and this sweep is what says so
+    /// out loud: many real random keys, in six encodings, through every argv
+    /// position, with no eight-character run of the body surviving.
+    #[test]
+    fn no_random_key_survives_any_argv_position_in_any_encoding() {
+        for _ in 0..128 {
+            let mut seed = [0u8; 32];
+            std::fs::File::open("/dev/urandom")
+                .expect("open /dev/urandom")
+                .read_exact(&mut seed)
+                .expect("read seed");
+            let key = ed25519_dalek::SigningKey::from_bytes(&seed);
+            let pem = key
+                .to_pkcs8_pem(ed25519_dalek::pkcs8::spki::der::pem::LineEnding::LF)
+                .expect("encode PKCS#8 PEM");
+            let body: String = pem
+                .lines()
+                .filter(|l| !l.trim_start().starts_with("-----"))
+                .map(str::trim)
+                .collect();
+
+            let mut forms = encodings_of(&seed, &pem);
+            // Every encoding again as a path whose segments are all short
+            // enough to pass for filenames.
+            for width in [8, 20, 30, 39] {
+                for form in encodings_of(&seed, &pem) {
+                    forms.push(chunked(&form, width));
+                }
+            }
+            for encoding in forms {
+                let messages = [
+                    KeySource::Env(encoding.clone()).to_string(),
+                    KeySource::File(PathBuf::from(&encoding)).to_string(),
+                    format!("unknown flag: {}", echoable_flag(&encoding)),
+                ];
+                for message in messages {
+                    for window in encoding.as_bytes().windows(8) {
+                        let needle = std::str::from_utf8(window).unwrap();
+                        assert!(
+                            !message.contains(needle),
+                            "argv leaked key material {needle:?}:\n{message}"
+                        );
+                    }
+                    for window in body.as_bytes().windows(8) {
+                        let needle = std::str::from_utf8(window).unwrap();
+                        assert!(!message.contains(needle), "argv leaked body:\n{message}");
+                    }
+                }
+            }
+        }
+    }
+
+    /// The fact the residual rests on, checked rather than asserted in prose.
+    ///
+    /// `echoable_path`'s narrowing could surface one segment of a key only if a
+    /// key encoding supplied **both** a `/` (to split on) and a `.`, `-` or `_`
+    /// (to pass for a filename). No encoding does: standard base64 has the
+    /// slash and none of the others; URL-safe base64 has `-` and `_` and never
+    /// a slash; base32 and hex have neither. So reaching that residual takes a
+    /// separator placed by hand, which is not the pasted-secret accident this
+    /// tool exists to diagnose. If a future encoding is added to the sweep and
+    /// this stops holding, the residual stops being theoretical — hence a test.
+    #[test]
+    fn no_encoding_supplies_both_a_slash_and_a_name_character() {
+        for _ in 0..64 {
+            let mut seed = [0u8; 48];
+            std::fs::File::open("/dev/urandom")
+                .expect("open /dev/urandom")
+                .read_exact(&mut seed)
+                .expect("read seed");
+
+            let encodings = [
+                BASE64_STANDARD.encode(seed),
+                BASE64_URL_SAFE_NO_PAD.encode(seed),
+                base32(&seed),
+                base32(&seed).to_lowercase(),
+                seed.iter().map(|b| format!("{b:02x}")).collect(),
+            ];
+
+            for encoded in encodings {
+                let has_slash = encoded.contains('/');
+                let has_name_char = encoded.chars().any(|c| matches!(c, '.' | '-' | '_'));
+                assert!(
+                    !(has_slash && has_name_char),
+                    "an encoding supplies both a separator and a filename \
+                     character, so a split of it could pass as a path: {encoded}"
+                );
+            }
+        }
+
+        // A whole PEM does carry both — `/` in its base64 body and `-` in its
+        // boundary lines — and is disqualified one step earlier instead: its
+        // newlines are not in the segment charset at all, so no part of a PEM
+        // is ever a printable segment. Asserting that here keeps the two halves
+        // of the argument in one place.
+        assert!(TEST_PRIVATE_PEM.contains('/') || TEST_PRIVATE_PEM.contains('-'));
+        assert!(TEST_PRIVATE_PEM.chars().any(|c| c.is_control()));
+        assert_eq!(echoable_path(TEST_PRIVATE_PEM), REDACTED);
+        for segment in TEST_PRIVATE_PEM.split('/') {
+            assert!(
+                !is_named_segment(segment),
+                "a slice of a PEM passed as a filename: {segment}"
+            );
+        }
+    }
+
+    /// URL-safe base64 is the one encoding whose alphabet contains the `.`/`-`/`_`
+    /// that the segment rule keys on, so it gets its own test rather than being
+    /// folded into the sweep — the guarantee for it is genuinely weaker, and a
+    /// test that quietly asserted the strong property for it would be lying.
+    ///
+    /// Whole, it is far past [`MAX_NAME_LEN`] and vanishes. Split on `/` into
+    /// filename-sized pieces, the rule bounds what can surface to a single
+    /// segment of at most [`MAX_SEGMENT_ALNUM`] alphanumerics — never the key,
+    /// and never more than one piece of it. This test pins that bound, so
+    /// widening the cap fails here rather than in a log.
+    #[test]
+    fn url_safe_base64_is_bounded_even_when_chunked_to_look_like_a_path() {
+        for _ in 0..64 {
+            let mut seed = [0u8; 32];
+            std::fs::File::open("/dev/urandom")
+                .expect("open /dev/urandom")
+                .read_exact(&mut seed)
+                .expect("read seed");
+            let encoded = BASE64_URL_SAFE_NO_PAD.encode(seed);
+
+            // Whole: nothing of it survives.
+            assert_eq!(echoable_path(&encoded), REDACTED);
+            assert_eq!(echoable_name(&encoded), REDACTED);
+            assert_eq!(echoable_flag(&encoded), REDACTED);
+
+            for width in [8, 20, 30, 39] {
+                let path = chunked(&encoded, width);
+                let shown = echoable_path(&path).into_owned();
+                if shown == REDACTED {
+                    continue; // the best outcome, and the common one
+                }
+                assert!(!shown.contains(&encoded), "the whole key surfaced: {shown}");
+                // Whatever is shown is one bounded segment, not a reassembly.
+                let alnum = shown.chars().filter(|c| c.is_ascii_alphanumeric()).count();
+                assert!(
+                    alnum <= MAX_SEGMENT_ALNUM,
+                    "more than one segment surfaced ({alnum} alphanumerics): {shown}"
+                );
+            }
+        }
+    }
+
+    /// The security half of #339. Errors may name the PEM label and the source,
+    /// and nothing else — no key body, no prefix of it, no length that narrows
+    /// it. `veld-sign` runs in CI with the org private key in its environment
+    /// and its stderr goes straight into a public workflow log.
+    #[test]
+    fn key_body_never_appears_in_an_error() {
+        let body = key_body();
+        assert!(body.len() > 32, "test key body looks wrong: {}", body.len());
+
+        let inputs = [
+            // The real key under a correct header, truncated so the parser
+            // rejects it: the one failure path handed genuine key material,
+            // and the only one that could leak it through an upstream error.
+            format!(
+                "-----BEGIN PRIVATE KEY-----\n{}\n-----END PRIVATE KEY-----\n",
+                &body[..body.len() - 8]
+            ),
+            // The real key under every wrong header, so the label branch is
+            // covered with material that actually matters.
+            format!("-----BEGIN PUBLIC KEY-----\n{body}\n-----END PUBLIC KEY-----\n"),
+            format!(
+                "-----BEGIN OPENSSH PRIVATE KEY-----\n{body}\n-----END OPENSSH PRIVATE KEY-----\n"
+            ),
+            format!("-----BEGIN veld/private+key-----\n{body}\n-----END veld/private+key-----\n"),
+            // Bare key material with no header at all.
+            body.clone(),
+        ];
+        let sources = [
+            env_source(),
+            KeySource::File(PathBuf::from("/etc/veld/signing.pem")),
+        ];
+
+        for source in &sources {
+            for input in &inputs {
+                let rendered = match parse_signing_key(input, source) {
+                    Ok(_) => panic!("expected {input:?} to be rejected"),
+                    Err(e) => e.render(),
+                };
+                for window in body.as_bytes().windows(8) {
+                    let needle = std::str::from_utf8(window).unwrap();
+                    assert!(
+                        !rendered.contains(needle),
+                        "error leaked key material {needle:?}:\n{rendered}"
+                    );
+                }
+                assert!(
+                    !rendered.contains(&body.len().to_string()),
+                    "error leaked the key length:\n{rendered}"
+                );
+                // The window scan above is necessary but not sufficient, and
+                // for a while it was the only check: it looks for runs of the
+                // *base64* body, so it was blind to the one leak that actually
+                // existed. `der` renders a rejected byte as `0x11` and a short
+                // body as `expected 48, actual 30` — neither is a substring of
+                // the base64, and both disclose the key. Nothing derived from
+                // the body may reach stderr in any encoding, so: no hex, and no
+                // digits beyond the two that live in fixed words.
+                assert!(
+                    !rendered.contains("0x"),
+                    "error rendered a raw byte of the key:\n{rendered}"
+                );
+                // The only digits any message may contain belong to these
+                // fixed words. Adding a message with a number in it means
+                // adding it here, which is the point: a number in this output
+                // is far more likely to have come from the key than from
+                // prose.
+                const DIGITS_IN_FIXED_WORDS: [&str; 3] = ["PKCS#8", "PKCS8", "ed25519"];
+                let mut residue = rendered.clone();
+                for word in DIGITS_IN_FIXED_WORDS {
+                    residue = residue.replace(word, "");
+                }
+                assert!(
+                    !residue.chars().any(|c| c.is_ascii_digit()),
+                    "error carries a number derived from the key (a length, an \
+                     offset, a byte):\n{rendered}"
+                );
+            }
+        }
     }
 }

--- a/crates/veld-sign/tests/smoke.rs
+++ b/crates/veld-sign/tests/smoke.rs
@@ -1,0 +1,591 @@
+//! End-to-end smoke test for the release signing path (issue #339).
+//!
+//! `release.yml`'s `Package client binaries` step is the only place `veld-sign`
+//! ever runs in production, and it runs **only on a tagged release**. Nothing on
+//! a PR or a merge to main used to touch this tool, its key handling, or the
+//! macOS ad-hoc-then-ed25519 ordering — so the first execution of a change here
+//! was the release itself. That is how v16.58.1 failed at packaging, and it is
+//! the same blind spot that hid the `veld-sign` cross-compile bug found in
+//! #253's review: CI's `Release Build` job compiles, it never packages.
+//!
+//! So this drives the real binary exactly as that step drives it: through the
+//! process boundary (`--key-env` / `--key-file`, exit status, stderr), not
+//! through the library.
+//!
+//! Every key here is generated per run from `/dev/urandom` and lives only in a
+//! temp dir. The org key is never involved and `SIGNING_PRIVATE_KEY` is never
+//! read — the CI job that runs this has no access to the secret at all.
+
+use std::io::Read;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use ed25519_dalek::SigningKey;
+use ed25519_dalek::pkcs8::EncodePrivateKey;
+use ed25519_dalek::pkcs8::spki::EncodePublicKey;
+use ed25519_dalek::pkcs8::spki::der::pem::LineEnding;
+
+// Verification goes through veld-core deliberately. `verify_data` is the exact
+// primitive the root helper's fail-closed relaunch gate calls — including its
+// own 64-byte length check and `verify_strict` — and `sig_path_for` is the rule
+// it uses to find the `.sig` beside a binary. Using them here, rather than a
+// second hand-rolled ed25519 check and a third copy of the path rule, is what
+// makes a drift between what veld-sign writes and what veld-helper will accept
+// fail a PR instead of a release.
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use veld_core::signing::{sig_path_for, verify_data};
+
+/// The env var the smoke test hands keys through. Deliberately **not**
+/// `SIGNING_PRIVATE_KEY`: nothing on a PR-triggered path may name the secret,
+/// so a copy-paste from here can never reach the real one.
+const KEY_ENV: &str = "VELD_SIGN_SMOKE_KEY";
+
+/// `veld-sign`'s documented exit codes. `release.yml` runs the tool under a
+/// `bash -e` step, so it only distinguishes zero from non-zero — but the split
+/// is what an operator reads to tell "you invoked me wrong" from "the key you
+/// gave me is not usable", and nothing else pins it.
+const EXIT_BAD_INPUT: i32 = 1;
+const EXIT_USAGE: i32 = 2;
+
+/// A fresh throwaway key. Any 32 bytes are a valid ed25519 seed, so this needs
+/// no RNG crate — and `/dev/urandom` keeps it genuinely per-run rather than a
+/// constant committed next to a tool that signs root binaries.
+fn throwaway_key() -> SigningKey {
+    let mut seed = [0u8; 32];
+    std::fs::File::open("/dev/urandom")
+        .expect("open /dev/urandom")
+        .read_exact(&mut seed)
+        .expect("read seed");
+    SigningKey::from_bytes(&seed)
+}
+
+/// A private, empty scratch dir named after the test that owns it (tests run in
+/// parallel in one process, so the pid alone would collide).
+///
+/// Returned as a guard so the directory is removed on unwind too. Every test
+/// here writes a throwaway private key into it, and an assertion that fails
+/// part-way through would otherwise leave that key behind at a fully
+/// predictable path. It is only ever a per-run `/dev/urandom` key that signs a
+/// dummy payload — never the org key — but a signing tool's test suite is the
+/// last place that should be casual about it.
+///
+/// `temp_dir()` is `$TMPDIR` (per-user) on macOS and `/tmp` (shared, sticky) on
+/// Linux, so the mode is set explicitly rather than left to the umask.
+struct Scratch(PathBuf);
+
+impl Scratch {
+    fn join(&self, name: impl AsRef<Path>) -> PathBuf {
+        self.0.join(name)
+    }
+}
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn scratch(name: &str) -> Scratch {
+    let dir = std::env::temp_dir().join(format!("veld-sign-smoke-{}-{name}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create scratch dir");
+    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700))
+        .expect("restrict scratch dir");
+    Scratch(dir)
+}
+
+fn write_pkcs8_pem(key: &SigningKey, path: &Path) {
+    let pem = key.to_pkcs8_pem(LineEnding::LF).expect("encode PKCS#8 PEM");
+    std::fs::write(path, pem.as_bytes()).expect("write key file");
+}
+
+fn veld_sign() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_veld-sign"))
+}
+
+fn stderr_of(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+/// Run `veld-sign` over `binary` with the key supplied through the env var —
+/// the shape `release.yml` actually uses. `None` removes the variable entirely,
+/// which is what a missing secret looks like to the job.
+fn sign_with_env(key_pem: Option<&str>, binary: &Path) -> Output {
+    let mut cmd = veld_sign();
+    cmd.args(["--key-env", KEY_ENV]).arg(binary);
+    match key_pem {
+        Some(pem) => cmd.env(KEY_ENV, pem),
+        None => cmd.env_remove(KEY_ENV),
+    };
+    cmd.output().expect("run veld-sign")
+}
+
+/// Run `veld-sign` over `binary` with the key in a file on disk.
+fn sign_with_file(key_path: &Path, binary: &Path) -> Output {
+    veld_sign()
+        .arg("--key-file")
+        .arg(key_path)
+        .arg(binary)
+        .output()
+        .expect("run veld-sign")
+}
+
+/// The happy path, over both key sources: a detached signature is written, it
+/// is exactly 64 raw bytes, and it verifies against the throwaway public key —
+/// and only against the bytes that were actually signed.
+#[test]
+fn signs_a_dummy_file_with_a_64_byte_verifiable_signature() {
+    let dir = scratch("happy");
+    let key = throwaway_key();
+    let key_path = dir.join("signing.pem");
+    write_pkcs8_pem(&key, &key_path);
+    let key_pem = std::fs::read_to_string(&key_path).unwrap();
+
+    for source in ["--key-file", "--key-env"] {
+        let binary = dir.join(format!("veld-helper{source}"));
+        let payload = format!("macho/elf payload bytes for {source}");
+        std::fs::write(&binary, &payload).unwrap();
+
+        let out = if source == "--key-file" {
+            sign_with_file(&key_path, &binary)
+        } else {
+            sign_with_env(Some(&key_pem), &binary)
+        };
+        assert!(
+            out.status.success(),
+            "{source} signing failed: {}",
+            stderr_of(&out)
+        );
+
+        // `sig_path_for` is veld-core's own rule, so this read failing means
+        // the writer and the reader disagree about where the `.sig` lives.
+        let sig_bytes =
+            std::fs::read(sig_path_for(&binary)).expect("signature written next to the binary");
+        assert_eq!(
+            sig_bytes.len(),
+            64,
+            "{source}: the detached signature must be the raw 64-byte ed25519 \
+             signature — veld-core's verifier rejects any other length outright"
+        );
+
+        let pubkey = key.verifying_key().to_bytes();
+        assert!(
+            verify_data(&pubkey, payload.as_bytes(), &sig_bytes),
+            "{source}: the signature veld-sign wrote is not one veld-core accepts"
+        );
+        assert!(
+            !verify_data(&pubkey, b"tampered", &sig_bytes),
+            "{source}: signature verified against bytes it does not cover"
+        );
+    }
+}
+
+/// The failure that actually broke the v16.58.1 release: the secret held the
+/// sibling `.pub` file. The message must name what it got, what it wanted, and
+/// which source it read — and must not carry the key.
+#[test]
+fn rejects_a_public_key_naming_the_label_and_the_source() {
+    let dir = scratch("pubkey");
+    let key = throwaway_key();
+    let binary = dir.join("veld-helper");
+    std::fs::write(&binary, b"payload").unwrap();
+
+    let public_pem = key
+        .verifying_key()
+        .to_public_key_pem(LineEnding::LF)
+        .expect("encode SPKI PEM");
+
+    let out = sign_with_env(Some(&public_pem), &binary);
+    assert_eq!(
+        out.status.code(),
+        Some(EXIT_BAD_INPUT),
+        "a public key must be rejected as bad input, not as a usage error: {}",
+        stderr_of(&out)
+    );
+    let err = stderr_of(&out);
+    assert!(err.contains("got \"BEGIN PUBLIC KEY\""), "{err}");
+    assert!(err.contains("\"BEGIN PRIVATE KEY\""), "{err}");
+    assert!(err.contains(&format!("--key-env {KEY_ENV}")), "{err}");
+    assert!(err.contains("this looks like the .pub"), "{err}");
+    assert!(
+        !sig_path_for(&binary).exists(),
+        "a rejected key must not leave a signature behind"
+    );
+    assert_no_key_material(&err, &public_pem);
+}
+
+/// An OpenSSH-format private key, from `ssh-keygen` when it is available.
+///
+/// The fallback matters: `cargo test --workspace` runs this file inside `check`
+/// — the ubuntu job every other job `needs:` — so an `ssh-keygen` missing from
+/// some future runner image would red out all of CI for a reason unrelated to
+/// the diff under test. A few lines above its own test step, `check` installs
+/// zsh explicitly so that a runner image cannot decide whether a test runs;
+/// this answers the same concern without a second apt package. The real tool
+/// stays preferred, so the label asserted below is the one OpenSSH actually
+/// writes if that ever changes.
+///
+/// The fixture's body is deliberately not a key — only the label is under test,
+/// and `veld-sign` rejects the file on its label before reading any further.
+fn openssh_format_key(dir: &Scratch) -> PathBuf {
+    const FIXTURE: &str = "-----BEGIN OPENSSH PRIVATE KEY-----\n\
+        bm90IGEga2V5IC0tIHRoZSBsYWJlbCBpcyB3aGF0IHRoaXMgZml4dHVyZSBpcyBmb3I=\n\
+        -----END OPENSSH PRIVATE KEY-----\n";
+
+    let key_path = dir.join("id_ed25519");
+    let generated = Command::new("ssh-keygen")
+        .args(["-t", "ed25519", "-N", "", "-q", "-f"])
+        .arg(&key_path)
+        .output();
+    match generated {
+        Ok(out) if out.status.success() => key_path,
+        _ => {
+            std::fs::write(&key_path, FIXTURE).expect("write OpenSSH fixture");
+            key_path
+        }
+    }
+}
+
+/// The other wrong-file shape a maintainer reaches for: an SSH key, in the
+/// format `ssh-keygen` writes rather than the PKCS#8 this tool wants.
+#[test]
+fn rejects_an_openssh_key_with_a_conversion_hint() {
+    let dir = scratch("openssh");
+    let binary = dir.join("veld-helper");
+    std::fs::write(&binary, b"payload").unwrap();
+
+    let key_path = openssh_format_key(&dir);
+
+    let out = sign_with_file(&key_path, &binary);
+    assert_eq!(
+        out.status.code(),
+        Some(EXIT_BAD_INPUT),
+        "an OpenSSH key must be rejected as bad input: {}",
+        stderr_of(&out)
+    );
+    let err = stderr_of(&out);
+    assert!(err.contains("got \"BEGIN OPENSSH PRIVATE KEY\""), "{err}");
+    assert!(err.contains("ssh-keygen -p -m PKCS8 -f <key>"), "{err}");
+    // The file's own name, not necessarily the whole path: under macOS's
+    // `$TMPDIR` the random directory component is indistinguishable from
+    // encoded bytes, so `veld-sign` narrows the rendering to `…/id_ed25519`.
+    // Naming the file is the part the operator needs.
+    assert!(
+        err.contains("id_ed25519"),
+        "the message must name the file to go and look at:\n{err}"
+    );
+    assert!(!sig_path_for(&binary).exists());
+    assert_no_key_material(&err, &std::fs::read_to_string(&key_path).unwrap());
+}
+
+/// A secret that never reached the job at all — absent, empty, or whitespace.
+/// All three are one operator mistake and get one message.
+#[test]
+fn rejects_an_empty_or_unset_secret() {
+    let dir = scratch("empty");
+    let binary = dir.join("veld-helper");
+    std::fs::write(&binary, b"payload").unwrap();
+
+    for key_pem in [None, Some(""), Some("   \n\n")] {
+        let out = sign_with_env(key_pem, &binary);
+        assert_eq!(
+            out.status.code(),
+            Some(EXIT_BAD_INPUT),
+            "an empty key must be rejected as bad input ({key_pem:?}): {}",
+            stderr_of(&out)
+        );
+        let err = stderr_of(&out);
+        assert!(err.contains("got an empty value"), "{key_pem:?}: {err}");
+        assert!(
+            err.contains(&format!("--key-env {KEY_ENV}")),
+            "{key_pem:?}: {err}"
+        );
+        assert!(err.contains("unset"), "{key_pem:?}: {err}");
+    }
+    assert!(!sig_path_for(&binary).exists());
+}
+
+/// The exit-code split, which is otherwise pinned nowhere: `EXIT_USAGE` means
+/// the command line itself is wrong, before any input is touched;
+/// `EXIT_BAD_INPUT` means the tool ran and could not produce a signature from
+/// what it was given.
+///
+/// It drifted once already. Before #339 an unset `--key-env` variable exited 2,
+/// reading as "you invoked me wrong" for what is really a missing secret — and
+/// an unreadable `--key-file` still exited 2 for the same reason. Both are the
+/// same mistake as an empty value and now exit 1 with the same vocabulary.
+#[test]
+fn separates_a_bad_invocation_from_bad_input() {
+    let dir = scratch("usage");
+    let binary = dir.join("veld-helper");
+    std::fs::write(&binary, b"payload").unwrap();
+    let key_path = dir.join("signing.pem");
+    write_pkcs8_pem(&throwaway_key(), &key_path);
+
+    for args in [
+        vec![],                             // no key source, no binary
+        vec!["--key-env".to_string()],      // flag with no value
+        vec!["--key-file".to_string()],     // flag with no value
+        vec![binary.display().to_string()], // binary but no key source
+        vec!["--nonsense".to_string()],     // unknown flag
+        // Two key sources at once — the shape of a half-edited release step.
+        vec![
+            "--key-env".to_string(),
+            KEY_ENV.to_string(),
+            "--key-file".to_string(),
+            key_path.display().to_string(),
+            binary.display().to_string(),
+        ],
+    ] {
+        let out = veld_sign().args(&args).output().expect("run veld-sign");
+        assert_eq!(
+            out.status.code(),
+            Some(EXIT_USAGE),
+            "{args:?} is a usage error: {}",
+            stderr_of(&out)
+        );
+        assert!(
+            stderr_of(&out).contains("usage: veld-sign"),
+            "{args:?} must print the usage line: {}",
+            stderr_of(&out)
+        );
+    }
+
+    // Bad *input*, not a bad invocation: the flags were right in both cases.
+    for (what, out) in [
+        (
+            "a missing key file",
+            sign_with_file(&dir.join("does-not-exist.pem"), &binary),
+        ),
+        (
+            "a missing binary to sign",
+            sign_with_file(&key_path, &dir.join("no-such-binary")),
+        ),
+    ] {
+        assert_eq!(
+            out.status.code(),
+            Some(EXIT_BAD_INPUT),
+            "{what} is bad input: {}",
+            stderr_of(&out)
+        );
+        assert!(
+            !stderr_of(&out).contains("usage: veld-sign"),
+            "{what} is not a usage error: {}",
+            stderr_of(&out)
+        );
+    }
+}
+
+/// `veld-sign` runs in CI with the org private key in its environment and its
+/// stderr goes straight into a public workflow log, so no body line of the key
+/// it was handed — nor any 8-character run of one — may appear in the output.
+fn assert_no_key_material(stderr: &str, key_pem: &str) {
+    let body: String = key_pem
+        .lines()
+        .filter(|l| !l.trim_start().starts_with("-----"))
+        .map(str::trim)
+        .collect();
+    assert!(
+        body.len() > 32,
+        "fixture key body looks wrong: {}",
+        body.len()
+    );
+    for window in body.as_bytes().windows(8) {
+        let needle = std::str::from_utf8(window).unwrap();
+        assert!(
+            !stderr.contains(needle),
+            "stderr leaked key material {needle:?}:\n{stderr}"
+        );
+    }
+}
+
+/// The leak this diff was reviewed into fixing, pinned at the process boundary.
+///
+/// A correctly-labelled body that is not valid PKCS#8 used to have the upstream
+/// RustCrypto error interpolated straight into stderr, and `der` quotes its
+/// input: a bare 32-byte seed pasted under a `-----BEGIN PRIVATE KEY-----`
+/// header printed `unknown/unsupported ASN.1 DER tag: 0x11`, where `0x11` was
+/// `seed[0]`; a truncated key printed `expected 48, actual 30`. Both went into
+/// a public workflow log with the org key in the environment.
+///
+/// The seed here is the throwaway's own, so if this regresses the test is
+/// leaking a key it generated rather than one that matters — and it fails.
+#[test]
+fn a_corrupt_body_is_diagnosed_without_quoting_any_of_it() {
+    let dir = scratch("corrupt");
+    let binary = dir.join("veld-helper");
+    std::fs::write(&binary, b"payload").unwrap();
+
+    // A bare seed under the right label: valid base64, not valid PKCS#8 DER.
+    let seed = throwaway_key().to_bytes();
+    let body = BASE64.encode(seed);
+    let pem = format!("-----BEGIN PRIVATE KEY-----\n{body}\n-----END PRIVATE KEY-----\n");
+
+    let out = sign_with_env(Some(&pem), &binary);
+    assert_eq!(
+        out.status.code(),
+        Some(EXIT_BAD_INPUT),
+        "a non-PKCS#8 body must be rejected: {}",
+        stderr_of(&out)
+    );
+    let err = stderr_of(&out);
+    assert!(err.contains("truncated or corrupt"), "{err}");
+    assert_no_key_material(&err, &pem);
+    assert!(
+        !err.contains("0x"),
+        "stderr rendered a raw byte of the key:\n{err}"
+    );
+    // No path is interpolated on the --key-env branch, so every digit left in
+    // the message would have come from the key.
+    let residue = err
+        .replace("PKCS#8", "")
+        .replace("PKCS8", "")
+        .replace("ed25519", "");
+    assert!(
+        !residue.chars().any(|c| c.is_ascii_digit()),
+        "stderr carries a number derived from the key (a length, an offset, a \
+         byte):\n{err}"
+    );
+    assert!(!sig_path_for(&binary).exists());
+}
+
+/// The worst failure this tool can have, pinned at the process boundary.
+///
+/// `std::env::var`'s `VarError::NotUnicode` Debug-formats the whole value, so a
+/// single non-UTF-8 byte anywhere in `SIGNING_PRIVATE_KEY` printed the **entire
+/// private key** into the public Actions log — no attacker needed, just a
+/// Latin-1 paste, a BOM, or raw DER uploaded instead of PEM. That is the very
+/// situation this issue exists to diagnose, so the diagnosis path was the one
+/// that leaked.
+///
+/// Nothing else can catch this: the unit tests call `parse_signing_key`
+/// directly and never go through the environment, and `Command::env` is usually
+/// handed a `&str`. This test sets genuinely invalid bytes with `OsStr::from_bytes`
+/// and asserts the key does not come back out.
+#[test]
+fn a_non_utf8_secret_does_not_print_the_key() {
+    let dir = scratch("notutf8");
+    let binary = dir.join("veld-helper");
+    std::fs::write(&binary, b"payload").unwrap();
+
+    let key = throwaway_key();
+    let pem = key.to_pkcs8_pem(LineEnding::LF).expect("encode PKCS#8 PEM");
+    // One stray byte in the middle of the base64 body — the realistic shape,
+    // and the one GitHub's secret masking cannot redact because the mangled
+    // line no longer matches the registered secret.
+    let mut raw = pem.as_bytes().to_vec();
+    let midpoint = raw.len() / 2;
+    raw.insert(midpoint, 0xff);
+
+    let out = veld_sign()
+        .args(["--key-env", KEY_ENV])
+        .arg(&binary)
+        .env(KEY_ENV, std::ffi::OsStr::from_bytes(&raw))
+        .output()
+        .expect("run veld-sign");
+
+    assert_eq!(
+        out.status.code(),
+        Some(EXIT_BAD_INPUT),
+        "a non-UTF-8 secret is bad input: {}",
+        stderr_of(&out)
+    );
+    let err = stderr_of(&out);
+    assert!(err.contains("not valid UTF-8"), "{err}");
+    assert!(err.contains(&format!("--key-env {KEY_ENV}")), "{err}");
+
+    // The key must not appear in any encoding: not as text, and not as the
+    // Debug-escaped rendering `VarError::NotUnicode` used to produce.
+    assert_no_key_material(&err, &pem);
+    let debug_rendered = format!("{:?}", String::from_utf8_lossy(&raw));
+    for line in debug_rendered.split("\\n").filter(|l| !l.contains("-----")) {
+        let line = line.trim_matches('"');
+        if line.len() >= 8 {
+            assert!(
+                !err.contains(line),
+                "stderr leaked the Debug rendering of the key:\n{err}"
+            );
+        }
+    }
+    assert!(!sig_path_for(&binary).exists());
+}
+
+/// The macOS ordering that `release.yml` and `install.sh` depend on, and that
+/// nothing but a real install has ever exercised: ad-hoc `codesign` first, then
+/// ed25519-sign the ad-hoc-signed bytes, then let install.sh re-sign ad-hoc on
+/// the user's machine. The `.sig` must still verify afterwards, which requires
+/// the re-sign to reproduce the signed bytes exactly.
+///
+/// **The trap.** An ad-hoc signature's identifier is derived from the file's
+/// **basename**, and that identifier is hashed into the CodeDirectory. So both
+/// signings must see the file under the same name, or the bytes differ for a
+/// reason that has nothing to do with idempotency — which is why `release.yml`
+/// signs `dist/veld-helper` rather than `target/<target>/release/veld-helper`,
+/// and why this test signs and re-signs one path. Working that out cost an hour
+/// during #253's review; it is written down here so nobody re-derives it.
+///
+/// The fixture is a copy of `veld-sign` itself because `codesign` only accepts
+/// a real Mach-O — a text file is rejected outright, so it has to be a binary
+/// that is already on disk and native to this host.
+#[cfg(target_os = "macos")]
+#[test]
+fn adhoc_resign_after_ed25519_signing_is_byte_idempotent() {
+    let dir = scratch("resign");
+    let key = throwaway_key();
+    let key_path = dir.join("signing.pem");
+    write_pkcs8_pem(&key, &key_path);
+
+    // Named `veld-helper` for the whole sequence: see the basename note above.
+    let binary = dir.join("veld-helper");
+    std::fs::copy(env!("CARGO_BIN_EXE_veld-sign"), &binary).expect("copy a real Mach-O");
+
+    adhoc_sign(&binary);
+    let signed_bytes = std::fs::read(&binary).unwrap();
+
+    let out = sign_with_file(&key_path, &binary);
+    assert!(out.status.success(), "signing failed: {}", stderr_of(&out));
+
+    let sig_bytes = std::fs::read(sig_path_for(&binary)).unwrap();
+    assert_eq!(sig_bytes.len(), 64);
+
+    // install.sh's own `codesign --force --sign -`, as it runs on the machine
+    // of whoever ran `curl | bash` or `veld update`.
+    adhoc_sign(&binary);
+    let resigned_bytes = std::fs::read(&binary).unwrap();
+
+    assert_eq!(
+        signed_bytes.len(),
+        resigned_bytes.len(),
+        "ad-hoc re-sign changed the binary's length, so install.sh invalidates \
+         the .sig that CI shipped"
+    );
+    assert!(
+        signed_bytes == resigned_bytes,
+        "ad-hoc re-sign was not byte-idempotent, so install.sh invalidates the \
+         .sig that CI shipped"
+    );
+    // Through veld-core, because the thing that must still hold is precisely
+    // "the root helper will relaunch onto these bytes".
+    assert!(
+        verify_data(&key.verifying_key().to_bytes(), &resigned_bytes, &sig_bytes),
+        "signature must still verify after install.sh's re-sign"
+    );
+}
+
+#[cfg(target_os = "macos")]
+fn adhoc_sign(path: &Path) {
+    let out = Command::new("/usr/bin/codesign")
+        .args(["--force", "--sign", "-"])
+        .arg(path)
+        .output()
+        .expect("run codesign");
+    assert!(
+        out.status.success(),
+        "codesign --force --sign - {}: {}",
+        path.display(),
+        stderr_of(&out)
+    );
+}


### PR DESCRIPTION
Closes #339. Part of #338, independent of the #337/#262 chain.

## Why

The first release after #253 failed at `release.yml`'s `Package client binaries`:

```
error: invalid ed25519 private key: PKCS#8 ASN.1 error: PEM error:
unexpected PEM type label: expecting "PRIVATE KEY"
```

The `SIGNING_PRIVATE_KEY` secret held a well-formed PEM block of the wrong kind —
the parser read a valid boundary and rejected only the *label*, so most likely the
sibling `notes/veld-signing-ed25519.pub` went up instead of the private key.
Re-uploading the correct PKCS#8 key fixed it: same run ID, same commit.

Two things turned a five-second mistake into a lost release run.

## 1. `veld-sign` diagnosed badly

It surfaced a raw RustCrypto ASN.1 string that named the label it *wanted* and
never the one it *got*, so it read like a corrupt key rather than the wrong file.

Every failure now names the label found, the label expected, and which source was
read — with the flag the operator actually typed, so it is immediately obvious
whether to go look at a repository secret or at a file on disk:

```
error: wrong key format from --key-env SIGNING_PRIVATE_KEY: expected a PKCS#8 private key ("BEGIN PRIVATE KEY"), got "BEGIN PUBLIC KEY"
hint: this looks like the .pub, not the private key

error: wrong key format from --key-file ~/keys/id_ed25519: expected a PKCS#8 private key ("BEGIN PRIVATE KEY"), got "BEGIN OPENSSH PRIVATE KEY"
hint: this is an OpenSSH key; convert it with `ssh-keygen -p -m PKCS8 -f <key>`

error: no key read from --key-env SIGNING_PRIVATE_KEY: expected a PKCS#8 private key ("BEGIN PRIVATE KEY"), got an empty value
hint: the variable is unset, or the secret was uploaded empty
```

Review added four more cases that used to produce an actively *false* message —
each one is the same wrong-file-reported-as-something-else failure this issue
exists to remove, pointed in a different direction:

| Input | Was | Now |
|---|---|---|
| A key indented into a YAML block scalar or heredoc | "the body is not valid DER, so the key is truncated or corrupt" + "the PEM header is right" — both false | "got the right label on an indented line" + "PEM boundaries must start at column 0" |
| A key saved with a UTF-8 BOM | "found no PEM header at all", of a file whose first line is exactly that header | "got a byte-order mark before the first line" |
| A PKCS#8 key for another algorithm (RSA, X25519) | a raw ASN.1 string | "the DER parsed, but names a different algorithm — a PKCS#8 key, but not an ed25519 one" |
| A label differing only in whitespace | `got "BEGIN PRIVATE KEY "` against `expected … "BEGIN PRIVATE KEY"` — visually identical in a log | "got the right label with stray whitespace around it" |

### The part that matters: no key material, ever

This tool runs with the org private key in its environment and its stderr goes
straight into a public workflow log. An error may name the PEM label and the
source, and nothing else — no body, no prefix of one, no length that narrows it.

**Review found five ways that was broken.** Every one of them looked like careful
code, none were caught by the compiler, and two were in a *previous round's fix*.
They are worth reading, because they are the substance of this PR:

| Leak | How |
|---|---|
| 🔴 `std::env::var` | Its `VarError::NotUnicode` Debug-formats the whole value, so one non-UTF-8 byte in the secret printed the **entire private key**. No attacker needed — a Latin-1 paste, a BOM, raw DER. It is the accident this issue exists to diagnose, so the diagnosis path was the leaking one. GitHub's masking is no backstop: Debug escaping is the documented transformation that defeats it. → `read_key` uses `var_os`. |
| 🟠 the parse error | `der` quotes what it rejected: `unknown/unsupported ASN.1 DER tag: 0x11` (that byte *is* `seed[0]`) and `expected 48, actual 30` (a length). → `key_parse_problem` classifies by variant into fixed strings, which also produced the "different algorithm" message above. |
| 🔴 `argv`, three doors | The key pasted where a *path*, a *variable name*, or the *binary* belongs. A PEM starts with `-`, so a positional key parses as an unknown flag. Each is one character from the correct invocation. → `echoable_*`. |
| 🔴 the guard's own bound | The first `argv` guard redacted values *longer than 200 characters*. A PKCS#8 ed25519 body is **64**, its hex form 96 — the guard was bounded above the thing it guarded. |
| 🔴 the guard, again | Then: "contains a `/`" meant "is a path" (base64 contains `/`); "mixed-case or hex" missed base32 (single-case by spec); and short separator-free segments let a key **chunked into eight-character pieces** pass as a directory tree. |

Each of those rules judged a *property of the key* and was beaten by an encoding
that lacked it. The fix was to stop calibrating and judge what a **filename**
has — a `.`, `-` or `_`, which no standard base64, base32 or hex alphabet
contains. That holds by construction rather than by tuning.

**The cost is deliberate**: most paths now render as `…/veld-helper` rather than
in full, because no rule can tell a directory name from encoded bytes. The flag
and the filename — what an operator acts on — survive.

**One residual is documented rather than hidden.** URL-safe base64 *does* contain
`-` and `_`. A key in it is far too long to print, but split on `/` into
filename-sized pieces, one piece could surface. That needs a `/` placed by hand:
no encoding supplies both a slash and a name character — standard base64 has the
slash and neither of the others, URL-safe has them and never a slash — which
`no_encoding_supplies_both_a_slash_and_a_name_character` checks rather than
asserts in prose. `url_safe_base64_is_bounded_even_when_chunked_to_look_like_a_path`
pins how much a hand-built input could ever surface, so widening the cap fails a
test instead of a log.

**The tests were part of the problem, twice.** One used a 256-character string
that sat just over the old bound, so it passed while the real 64-character body
leaked. The randomised sweep that replaced it relied on base64's own `/` landing
in a lucky window — I proved it toothless by mutating the guard and watching it
stay green while the binary leaked. It now chunks every encoding at four widths
deterministically, and is mutation-tested against all five historical bypasses.

**Not done, deliberately:** widening the accepted formats. #339 puts that out of
scope, and one format with a clear error is easier to reason about for a signing
tool than several with a vague one.

## 2. CI never ran this code at all

`Package client binaries` runs **only on a tagged release**. Nothing on a PR or a
merge to main touched `veld-sign`, its key handling, or the macOS
ad-hoc-then-ed25519 ordering — so the first execution of a change to that path
*was* the release. Same blind spot that hid the `veld-sign` cross-compile bug
found in #253's review: `Release Build` compiles, it never packages.

`crates/veld-sign/tests/smoke.rs` drives the real binary through the process
boundary, exactly as `release.yml` drives it. It generates a throwaway ed25519
key per run from `/dev/urandom` (any 32 bytes are a valid seed, so no RNG crate
and no committed fixture key), then:

- signs a dummy file through both `--key-file` and `--key-env`, asserting the
  `.sig` is exactly 64 raw bytes, that it verifies, and that it does **not**
  verify against bytes it doesn't cover;
- asserts the specific message for a public key, an OpenSSH key, an
  absent/empty/whitespace secret, a non-PKCS#8 body, and a non-UTF-8 secret;
- asserts the exit-code split (`1` bad input, `2` bad command line);
- **on macOS**, ad-hoc `codesign`s the dummy, ed25519-signs those bytes, then
  ad-hoc re-signs it the way `install.sh` does on the user's machine, and asserts
  the bytes are identical and the signature still verifies.

**Verification goes through `veld_core::signing::{verify_data, sig_path_for}`**,
not a second hand-rolled ed25519 check. Those are the exact primitives the root
helper's fail-closed relaunch gate uses. veld-sign writes and veld-core reads,
with no compiler tie between them; routing the test through the real verifier is
what makes that drift fail a PR instead of shipping a helper that refuses to
relaunch. (`veld-core` is a dev-dependency only — nothing new links into the
shipped binary.)

The ad-hoc identifier is derived from the file's **basename**, so both signings
must see the same filename or the bytes differ for reasons that have nothing to
do with idempotency. That cost an hour during #253's review, so it is written
down in the test rather than left to be re-derived. Measured while writing it:

```
codesign --force --sign - .../veld-helper  → 5bdec7fe…   Identifier=veld-helper-5555…
codesign --force --sign - .../veld-helper  → 5bdec7fe…   (byte-identical)
codesign --force --sign - .../other-name   → 91eabeb0…   Identifier=other-name-5555…
```

### The CI job, and its guard

`ci.yml` gains one job, `Helper Signing Smoke (macOS)`, with the standard draft
guard. Linux coverage is already free — `check` runs `cargo test --workspace` on
ubuntu, which includes this crate's smoke test — so the new job buys only the
macOS half, where `codesign` lives and nothing else in CI can reach it.

It generates its own key and never references `SIGNING_PRIVATE_KEY`. Review
pointed out that this was enforced by comment alone, so the `schema` job gained a
drift gate that walks the parsed `ci.yml` and fails on any reference to that
secret — plus the job's own existence, that it still runs on macOS, and that the
resign test is neither deleted, renamed, nor `#[ignore]`d. All four branches are
mutation-tested. (Writing it turned up a self-reference bug: the gate's own
`run:` block contains the secret's name, so it failed on a clean tree. The name
is assembled at runtime now.)

Why a Rust integration test rather than a bash script: the verification steps need
Ed25519, and `/usr/bin/openssl` on macOS runners is LibreSSL, which cannot do
Ed25519 at all (confirmed: `Algorithm ED25519 not found`). Using the same crate
the tool uses avoids a Homebrew OpenSSL dependency and keeps the Linux leg free
inside a job that already runs.

### What this still does *not* cover

Stated in the job comment too, so nobody reads the name as more than it is. Both
still first run at a release:

- the `macos-amd64` leg ad-hoc signs a **cross-compiled** x86_64 Mach-O on an
  arm64 runner; the idempotency test uses a host-native one;
- nothing asserts `veld-helper.sig` actually lands in the tarball.

## `release.yml` is unchanged

This issue protects that path; it does not alter it.

## Test evidence

- 23 unit + 8 integration tests, all green, including the macOS `codesign`
  idempotency case against a real Mach-O.
- `cargo test --workspace`: 1633 passed, 0 failed (rebased onto #337 + v16.58.2).
- `cargo clippy -p veld-sign --all-targets -- -D warnings`, `cargo fmt --all --check`,
  and `RUSTFLAGS="-D warnings" cargo test -p veld-sign --no-run` all clean (CI sets
  `RUSTFLAGS: -D warnings` globally, so test targets are held to it too).
- `validate-workflow-gates.py --selftest` + real run: green, so the new job carries
  its draft guard.
- Every error path driven by hand against the built binary; the messages above are
  its real output.
- Mutation-tested: every key leak above, all gate branches, and the temp-dir
  cleanup. Re-introducing any historical bypass fails the suite.
- Every encoding × chunking combination (base64/hex/base32/URL-safe × 4 widths)
  driven through all three argv positions against the built binary.

## Review

Standard multi-angle loop, stakes-elevated (§3.3 — crypto + secret handling).
Thirteen subagent spawns across five rounds; the opus budget is spent.

Outcome: 4 critical, 9 major, and a tail of medium/minor — all fixed. Several
were found by me rather than by an agent, while verifying or mutation-testing a
previous fix, and two agents independently found the same `NotUnicode` leak and
the same temp-dir issue, which the loop counts as real signal rather than one
agent's guess. Nothing was fixed without a live reproduction first.

**Where the yield went.** Rounds 1-3 covered #339's actual scope and settled.
Rounds 3-5 were almost entirely one surface — the `argv` guard — which is
*defence beyond what #339 asks for*: `release.yml` passes
`--key-env SIGNING_PRIVATE_KEY dist/veld-helper` and never puts the key on a
command line. It is worth having, and it is also why this PR grew. Round 5 could
not break the current rule by accident, only by hand-constructing input, which is
the documented residual above.

I would flag one judgement for you: the alternative to `echoable_*` is to print
**nothing** from `argv` — trivially safe, and it costs the filename in every
error. I kept the bounded version because the filename is most of the diagnosis
this issue is about. Say the word and it collapses to four lines.

## Docs

Purely internal. `veld-sign` is a CI-only release tool with no user-visible
surface — no config field, CLI flag, or subcommand changes, and `rg veld-sign`
over `README.md`, `docs/`, `skills/`, `website/` and `AGENTS.md` returns nothing.
No promotion: this is a fix plus test coverage, which `docs/promotions.md`
explicitly excludes.
