### PR TITLE
feat(helper): rotate the org signing key with one row and one secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,13 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          # Two commits, so that on a pull request the merge commit's own parents
+          # are present: `HEAD^1` is the base GitHub merged against and `HEAD^2` is
+          # the pull request head. `One release never both adds a key and retires
+          # one` below is the only step that needs it — everything else in this job
+          # is static and reads the tree.
+          fetch-depth: 2
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
@@ -160,6 +167,11 @@ jobs:
           # check trivially, which reads as a clean bill of health.
           python3 tests/validate-workflow-gates.py --selftest
           python3 tests/validate-workflow-gates.py
+          # Same rule for the org key table's parser: its fixtures are mis-parses
+          # it must refuse, and a parser that quietly returns a shorter list than
+          # the table has is a release missing a slot. Run before the slot-layout
+          # gate below trusts its output for anything.
+          python3 tests/signing-slots.py --selftest
       # Static, checkout-only and PyYAML-only, so it rides along with the gate
       # above — which is also where PyYAML is installed, so this step must stay
       # after it. What it guards is the release path itself: release.yml publishes
@@ -430,7 +442,7 @@ jobs:
       - name: Signature slot layout matches release.yml
         run: |
           python3 - <<'PY'
-          import pathlib, re, sys, yaml
+          import json, pathlib, re, subprocess, sys, yaml
 
           signing = pathlib.Path("crates/veld-core/src/signing.rs").read_text()
 
@@ -441,7 +453,13 @@ jobs:
                            "ci.yml read it (issue #261 slice C)")
               return int(m.group(1))
 
-          slots = rust_const("RELEASE_SIG_SLOTS", signing, "crates/veld-core/src/signing.rs")
+          # The signature format's slot ceiling, and therefore the size of the
+          # permanent secret roster in release.yml. `RELEASE_SIG_SLOTS` is no longer
+          # read here: it is `ORG_KEYS.len()` now, so a number in this file would be
+          # a third copy of something the table already says.
+          slots_ceiling = rust_const(
+              "MAX_SIG_SLOTS", signing, "crates/veld-core/src/signing.rs"
+          )
 
           release = yaml.safe_load(open(".github/workflows/release.yml"))
           pkg = [
@@ -461,51 +479,38 @@ jobs:
               line for line in run.splitlines() if not line.strip().startswith("#")
           )
 
-          # 1. One key flag per slot. A key added to the keyring or the
-          #    required-slot list in `crates/veld-core/src/signing.rs` — the two
-          #    constants RELEASE_SIG_SLOTS summarises — without a matching secret
-          #    produces a release
-          #    that omits a slot some helper generation accepts *only* that key
-          #    for — and that generation then refuses every future release.
-          flags = command.count("--key-env") + command.count("--key-file")
-          if flags != slots:
-              sys.exit(
-                  f"release.yml signs the helper with {flags} key(s) but "
-                  f"veld_core::signing::RELEASE_SIG_SLOTS says {slots}. Add or remove a "
-                  "`--key-env <SECRET>` line in `Package client binaries` to match, and "
-                  "read docs/signing-key-rotation.md before changing either."
-              )
+          # 1. Every key the source names has a secret this step can read.
+          #
+          #    `release.yml` no longer carries a key list at all: it derives the
+          #    whole slot layout from `ORG_KEYS` with `tests/signing-slots.py`, so
+          #    rotating needs no edit to that file. What still needs one — once,
+          #    ever — is the `env:` roster, because GitHub only exposes a secret to
+          #    a step that names it, and a workflow cannot enumerate secrets (the
+          #    leak gate above forbids the two ways of trying).
+          #
+          #    So the failure this replaces is unchanged in kind and better aimed:
+          #    it used to be "a `--key-env` with no `env:` entry", which was the
+          #    workflow checked against itself. It is now the SOURCE checked against
+          #    the workflow. veld-sign reads a key by variable NAME, so a name with
+          #    no `env:` entry is indistinguishable from an unset secret — and the
+          #    release dies at a push-only step, i.e. after merge.
+          rows = json.loads(
+              subprocess.run(
+                  [sys.executable, "tests/signing-slots.py", "--json"],
+                  capture_output=True, text=True, check=False,
+              ).stdout
+              or "[]"
+          )
+          if not rows:
+              # The script exits non-zero with its own message for every table it
+              # will not guess about; re-run it so that message is what CI prints,
+              # rather than this gate reporting an empty list as "no keys".
+              subprocess.run([sys.executable, "tests/signing-slots.py"], check=True)
+              sys.exit("tests/signing-slots.py produced no rows and did not say why")
 
-          # 2. Every `--key-env NAME` has a matching `env:` entry, and every NAME
-          #    carries the shared signing-secret prefix.
-          #
-          #    The first half: veld-sign reads a key by variable NAME, so a flag
-          #    with no `env:` entry is indistinguishable from an unset secret — the
-          #    release dies at this step, push-only, AFTER merge. Counting flags
-          #    alone let a PR go green on exactly that.
-          #
-          #    The second half turns a convention into an invariant. The leak gate
-          #    above matches signing secrets by prefix so that a rotation's second
-          #    key is covered without an edit; that only works if the name actually
-          #    carries the prefix, which until now was prose in a runbook. A key
-          #    added as `ORG_KEY_2_PEM` would reach a PR-startable job with neither
-          #    needle firing. Assembled at runtime, same reason as everywhere else
-          #    in this job.
           env_keys = set((pkg[0].get("env") or {}).keys())
-          prefix = "SIGN" + "ING_"
-          names = re.findall(r"--key-env\s+(\S+)", command)
-          # `--key-env=NAME` keeps the count right and yields no name, which would
-          # skip both checks below in silence — precisely the failure they exist to
-          # catch. veld-sign rejects that form as an unknown flag, so the release
-          # would die after merge.
-          if len(names) != command.count("--key-env"):
-              sys.exit(
-                  "release.yml: a `--key-env` in `Package client binaries` is not written as "
-                  "`--key-env <NAME>` (the `--key-env=NAME` form is rejected by veld-sign and "
-                  "is invisible to the checks below). Use a space."
-              )
-          for name in names:
-              if name not in env_keys:
+          for row in rows:
+              if row["secret"] not in env_keys:
                   # The remedy is described in prose on purpose, and the reason is
                   # worth stating without demonstrating it: GitHub's expression
                   # syntax, written out in a `run:` block, is EVALUATED before the
@@ -517,121 +522,132 @@ jobs:
                   # two blocked CI runs to get right, the second because it
                   # quoted the syntax while explaining not to.
                   sys.exit(
-                      f"release.yml: `Package client binaries` passes `--key-env {name}` but "
-                      f"its `env:` block has no {name} entry, so veld-sign sees an unset "
-                      f"variable and the release fails at the signing step. Add a {name} "
-                      f"entry to that step's env:, taking its value from the {name} secret "
-                      "the same way the existing line does."
+                      f"crates/veld-core/src/signing.rs: ORG_KEYS row {row['index']} names the "
+                      f"secret {row['secret']}, but `Package client binaries` has no {row['secret']} "
+                      "entry in its `env:` block — so veld-sign would see an unset variable and the "
+                      "release would fail at the signing step, which is push-only and therefore "
+                      f"after merge. Add a {row['secret']} entry to that step's env:, taking its "
+                      "value from the secret of the same name the way the existing lines do."
                   )
-              if not name.startswith(prefix):
+
+          # 2. The roster covers every slot the format allows, so a rotation never
+          #    has to touch `release.yml` at all.
+          #
+          #    Gate 1 above would catch a key with no `env:` entry — but it would
+          #    catch it as an edit the operator still has to make, which is the
+          #    thing this whole design removed. The roster is written once, to the
+          #    ceiling, and pinned here so it cannot be trimmed back to "just what
+          #    we use today" by someone tidying.
+          #
+          #    A name whose secret is unset costs nothing: it is an environment
+          #    variable that is not there, and veld-sign never asks for it unless
+          #    ORG_KEYS names it.
+          roster = ["SIGN" + "ING_PRIVATE_KEY"] + [
+              "SIGN" + f"ING_PRIVATE_KEY_{n}" for n in range(2, slots_ceiling + 1)
+          ]
+          # And each roster entry must take its value from the secret of the SAME
+          # name. Binding the second roster entry to the FIRST key's secret is a
+          # plausible copy-paste when the roster is written (the two names differ by
+          # one character, and this comment cannot spell either of them out: the
+          # leak gate above matches the shared prefix across every string in a
+          # PR-startable job, and found this line the first time it was written).
+          # It passes the presence check
+          # above, and the expected-key half of `--slots` then catches it — but at
+          # the push-only signing step, after merge, which is precisely the failure
+          # this job exists to move to pull-request time. The reference is matched
+          # by shape rather than quoted, because GitHub evaluates its expression
+          # syntax inside a `run:` block before the shell sees it — including in a
+          # comment or a string literal — and an invalid one fails the whole
+          # workflow at startup with zero jobs and no usable error.
+          #
+          #    Matched whole, not as a substring. Every roster name is a **prefix**
+          #    of the ones after it by construction, so a substring test accepts
+          #    slot 0 bound to a later slot's secret — and that is the fatal
+          #    direction: slot 0 signed by any other key is a release NO shipped
+          #    helper can relaunch onto. Built from the roster variable so this
+          #    block contains no signing-secret name for the leak gate to hit.
+          env_block = pkg[0].get("env") or {}
+          for name in roster:
+              value = str(env_block.get(name, ""))
+              wanted = re.compile(r"\$\{\{\s*secrets\." + re.escape(name) + r"\s*\}\}")
+              if name in env_block and not wanted.fullmatch(value.strip()):
                   sys.exit(
-                      f"release.yml: the signing secret {name!r} does not carry the shared "
-                      "signing-secret name prefix. The leak gate in this job matches that "
-                      "prefix so a rotation's second key is covered without an edit — a name "
-                      "without it is a secret that can reach a pull-request job unnoticed. "
-                      "Rename it, and see docs/signing-key-rotation.md step 1."
+                      f"release.yml: `Package client binaries` sets {name} from something "
+                      f"other than the {name} secret. Every roster entry must read the "
+                      "secret of its own name — a slot signed by another slot's key ships "
+                      "a release no installed helper can relaunch onto, and the check that "
+                      "catches it runs at the push-only signing step, after merge."
                   )
-
-          # 3. EVERY slot's expected public key, element-wise against the source.
-          #
-          #    Not just slot 0. A wrong key in slot 1 ships INVISIBLY — the release
-          #    still installs everywhere via slot 0 — and then wedges every
-          #    privileged install one release later, when that key becomes the only
-          #    one a helper accepts: refusing to relaunch, refusing `restart` and
-          #    `shutdown`, refusing every future candidate. Fleet-wide, sudo-only,
-          #    which is the one outcome #338 forbids. Before this check the only
-          #    thing in the way was the operator pasting the right hex.
-          #
-          #    Element-wise also makes the ORDER of `ORG_REQUIRED_SLOT_KEYS` a
-          #    checked property rather than a convention, which matters because slot
-          #    position is the format's only key identifier.
-          #
-          #    This parses Rust with a regex, so the question that matters is whether
-          #    a mis-parse can fail SILENTLY. Every shape tried fails loudly instead:
-          #    a comment inside the array, a nested path (`keys::ORG_KEY_1`), an
-          #    array-repeat (`&[K; 1]`), or bytes written inline all produce a name
-          #    that has no `pub const <name>: PubKey` and exit with "named by
-          #    ORG_REQUIRED_SLOT_KEYS but is not defined"; a trailing comma is
-          #    filtered; and the two lists come from different files, so a mis-parse
-          #    that dropped a key would make them differ rather than agree. Checked
-          #    against a rustfmt'd three-key list, which is the realistic future
-          #    shape.
-          m = re.search(r"--expect-slot-pubkeys\s+([0-9a-fA-F,]+)", command)
-          if not m:
+          missing = [n for n in roster if n not in env_keys]
+          if missing:
               sys.exit(
-                  "release.yml: `Package client binaries` no longer passes "
-                  "`--expect-slot-pubkeys <hex>[,<hex>...]` to veld-sign. Without it a signing "
-                  "secret holding a different valid key ships a release that no helper in the "
-                  "field can relaunch onto (issue #261 slice C)."
-              )
-          # Split exactly as veld-sign does (`v.split(',').map(trim)`), and do NOT
-          # filter empties. Filtering them made a stray comma a GREEN pull request
-          # and a dead release: the gate saw the right list while veld-sign saw an
-          # extra empty entry and exited at the push-only signing step, after merge.
-          # That is the same class as the `--key-env=NAME` check above.
-          declared = [h.strip().lower() for h in m.group(1).split(",")]
-          if any(not h for h in declared):
-              sys.exit(
-                  "release.yml: `--expect-slot-pubkeys` has an empty entry — a leading, "
-                  "trailing or doubled comma. veld-sign does not ignore it and would fail "
-                  "the release at the signing step, which is push-only and therefore after "
-                  "merge."
-              )
-          # And the count veld-sign actually enforces, which is one expected key per
-          # key flag. A duplicated entry in ORG_REQUIRED_SLOT_KEYS would otherwise
-          # match element-wise against a duplicated expect list and still die at
-          # release.
-          if len(declared) != flags:
-              sys.exit(
-                  f"release.yml: `--expect-slot-pubkeys` names {len(declared)} key(s) but "
-                  f"{flags} key flag(s) are passed. veld-sign requires one expected key per "
-                  "key, in slot order."
+                  f"release.yml: `Package client binaries` env: is missing {len(missing)} of the "
+                  f"{len(roster)} permanent signing-secret names (first: {missing[0]}). That block "
+                  "is written once to the signature format's slot ceiling and never edited again — "
+                  "it is what makes rotating a key a source edit plus a new secret, with no "
+                  "workflow change. See docs/signing-key-rotation.md."
               )
 
-          def key_hex(name):
-              # `re.escape`, because `name` comes out of the parsed array and is
-              # interpolated into a pattern. Without it, a key written inline as bytes
-              # or a comment carrying an unbalanced paren dies with a Python
-              # traceback instead of the message below — still loud, but not the
-              # message this gate's comment promises.
-              k = re.search(rf"pub const {re.escape(name)}: PubKey = \[(.*?)\];", signing, re.S)
-              if not k:
-                  sys.exit(f"crates/veld-core/src/signing.rs: `{name}` is named by "
-                           "ORG_REQUIRED_SLOT_KEYS but is not defined")
-              hexes = re.findall(r"0x([0-9a-fA-F]{2})", k.group(1))
-              if len(hexes) != 32:
-                  sys.exit(f"{name} parsed as {len(hexes)} bytes, expected 32")
-              return "".join(h.lower() for h in hexes)
+          # 3. The step really does derive the layout, and still checks it.
+          #
+          #    This is the gate with the most to lose, because what it protects is
+          #    now invisible in `release.yml`: there is no key list there to read.
+          #    Deleting the derivation and hard-coding something would look tidier
+          #    and would silently reintroduce every failure the element-wise check
+          #    used to catch — above all a signing secret holding a *different but
+          #    valid* key, which parses, signs, and publishes a release no helper in
+          #    the field can relaunch onto.
+          #
+          #    `--slots` is what carries the expected public key for EVERY slot, not
+          #    just slot 0: a wrong key in a later slot ships invisibly (the release
+          #    still installs everywhere via slot 0) and then wedges every privileged
+          #    install one release later, when that key becomes the only one a helper
+          #    accepts. Fleet-wide, sudo-only, which is the one outcome #338 forbids.
+          for needle, why in [
+              ("tests/signing-slots.py",
+               "the slot layout would stop coming from crates/veld-core/src/signing.rs, "
+               "which is the reviewed source the helper's own keyring is compiled from"),
+              ("--slots",
+               "veld-sign would be given no expected public key per slot, and a secret "
+               "holding a different valid key would ship a release no installed helper "
+               "can relaunch onto"),
+          ]:
+              if needle not in command:
+                  sys.exit(
+                      f"release.yml: `Package client binaries` no longer passes `{needle}` — {why} "
+                      "(issue #261 slice C). Read docs/signing-key-rotation.md before changing how "
+                      "that step signs."
+                  )
+          #    And the flags `--slots` replaced must NOT come back. Adding a
+          #    `--key-env` line is the old runbook's reflex and the first thing an
+          #    operator reaches for; veld-sign refuses the mix and writes no
+          #    signature, but it refuses at the push-only signing step, after merge.
+          for banned, why in [
+              ("--key-env",
+               "the slot layout comes from ORG_KEYS now; a key flag here is the old "
+               "procedure's reflex and veld-sign refuses it, but only at release time"),
+              ("--expect-slot-pubkeys",
+               "--slots already carries the expected key for every slot, and veld-sign "
+               "refuses both together"),
+          ]:
+              if banned in command:
+                  sys.exit(
+                      f"release.yml: `Package client binaries` passes `{banned}` alongside "
+                      f"`--slots`, which veld-sign refuses — {why}. Rotating a key needs NO edit "
+                      "to this file: append a row to ORG_KEYS in "
+                      "crates/veld-core/src/signing.rs and set the matching secret. See "
+                      "docs/signing-key-rotation.md."
+                  )
+          # **What is deliberately NOT checked here**, so nobody adds it back thinking
+          # it does something: comparing the script's `--slots` output against its own
+          # `--json` output. Both come from the same parse, so a parse that drops a row
+          # drops it identically on both sides — it reads like a cross-check and pins
+          # nothing. The parse is a *second implementation* of a value rustc already
+          # has, and the only thing that can catch it diverging is a comparison against
+          # the compiler: `the_slot_script_reads_the_same_table_the_compiler_does` in
+          # `crates/veld-core/src/signing.rs`, which runs in `cargo test --workspace`.
+          # Gate 6 below pins that test's existence.
 
-          req = re.search(
-              r"pub const ORG_REQUIRED_SLOT_KEYS: &\[PubKey\] = &\[(.*?)\];", signing, re.S
-          )
-          if not req:
-              sys.exit("crates/veld-core/src/signing.rs: `ORG_REQUIRED_SLOT_KEYS` is gone; it "
-                       "is the list of keys every release must be signed by")
-          expected = [key_hex(n.strip()) for n in req.group(1).split(",") if n.strip()]
-          if len(set(expected)) != len(expected):
-              sys.exit(
-                  "crates/veld-core/src/signing.rs: ORG_REQUIRED_SLOT_KEYS lists a key twice. "
-                  "RELEASE_SIG_SLOTS counts the distinct union, so the Rust tests stay green "
-                  "while veld-sign is handed a different number of keys than expected entries."
-              )
-          if declared != expected:
-              sys.exit(
-                  "release.yml's --expect-slot-pubkeys does not match "
-                  "veld_core::signing::ORG_REQUIRED_SLOT_KEYS, element for element and in "
-                  f"order ({len(declared)} declared vs {len(expected)} required). One side was "
-                  "edited without the other. Slot position is this format's only key "
-                  "identifier, and slot 0 is a compatibility contract with every "
-                  "already-shipped helper — neither side may change alone. See "
-                  "docs/signing-key-rotation.md."
-              )
-          if expected[0] != key_hex("ORG_KEY_1"):
-              sys.exit(
-                  "crates/veld-core/src/signing.rs: ORG_KEY_1 is no longer first in "
-                  "ORG_REQUIRED_SLOT_KEYS. Every helper shipped up to v16.59.0 verifies "
-                  "bytes 0..64 against it and nothing else."
-              )
 
           # 4. veld-sign's own slot ceiling. It deliberately does not depend on
           #    veld-core outside its tests (it must build fast for the host while
@@ -639,12 +655,25 @@ jobs:
           #    this is what stops the copy rotting. A ceiling above the reader's
           #    would write slots no helper ever looks at.
           sign_main = pathlib.Path("crates/veld-sign/src/main.rs").read_text()
-          if rust_const("MAX_SLOTS", sign_main, "crates/veld-sign/src/main.rs") != rust_const(
-              "MAX_SIG_SLOTS", signing, "crates/veld-core/src/signing.rs"
-          ):
+          if rust_const("MAX_SLOTS", sign_main, "crates/veld-sign/src/main.rs") != slots_ceiling:
               sys.exit(
                   "veld-sign's MAX_SLOTS and veld_core::signing::MAX_SIG_SLOTS disagree. "
                   "The signer would write slots the reader never reads."
+              )
+          #    `tests/signing-slots.py` carries a third copy, and it was the one with
+          #    no gate: raise MAX_SIG_SLOTS and everything stays green until somebody
+          #    appends the 9th row, which then fails with "no reader looks past slot
+          #    7" and tells them to raise a constant they already raised.
+          script_ceiling = re.search(
+              r"^MAX_SLOTS = (\d+)$", pathlib.Path("tests/signing-slots.py").read_text(), re.M
+          )
+          if not script_ceiling:
+              sys.exit("tests/signing-slots.py: `MAX_SLOTS` is gone; this gate reads it")
+          if int(script_ceiling.group(1)) != slots_ceiling:
+              sys.exit(
+                  f"tests/signing-slots.py's MAX_SLOTS ({script_ceiling.group(1)}) and "
+                  f"veld_core::signing::MAX_SIG_SLOTS ({slots_ceiling}) disagree. The script "
+                  "would refuse a table the readers accept, or accept one they do not."
               )
 
           # 5. The rotation format runs in production exactly once, on the worst
@@ -678,6 +707,16 @@ jobs:
               ("adhoc_resign_is_byte_idempotent_for_a_multi_slot_signature",
                "install.sh's macOS re-sign is unverified for the multi-slot shape "
                "otherwise, and this is the only macOS home for it"),
+              ("slots_is_the_same_signature_as_key_env_plus_expected_pubkeys",
+               "--slots is the flag the release actually uses, and every other guard in "
+               "that file is written against the spelling it stands for; without this "
+               "equivalence none of them cover the path that ships"),
+              ("a_slots_entry_whose_secret_holds_another_key_is_refused",
+               "the wrong-secret guard reached through the release path, which is the "
+               "only path a release takes"),
+              ("slots_and_expect_slot_pubkeys_together_is_refused",
+               "a step passing both is a half-finished edit, and letting one silently win "
+               "is how a slot ends up checked against the wrong key"),
           ]:
               if f"fn {name}" not in smoke:
                   sys.exit(f"crates/veld-sign/tests/smoke.rs: `{name}` is gone — {why} "
@@ -685,20 +724,64 @@ jobs:
 
           # 6. The invariants a rotation must NOT delete.
           #
-          #    `signing.rs` deliberately carries two TRIPWIRES that go red for a
-          #    correct rotation and whose docs tell the operator to delete them —
-          #    `nothing_is_retired_yet` and
-          #    `no_rotation_has_happened_yet_so_the_artifact_is_unchanged`. Beside
-          #    them sit permanent invariants that look identical when the whole
-          #    file is red. Deleting a red test is the natural reaction on the day
-          #    the runbook itself says you are reading it under pressure, and this
-          #    is the list that survives it. Each was in a bundled test until a
-          #    simulated rotation against this repo showed what deleting it cost.
+          #    `signing.rs` used to carry two TRIPWIRES that went red for a *correct*
+          #    rotation and whose own docs told the operator to delete them. That
+          #    made step 2 of a rotation "delete a red test", rehearsed on the worst
+          #    day available, beside permanent invariants that look identical when
+          #    the whole file is red. Both are gone: one was restated as a relation
+          #    that holds before and after every rotation
+          #    (`the_artifact_carries_exactly_one_slot_per_key`), and the other was
+          #    replaced by tests that go red when a retirement is *unsafe* rather
+          #    than whenever one happens
+          #    (`one_release_never_both_adds_a_key_and_retires_one` and the two
+          #    invariants that keep its dates honest).
+          #
+          #    **Nothing in this list is ever deleted by a rotation.** That is the
+          #    whole content of the list now, and it is a stronger statement than the
+          #    one it replaces: if a test in `signing.rs` is red, the answer is never
+          #    to delete it.
           invariants = pathlib.Path("crates/veld-core/src/signing.rs").read_text()
           for name, why in [
               ("a_one_key_signature_is_exactly_64_bytes",
-               "the permanent half of the byte-identical claim; its tripwire twin is "
-               "the half a rotation deletes"),
+               "the format claim a pre-rotation reader depends on: one key is still "
+               "exactly the 64 bytes that shipped before slots existed"),
+              ("the_artifact_carries_exactly_one_slot_per_key",
+               "the writer must emit one slot per ORG_KEYS row with no padding and no "
+               "holes; slot position is this format's only key identifier"),
+              ("one_release_never_both_adds_a_key_and_retires_one",
+               "this is the two-release rule itself — the only thing that fails a pull "
+               "request which both adds a key and retires one, which was unguarded "
+               "before it and is the mistake this whole runbook repeats most"),
+              ("the_slot_script_reads_the_same_table_the_compiler_does",
+               "tests/signing-slots.py is a second implementation of ORG_KEYS, read by "
+               "both workflows; this is the only comparison against what rustc actually "
+               "compiles, and a row the script misses is a slot the release omits"),
+              ("added_after_increases_down_the_table",
+               "without it the two-release guard is defeated by pasting row 0's 0.0.0 or "
+               "the previous row's version into a new row"),
+              ("every_secret_name_is_one_of_the_permanent_roster",
+               "a name outside the roster turns rotating back into a release.yml edit, "
+               "which is the whole thing this design removed"),
+              ("every_key_lifecycle_date_names_a_release_that_has_happened",
+               "the rule above is only as good as its two dates: a value newer than this "
+               "tree is somebody guessing at the version their merge will ship as, which "
+               "is the combined edit wearing a disguise"),
+              # The keyring constant is referred to by description rather than by
+              # name here, and that is not squeamishness: its name contains the
+              # signing-secret prefix as a substring, so the leak gate above — which
+              # matches that prefix across every string in a PR-startable job —
+              # fails this whole workflow if it is spelled out. Found by the gate
+              # itself while this list was being written.
+              ("the_derived_views_match_the_table",
+               "the keyring, the required-slot list and the slot count are const-fn "
+               "views of ORG_KEYS; one that quietly dropped a row would compile and "
+               "ship a release signed by a key no reader expects"),
+              ("no_key_and_no_secret_appears_twice",
+               "two rows sharing a secret means one slot is signed by the other row's "
+               "key — the invisible mis-pairing the secret field exists to prevent"),
+              ("every_secret_name_carries_the_signing_prefix",
+               "the leak gate in this job matches that prefix to prove no "
+               "pull-request-startable job can reach a signing secret"),
               ("the_keyring_is_never_empty",
                "without it, a retirement performed without its matching addition ships a "
                "helper that trusts nothing and leaves sudo as the only repair"),
@@ -730,11 +813,14 @@ jobs:
                "simplified away"),
           ]:
               if f"fn {name}" not in invariants:
-                  sys.exit(f"crates/veld-core/src/signing.rs: `{name}` is gone — {why}. If you "
-                           "are performing a rotation, docs/signing-key-rotation.md names the "
-                           "ONE test each step deletes; this is not one of them.")
+                  sys.exit(f"crates/veld-core/src/signing.rs: `{name}` is gone — {why}. A "
+                           "rotation deletes no test at all any more: if one here is red, the "
+                           "answer is never to delete it. See docs/signing-key-rotation.md.")
 
-          print(f"signature slots: {slots}; slot 0 pinned to ORG_KEY_1; rotation smoke tests intact")
+          print(
+              f"signature slots: {len(rows)} of at most {slots_ceiling}; slot 0 pinned to "
+              "ORG_KEY_1; roster and rotation smoke tests intact"
+          )
           print("signing.rs rotation invariants intact")
           PY
 
@@ -745,6 +831,126 @@ jobs:
       # no linter reads it. `--severity=warning` is where the file sits clean
       # today; the remaining `info` diagnostics are deliberate (`sudo` with a
       # `/dev/tty` redirect is the point of that line).
+      # ── The two-release rule, at the level it actually lives on ────────
+      #
+      # `one_release_never_both_adds_a_key_and_retires_one` in
+      # `crates/veld-core/src/signing.rs` catches the combined edit whenever both
+      # halves were written against the same release, which is the common shape
+      # and costs nothing — it runs in `cargo test --workspace`, locally and on a
+      # direct push to main, with no git and no network.
+      #
+      # **It has one hole, and this step is that hole's patch.** A branch whose
+      # `Cargo.toml` moves between the two edits — an unrelated release lands, the
+      # operator updates the branch, then retires — records two dates that are both
+      # *honest* and *different*. Neither equals the current version, so the static
+      # test sees no combined edit, and the release strands every helper whose only
+      # key was the retired one. The tree genuinely cannot tell "added last release"
+      # from "added in this pull request"; only the diff can.
+      #
+      # So this is deliberately the one piece of the schema job that reads git
+      # rather than the tree. It needs no fetch and no ref from the event payload:
+      # on a pull request `actions/checkout` checks out the **merge commit**
+      # (`refs/pull/N/merge`), whose first parent is the base branch tip GitHub
+      # merged against and whose second is the pull request's head. So
+      # `git diff HEAD^1 HEAD` is exactly this pull request's contribution — the
+      # job's checkout carries `fetch-depth: 2` for it, one extra commit.
+      #
+      # Deliberately not `github.event.pull_request.base.sha`: that value is the
+      # base as of the event, and it goes stale when the base branch moves without
+      # the pull request being synchronised — which here means an intervening
+      # release, i.e. precisely the situation this step exists for. A stale base
+      # would fold somebody else's merged rotation into this diff and fail an
+      # innocent pull request. `HEAD^1` is whatever GitHub actually merged against,
+      # recomputed for every run.
+      #
+      # Scoped to `pull_request`, because on a push there is no merge commit and no
+      # such thing as "this pull request's diff". The unit test in `signing.rs` is
+      # what still covers a direct push to main.
+      - name: One release never both adds a key and retires one
+        if: github.event_name == 'pull_request'
+        run: |
+          python3 - <<'PY'
+          import importlib.util, subprocess, sys
+
+          # The table is compared **parsed**, not as diff text. Matching added lines
+          # for `OrgKey {` and `KeyStatus::Retired` was the first version and it is
+          # wrong in both directions: it fires on any pull request that merely
+          # mentions the variant in a comment or a test (it fired on the one that
+          # introduced this file), and it would miss a row edited into a shape the
+          # regex does not recognise. Reusing the parser both workflows already read
+          # the table with means this gate sees exactly what a release will sign.
+          spec = importlib.util.spec_from_file_location("slots", "tests/signing-slots.py")
+          slots = importlib.util.module_from_spec(spec)
+          spec.loader.exec_module(slots)
+
+          path = "crates/veld-core/src/signing.rs"
+
+          def table(ref):
+              got = subprocess.run(
+                  ["git", "show", f"{ref}:{path}"], capture_output=True, text=True
+              )
+              if got.returncode != 0:
+                  return None
+              try:
+                  return slots.parse(got.stdout)
+              except slots.TableError:
+                  return None
+
+          # `HEAD^1` is the base GitHub merged against; `HEAD` is the merge result.
+          before, after = table("HEAD^1"), table("HEAD")
+          if after is None:
+              sys.exit(
+                  f"{path}: the key table in this pull request cannot be read. "
+                  "`python3 tests/signing-slots.py` says why, and a table the release "
+                  "cannot read is a release that signs nothing."
+              )
+          if before is None:
+              # One-time, and loud rather than silent: the base has no readable table,
+              # so this change introduces or restructures the table itself. There is no
+              # before-and-after to compare, and a change of that shape is one a human
+              # reads anyway.
+              print(
+                  f"{path}: the base has no readable ORG_KEYS, so this change introduces "
+                  "or restructures the table rather than rotating a key. Nothing to "
+                  "compare."
+              )
+              raise SystemExit(0)
+
+          was = {r["pubkey"]: r["status"] for r in before}
+          now = {r["pubkey"]: r["status"] for r in after}
+          added = sorted(k for k in now if k not in was)
+          retired = sorted(k for k in now if was.get(k) == "accepted" and now[k] == "retired")
+          dropped = sorted(k for k in was if k not in now)
+
+          def short(keys):
+              return ", ".join(k[:8] + "\u2026" for k in keys)
+
+          # A row that left the table stops producing its slot, which strands every
+          # helper generation that accepts only that key. Nothing else in the repo can
+          # see it: removing a row destroys the evidence it was ever there, which is
+          # the same shape as the combined edit below.
+          if dropped:
+              sys.exit(
+                  f"{path}: this pull request REMOVES {len(dropped)} row(s) from ORG_KEYS "
+                  f"({short(dropped)}). Rows are append-only: a row that leaves stops "
+                  "producing its slot, and every helper generation whose keyring holds only "
+                  "that key then refuses every future release, sudo-only. Retiring a key "
+                  "changes its `status` and keeps the row. Dropping one is the announced "
+                  "flag day in docs/signing-key-rotation.md, not something a rotation does."
+              )
+          if added and retired:
+              sys.exit(
+                  f"{path}: this pull request both adds a key ({short(added)}) and retires "
+                  f"one ({short(retired)}). Merging is releasing here, so that is ONE release "
+                  "doing both — and every helper whose only key is the retired one then "
+                  "refuses the very artifact meant to move it forward, with sudo on every "
+                  "machine as the only repair.\n\n"
+                  "Split it: ship the adding release first, wait for it to reach the fleet, "
+                  "then retire in a second pull request. See docs/signing-key-rotation.md."
+              )
+          print(f"{path}: {len(added)} key(s) added, {len(retired)} retired — not both")
+          PY
+
       - name: Shell scripts parse and lint
         run: |
           sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,61 +257,81 @@ jobs:
           # for the host — never for ${{ matrix.target }}, whose binary is
           # cross-compiled (aarch64 on an x86_64 runner) and cannot execute here.
           cargo build --release -p veld-sign
-          # `--key-env` is REPEATABLE and the order is the slot order (issue #261
-          # slice C). `<binary>.sig` carries one 64-byte signature per key, and
-          # slot 0 belongs to the org's original key forever: every helper shipped
-          # up to v16.59.0 verifies bytes 0..64 against that key and nothing else,
-          # so a release whose slot 0 is anything else is a release NO privileged
-          # install can relaunch onto — repairable only with sudo on every
-          # machine, which is the one outcome #338's rules forbid.
+          # **Rotating an org key needs no edit to this file.** The whole slot
+          # layout — which keys a release is signed by, in which slot, and which
+          # secret supplies each private half — is read out of
+          # `crates/veld-core/src/signing.rs`'s ORG_KEYS table, which is the same
+          # reviewed source the helper's own keyring is compiled from. Adding a key
+          # is one row there plus one new repository secret; nothing here changes.
+          # `docs/signing-key-rotation.md` is the runbook.
           #
-          # To rotate, in the same release: generate the new key offline, add it to
-          # the repo secrets, then FOUR edits —
-          #   1. a SECOND `--key-env <NEW_SECRET>` line BELOW this one (never
-          #      above: order is slot order and slot 0 cannot move);
-          #   2. a matching `<NEW_SECRET>:` entry in this step's own `env:` block
-          #      further down, taking its value from `secrets.<NEW_SECRET>` the same
-          #      way the existing line does. (Written in prose rather than as the
-          #      expression, so this comment needs no escaping to keep Actions from
-          #      evaluating it.) Easy to miss, and the symptom is the release dying
-          #      at this step *after merge* — `veld-sign` reads the key by variable
-          #      NAME, so a flag with no matching `env:` entry looks exactly like an
-          #      unset secret;
-          #   3. the new public key APPENDED to `--expect-slot-pubkeys` below,
-          #      comma-separated, in slot order — not optional: it is the only check
-          #      that a secret holds the key the keyring names, and for a later slot
-          #      that mistake ships invisibly and wedges the fleet one release on;
-          #   4. the new public key in the keyring in
-          #      `crates/veld-core/src/signing.rs`, with RELEASE_SIG_SLOTS bumped.
-          # Then `cargo fmt --all`. Retirement is a LATER release. Full runbook:
-          # `docs/signing-key-rotation.md`. `ci.yml`'s `schema` job fails a pull
-          # request for every one of those four going wrong: a flag count that stops
-          # matching `veld_core::signing::RELEASE_SIG_SLOTS`, a `--key-env` with no
-          # matching `env:` entry (or written with `=` rather than a space), a secret
-          # name without the shared prefix the leak gate matches on, and an
-          # `--expect-slot-pubkeys` list that does not equal `ORG_REQUIRED_SLOT_KEYS`
-          # element for element and in order.
+          # `--slots` takes `<expected public key hex>=<VARIABLE>` per slot, in slot
+          # order. Pairing the two halves in one token is what makes deriving them
+          # safe: they cannot drift apart, and a row that went missing cannot shift
+          # every later key one slot to the left — which would move slot 0, and slot
+          # 0 belongs to the org's original key forever. Every helper shipped up to
+          # v16.59.0 verifies bytes 0..64 against that one key and nothing else, so
+          # a release whose slot 0 is anything else is a release NO privileged
+          # install can relaunch onto, repairable only with sudo on every machine —
+          # the one outcome #338's rules forbid.
           #
-          # `--expect-slot-pubkeys` is the check nothing else in the pipeline can
-          # make: if a signing secret is ever re-uploaded, rotated or created holding
-          # a *different but valid* key, the PEM parses, a signature is written and
-          # the release publishes — a signature by the wrong key is indistinguishable
-          # from a correct one without knowing which key was meant.
+          # The expected-key half is the check nothing else in the pipeline can
+          # make: if a signing secret is ever re-uploaded, rotated or created
+          # holding a *different but valid* key, the PEM parses, a signature is
+          # written and the release publishes — a signature by the wrong key is
+          # indistinguishable from a correct one without knowing which key was
+          # meant. It covers EVERY slot, not just slot 0: a wrong key in a later
+          # slot ships invisibly (the release still installs everywhere via slot 0)
+          # and then wedges every privileged install one release later, when that
+          # key becomes the only one a helper accepts.
           #
-          # It lists EVERY slot's expected public key, comma-separated in slot order,
-          # not just slot 0's. A wrong key in slot 1 would ship invisibly (the
-          # release still installs everywhere via slot 0) and then wedge every
-          # privileged install one release later, when that key becomes the only one
-          # a helper accepts. `ci.yml` compares this list element-wise against
-          # `ORG_REQUIRED_SLOT_KEYS` in the source, so adding a key here without
-          # adding it there — or in the wrong order — fails a pull request.
-          ./target/release/veld-sign \
-            --key-env SIGNING_PRIVATE_KEY \
-            --expect-slot-pubkeys 9d75a4c55c02b46e53a30d1df884c8aaf0d3902306d1c6ee53603299a31b3156 \
-            dist/veld-helper
+          # Deriving it does not move the trust root anywhere. It reads git, not the
+          # secret store — the point is that a reviewer can still see in reviewed
+          # source which keys a release trusts and which it is signed by, and now
+          # they cannot disagree with each other.
+          #
+          # `ci.yml`'s `schema` job runs the same script on every pull request and
+          # checks each secret it names against this step's `env:` block below, so a
+          # key added to the table without its secret being listed fails a pull
+          # request instead of this push-only step, i.e. instead of failing after
+          # merge.
+          SLOTS="$(python3 tests/signing-slots.py)"
+          echo "signing slots: $SLOTS"
+          ./target/release/veld-sign --slots "$SLOTS" dist/veld-helper
           tar -czf veld-${{ needs.plan.outputs.new_release_version }}-${{ matrix.suffix }}.tar.gz -C dist .
         env:
+          # **The permanent roster. Do not edit this block to rotate a key.**
+          #
+          # Eight names, the signature format's own slot ceiling
+          # (`veld_core::signing::MAX_SIG_SLOTS`), listed once and never again.
+          # Which of them a release actually uses is decided by the ORG_KEYS table
+          # in `crates/veld-core/src/signing.rs`. A name no row names is simply an
+          # environment variable that is not there, and `veld-sign` never asks for
+          # it. A name a row DOES name must have its secret set — including a
+          # **retired** row, whose slot is still produced on every release.
+          # Deleting a retired key's secret breaks every release from then on, and
+          # nothing can warn about it, because secrets cannot be enumerated.
+          #
+          # Listed rather than looked up because a workflow cannot enumerate
+          # secrets: `ci.yml`'s own gate forbids `toJSON(secrets)` and any dynamic
+          # index into the secrets context on every workflow a pull request can
+          # start, deliberately. A fixed set of names whose presence at runtime
+          # drives behaviour is the shape that IS expressible.
+          #
+          # SIGNING_PRIVATE_KEY holds the org's ORIGINAL key and is never
+          # re-uploaded with different material — it is slot 0, which is a
+          # compatibility contract with every already-shipped helper. A new key goes
+          # in the next free number. Names are positional, never relative to now: an
+          # `_OLD`/`_CURRENT` pair reads as the obvious scheme and puts the second
+          # key in slot 0 on the second rotation, which strands the whole fleet.
           SIGNING_PRIVATE_KEY: ${{ secrets.SIGNING_PRIVATE_KEY }}
+          SIGNING_PRIVATE_KEY_2: ${{ secrets.SIGNING_PRIVATE_KEY_2 }}
+          SIGNING_PRIVATE_KEY_3: ${{ secrets.SIGNING_PRIVATE_KEY_3 }}
+          SIGNING_PRIVATE_KEY_4: ${{ secrets.SIGNING_PRIVATE_KEY_4 }}
+          SIGNING_PRIVATE_KEY_5: ${{ secrets.SIGNING_PRIVATE_KEY_5 }}
+          SIGNING_PRIVATE_KEY_6: ${{ secrets.SIGNING_PRIVATE_KEY_6 }}
+          SIGNING_PRIVATE_KEY_7: ${{ secrets.SIGNING_PRIVATE_KEY_7 }}
+          SIGNING_PRIVATE_KEY_8: ${{ secrets.SIGNING_PRIVATE_KEY_8 }}
           # Read by the version-record check above. Passed through the
           # environment rather than interpolated into the heredoc so the heredoc
           # stays quoted and the shell cannot touch the Python source.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ reboot. Updates still need no sudo — the installer hands the new binary to the
 running root helper, which verifies its signature and refuses anything older than
 the newer of what is running and what is already installed.
 
+That signature is checked against a list of org keys compiled into the helper, so
+the key can be **replaced without asking anyone to run anything** — two releases,
+and the old key keeps working until the second one. If you hold the key, the
+procedure is [docs/signing-key-rotation.md](docs/signing-key-rotation.md), and
+it is two releases, one new GitHub secret and one row of Rust.
+
 No sudo required. Ensure `~/.local/bin` is on your `PATH`.
 
 Setup is optional — commands auto-bootstrap on first use with HTTPS on port 18443.

--- a/crates/veld-core/src/paths.rs
+++ b/crates/veld-core/src/paths.rs
@@ -239,7 +239,22 @@ pub fn privileged_helper_bin() -> PathBuf {
 /// spelling, but a definition written by hand or resolved elsewhere may carry
 /// the resolved one.
 pub fn is_privileged_helper_path(path: &Path) -> bool {
-    let bin = privileged_helper_bin();
+    names_the_same_binary(path, &privileged_helper_bin())
+}
+
+/// [`is_privileged_helper_path`]'s comparison, against an explicit `bin` rather
+/// than the store's.
+///
+/// Split out purely so the "never asks the filesystem" property is testable on
+/// **every** machine. Through [`is_privileged_helper_path`] alone it is not: the
+/// only path that must answer *true* is the real store binary, and whether that
+/// is present is a property of the machine — so on a maintainer's machine with a
+/// privileged install (which #262's own migration eventually creates), an
+/// implementation that canonicalised would answer true for the present store path
+/// and false for an absent sibling, i.e. it would pass. With this seam a test can
+/// hand over two paths that exist nowhere and still demand *true*, which
+/// canonicalising cannot produce.
+fn names_the_same_binary(path: &Path, bin: &Path) -> bool {
     if path == bin {
         return true;
     }
@@ -285,19 +300,75 @@ pub fn caddy_log_path() -> PathBuf {
 mod tests {
 
     /// The migrated-path check is lexical, so a **missing** store binary still
-    /// reads as migrated.
+    /// reads as migrated — and an *existing* one does too.
     ///
-    /// This is the fail-open that made `veld _helper-install` return 0 in
-    /// silence, and `veld doctor` report green, for a machine whose root daemon
-    /// had no binary to exec — the two places that exist to say so loudly.
+    /// That fail-open is what an implementation which canonicalised got wrong:
+    /// `canonicalize` errors on a path that is not there, so a machine whose root
+    /// daemon had no binary to exec read as "not migrated" — and `veld
+    /// _helper-install` returned 0 in silence while `veld doctor` went green, the
+    /// two places that exist to say so loudly.
+    ///
+    /// **This test used to assert `!bin.exists()` as a precondition**, which made
+    /// it fail on any machine that has a privileged install — and #262's own
+    /// migration guarantees a maintainer's machine eventually becomes one, so the
+    /// test was on a timer. The state of the machine was never part of the
+    /// property: [`is_privileged_helper_path`] is a comparison against a constant
+    /// and never touches the filesystem, which is the whole point. So the
+    /// machine's state is *recorded* here rather than asserted.
+    ///
+    /// **That rewrite alone was not enough, and the gap is worth naming**, because
+    /// it is invisible: with the precondition simply dropped, this test could no
+    /// longer fail on a machine that *has* a store. A canonicalising
+    /// implementation answers true for the present store path and false for the
+    /// absent sibling — both of which this test wants — so it passes. The
+    /// regression would then be caught only by a machine with no privileged
+    /// install, i.e. by CI's Linux runner and not by the maintainer's Mac, which
+    /// is the same "depends on the machine" defect pointing the other way.
+    /// [`names_the_same_binary`] below is the seam that closes it.
     #[test]
-    fn a_missing_store_binary_still_reads_as_the_privileged_helper_path() {
+    fn the_store_path_reads_as_migrated_either_way() {
         let bin = super::privileged_helper_bin();
+        let present = bin.exists();
         assert!(
-            !bin.exists(),
-            "this test assumes no store on the test machine"
+            super::is_privileged_helper_path(&bin),
+            "the store path must read as migrated regardless of the binary being \
+             there; it is there on this machine: {present}"
         );
-        assert!(super::is_privileged_helper_path(&bin));
+
+        // Exact, not "somewhere in the store": a sibling in the same directory is
+        // not the helper the service definition names.
+        let sibling = bin.with_file_name("veld-helper-absent");
+        assert!(
+            !super::is_privileged_helper_path(&sibling),
+            "{sibling:?} is not the store's helper"
+        );
+    }
+
+    /// The comparison never asks the filesystem — asserted on **every** machine.
+    ///
+    /// This is the half the test above cannot carry. Both paths here exist
+    /// nowhere: the directory is one this crate never writes, on macOS and on
+    /// Linux alike. A lexical comparison says they name the same binary; an
+    /// implementation that canonicalises gets an error from both sides and says
+    /// they do not. So this goes red for that regression on a machine with a
+    /// privileged install and on one without, which is the property the fail-open
+    /// documented on [`is_privileged_helper_path`] actually rests on.
+    #[test]
+    fn the_comparison_never_asks_the_filesystem() {
+        let absent = Path::new("/var/db/veld-helper-nowhere/veld-helper");
+        assert!(
+            super::names_the_same_binary(absent, absent),
+            "a path that is not there must still compare equal to itself; \
+             canonicalising is what breaks this"
+        );
+
+        // And the `/private` arm, on the same absent path — macOS's `/var`
+        // symlink spelling, which on Linux cannot resolve at all.
+        let absent_private = Path::new("/private/var/db/veld-helper-nowhere/veld-helper");
+        assert!(
+            super::names_the_same_binary(absent_private, absent),
+            "the /private spelling of an absent path must still read as the store"
+        );
     }
 
     /// macOS resolves `/var` to `/private/var`; both spellings are the store.

--- a/crates/veld-core/src/signing.rs
+++ b/crates/veld-core/src/signing.rs
@@ -94,7 +94,155 @@ pub const ORG_KEY_1: PubKey = [
     0xf0, 0xd3, 0x90, 0x23, 0x06, 0xd1, 0xc6, 0xee, 0x53, 0x60, 0x32, 0x99, 0xa3, 0x1b, 0x31, 0x56,
 ];
 
-/// The keys **this build accepts** a signature from.
+/// One org signing key, and everything about it that a release has to know.
+///
+/// **This table is the whole trust root, and rotating is appending to it.** Before
+/// it there were two hand-kept lists plus a hand-kept count, and a rotation edited
+/// all three plus three lines of `release.yml`; the count and the workflow's
+/// expected-key list were transcriptions of what the lists already said. They are
+/// derived now, so the transcription cannot rot and there is nothing left to
+/// forget.
+///
+/// It is a **table of records rather than two sets** for a second reason, and it is
+/// the load-bearing one. Two flat lists can only express *state*: removing a key
+/// from a keyring destroys, from the post-image, every trace that the key ever
+/// existed — so no static check can tell a retirement apart from a steady state
+/// that never held that key, and the two-release rule was therefore unguardable in
+/// principle. A row that **survives** its own retirement is the only place that
+/// evidence can live. See [`KeyStatus::Retired`].
+#[derive(Debug, Clone, Copy)]
+pub struct OrgKey {
+    /// The public half. This key's **slot index** in `<binary>.sig` is its index
+    /// in [`ORG_KEYS`], which is why rows are appended and never reordered.
+    pub key: PubKey,
+
+    /// The GitHub Actions secret holding the private half, which signs this key's
+    /// slot at release time.
+    ///
+    /// Recorded *here*, beside the key, rather than left implicit in the order of
+    /// flags in `release.yml`. That pairing is the thing this format has no room
+    /// for — slot position is its only key identifier — so a mis-pairing between a
+    /// key and the secret that signs its slot is invisible in the artifact and
+    /// fatal one release later. `ci.yml` checks every name here against the
+    /// workflow's `env:` block on every pull request.
+    ///
+    /// **Names are positional and immortal**, never relative to *now*.
+    /// `SIGNING_PRIVATE_KEY` holds the original key forever and is never
+    /// re-uploaded; a new key takes the next free number. A recency-based name — a
+    /// `_OLD`/`_CURRENT` pair — reads as the obvious scheme and is fatal on the
+    /// **second** rotation: slot 0 would then hold the second key, which no helper
+    /// shipped up to v16.59.0 has ever trusted, and the first key would have no
+    /// slot at all.
+    pub secret: &'static str,
+
+    /// `Cargo.toml`'s `version` at the moment this row was written — i.e. the
+    /// last release before the one that introduces this key. Copy it verbatim.
+    ///
+    /// **You can always know this, and that is the whole point.** `Cargo.toml`
+    /// holds the *previous* release until semantic-release bumps it after the
+    /// merge, so a pull request can never name the version it will itself ship as
+    /// — but it can always name the one it was written against. Together with
+    /// [`KeyStatus::Retired`]'s matching field, that is what makes the two-release
+    /// rule checkable from one file with no git history: see
+    /// `one_release_never_both_adds_a_key_and_retires_one`.
+    ///
+    /// [`ORG_KEY_1`] carries `0.0.0` because it predates this table and every
+    /// release in it.
+    pub added_after: &'static str,
+
+    /// Whether this build still accepts a signature by this key.
+    pub status: KeyStatus,
+}
+
+/// Whether a build accepts a key — and, once it does not, the evidence that
+/// retiring it was safe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyStatus {
+    /// This build accepts a signature by this key.
+    Accepted,
+
+    /// This build no longer accepts it. Releases keep carrying its slot, because
+    /// some helper generation in the field accepts *only* this key.
+    ///
+    /// **This variant is the two-release rule, mechanised**, and that is why it
+    /// carries a mandatory field instead of being a `bool`. A one-character flip is
+    /// the cheapest dangerous edit in the repository and invisible in a skim;
+    /// constructing a variant with a value in it is an act of authorship.
+    Retired {
+        /// `Cargo.toml`'s `version` at the moment this key was retired — the same
+        /// thing [`OrgKey::added_after`] records, for the other half of the edit.
+        /// Copy it verbatim.
+        ///
+        /// **The rule these two fields express:** no single release may both add a
+        /// key and retire one. A pull request that tried would have to write the
+        /// *same* version in both fields — the one `Cargo.toml` shows right now —
+        /// and `one_release_never_both_adds_a_key_and_retires_one` fails exactly
+        /// that. Neither needs git history; both are simply what the tree says.
+        ///
+        /// Not "the next version is unknowable": `release.yml`'s `plan` job runs
+        /// semantic-release in dry-run on every non-draft pull request and prints
+        /// it. The point is narrower and survives that — the tree cannot be made to
+        /// *say* the pull request has already shipped, and
+        /// `every_key_lifecycle_date_names_a_release_that_has_happened` refuses a
+        /// value newer than `Cargo.toml`, so writing the upcoming version is caught
+        /// too.
+        ///
+        /// **The hole this leaves, named rather than glossed:** if the branch's
+        /// `Cargo.toml` moves between the two edits — an unrelated release lands,
+        /// the branch is updated, then the retirement is written — the two dates
+        /// are both *honest* and *different*, neither equals the current version,
+        /// and the test sees nothing. The tree cannot tell "added last release"
+        /// from "added in this pull request", and nothing written in this file
+        /// can. `ci.yml`'s *One release never both adds a key and retires one* is
+        /// the layer that closes it, by reading the pull request's own diff; this
+        /// one is what still works on a direct push to `main`, where there is no
+        /// diff to read.
+        ///
+        /// What remains uncaught by both is a value *invented* for
+        /// `added_after` — neither the truth nor anything already written down.
+        /// `added_after_increases_down_the_table` removes the stale values that are
+        /// lying around to copy (row 0's `0.0.0`, any earlier row's version), so
+        /// what is left takes deliberate arithmetic. Nothing in the tree can prove
+        /// a date honest.
+        retired_after: &'static str,
+    },
+}
+
+/// Every org key, in slot order. **Append only; never reorder, never delete.**
+///
+/// Row 0 is [`ORG_KEY_1`] forever — see that constant for why its slot position is
+/// a compatibility contract rather than a convention.
+///
+/// * **Rotating** = append one row, `status: KeyStatus::Accepted`.
+/// * **Retiring** = change one row's status to [`KeyStatus::Retired`], in a
+///   **later** release. The row stays; its slot keeps being produced.
+///
+/// Deleting a row is the one edit nothing here can see, because it destroys the
+/// same evidence a retirement preserves. It also drops a slot, which strands every
+/// helper generation that accepts only that key — the announced flag day described
+/// in `docs/signing-key-rotation.md`, not something a rotation does.
+pub const ORG_KEYS: &[OrgKey] = &[OrgKey {
+    key: ORG_KEY_1,
+    secret: "SIGNING_PRIVATE_KEY",
+    // Predates this table and every release in it.
+    added_after: "0.0.0",
+    status: KeyStatus::Accepted,
+}];
+
+/// A release may not claim more slots than any reader looks at.
+const _: () = assert!(ORG_KEYS.len() <= MAX_SIG_SLOTS);
+
+/// **A build that trusts nothing must not compile.**
+///
+/// Flipping the last `Accepted` row to `Retired` is one field, and the result is a
+/// helper that refuses every relaunch, refuses `restart` and `shutdown`, refuses
+/// every candidate, and leaves sudo as the only repair —
+/// `the_keyring_is_never_empty` catches it, but only for somebody who runs the
+/// tests. An engineer who builds and installs locally bricks their own machine
+/// first and reads the test failure second.
+const _: () = assert!(accepted_key_count() > 0);
+
+/// The keys **this build accepts** a signature from — [`ORG_KEYS`]' accepted rows.
 ///
 /// A binary verifies when any slot of its `.sig` verifies under any key here, so
 /// this list is what "trusted" means for the helper that links it. It rides the
@@ -102,36 +250,74 @@ pub const ORG_KEY_1: PubKey = [
 /// when the binary it executes changes, and that transition is already governed
 /// by [`crate::helper_store`]'s version floor.
 ///
-/// **Rotating** = a release that adds a key here *and* a matching slot in
-/// `release.yml`. **Retiring** = a later release that removes a key from here
-/// while [`ORG_REQUIRED_SLOT_KEYS`] keeps producing its slot. Do those in two
-/// separate releases: a release that both adds and retires leaves any helper
-/// whose only key was the retired one unable to verify the very artifact meant to
-/// move it forward.
-pub const ORG_SIGNING_KEYRING: &[PubKey] = &[ORG_KEY_1];
+/// Derived rather than hand-kept: a release that both adds a key here and removes
+/// one leaves any helper whose only key was the retired one unable to verify the
+/// very artifact meant to move it forward, and expressing both as edits to *one*
+/// row's status is what makes that combination checkable at all.
+pub const ORG_SIGNING_KEYRING: &[PubKey] = &accepted_keys::<{ accepted_key_count() }>();
 
 /// The keys every release must still be **signed by**, whether or not this build
-/// would accept them.
+/// would accept them — i.e. every row of [`ORG_KEYS`], in slot order.
 ///
-/// A key stays here after it leaves [`ORG_SIGNING_KEYRING`], because some helper
-/// generation in the field accepts *only* that key and a release carrying no slot
-/// for it is a release that generation refuses. Dropping a key from this list is
-/// therefore a deliberate flag day that strands whatever remains of that
-/// generation on sudo — not a tidy-up. It is not something a rotation does.
-pub const ORG_REQUIRED_SLOT_KEYS: &[PubKey] = &[ORG_KEY_1];
+/// A key stays here after it stops being accepted, because some helper generation
+/// in the field accepts *only* that key and a release carrying no slot for it is a
+/// release that generation refuses. This being *every* row rather than a second
+/// hand-kept list is what makes "grows, never shrinks" a derivation instead of a
+/// convention: forgetting to keep a retired key's slot is now unrepresentable.
+pub const ORG_REQUIRED_SLOT_KEYS: &[PubKey] = &all_keys::<{ ORG_KEYS.len() }>();
 
 /// How many 64-byte slots `<binary>.sig` must carry for a release to be
-/// installable by every helper generation still in the field: one per distinct
-/// key across [`ORG_SIGNING_KEYRING`] and [`ORG_REQUIRED_SLOT_KEYS`].
+/// installable by every helper generation still in the field: one per row of
+/// [`ORG_KEYS`].
 ///
-/// Written out as a number rather than computed because it is read from **two**
-/// places that cannot evaluate Rust: `release.yml` passes exactly this many keys
-/// to `veld-sign`, and `ci.yml`'s `schema` job compares this constant against the
-/// number of key flags in that step — so a key added to the lists above without a
-/// matching secret fails a **pull request** instead of a release. The number is
-/// held honest against the lists themselves by
-/// `release_slot_count_matches_the_key_lists`.
-pub const RELEASE_SIG_SLOTS: usize = 1;
+/// It used to be a hand-written number, because it is read from **two** places
+/// that cannot evaluate Rust — `release.yml`'s signing step and `ci.yml`'s gate on
+/// it. Both now read [`ORG_KEYS`] itself, by the same regex, so the number has one
+/// home again.
+pub const RELEASE_SIG_SLOTS: usize = ORG_KEYS.len();
+
+/// How many rows of [`ORG_KEYS`] are [`KeyStatus::Accepted`].
+///
+/// A `const fn` rather than a `Vec` at runtime so [`ORG_SIGNING_KEYRING`] stays a
+/// `&'static [PubKey]` — every caller, including the root helper's relaunch gate,
+/// keeps taking a plain slice with no allocation on a path that runs on a timer.
+const fn accepted_key_count() -> usize {
+    let mut n = 0;
+    let mut i = 0;
+    while i < ORG_KEYS.len() {
+        if matches!(ORG_KEYS[i].status, KeyStatus::Accepted) {
+            n += 1;
+        }
+        i += 1;
+    }
+    n
+}
+
+/// The accepted rows' keys, in slot order. `N` must be [`accepted_key_count`].
+const fn accepted_keys<const N: usize>() -> [PubKey; N] {
+    let mut out = [[0u8; 32]; N];
+    let mut i = 0;
+    let mut n = 0;
+    while i < ORG_KEYS.len() {
+        if matches!(ORG_KEYS[i].status, KeyStatus::Accepted) {
+            out[n] = ORG_KEYS[i].key;
+            n += 1;
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Every row's key, in slot order. `N` must be `ORG_KEYS.len()`.
+const fn all_keys<const N: usize>() -> [PubKey; N] {
+    let mut out = [[0u8; 32]; N];
+    let mut i = 0;
+    while i < N {
+        out[i] = ORG_KEYS[i].key;
+        i += 1;
+    }
+    out
+}
 
 /// One slot of a detached signature file: a raw ed25519 signature.
 pub const SIG_SLOT_LEN: usize = 64;
@@ -225,9 +411,45 @@ pub fn verify_data(pubkey: &PubKey, data: &[u8], sig: &[u8]) -> bool {
 /// A trailing partial slot is ignored for the same reason. `sig` is expected to
 /// be bounded by the caller — [`read_detached_sig_slots`] is what does that.
 pub fn verify_data_slots(keyring: &[PubKey], data: &[u8], sig: &[u8]) -> bool {
+    verifying_key(keyring, data, sig).is_some()
+}
+
+/// [`verify_data_slots`], but naming the key that verified.
+///
+/// The verdict on its own answers "may root execute this", which is all the gates
+/// need. **Which** key answered it is what a person needs when a machine is
+/// somewhere unexpected in a rotation window: a helper's keyring and a release's
+/// slots are two lists that move at different times, and "signature OK" is the same
+/// sentence whether this machine is on the key before the rotation or the one
+/// after. `veld doctor` says which; nothing else does, and nothing on the machine
+/// records it.
+///
+/// A public key, so there is nothing here that must not be printed.
+pub fn verifying_key(keyring: &[PubKey], data: &[u8], sig: &[u8]) -> Option<PubKey> {
+    let mut found = None;
     any_slot_verifies(sig, |slot| {
-        keyring.iter().any(|key| verify_data(key, data, slot))
-    })
+        found = keyring
+            .iter()
+            .find(|key| verify_data(key, data, slot))
+            .copied();
+        found.is_some()
+    });
+    found
+}
+
+/// Where `key` sits in [`ORG_KEYS`], as a 1-based slot number, and how many rows
+/// there are — `(2, 3)` reads as "org key 2 of 3".
+///
+/// The index is the key's **permanent identity**: rows are appended and never
+/// reordered, so key 2 stays key 2 across every later rotation and retirement, and
+/// the number in a `veld doctor` row a user pastes into an issue means the same
+/// thing a year later. Falls back to `None` for a key that is not in the table,
+/// which is only reachable from a test.
+pub fn org_key_position(key: &PubKey) -> Option<(usize, usize)> {
+    ORG_KEYS
+        .iter()
+        .position(|k| &k.key == key)
+        .map(|i| (i + 1, ORG_KEYS.len()))
 }
 
 /// Whether any **distinct** 64-byte slot of `sig` satisfies `verify`.
@@ -485,12 +707,44 @@ fn retired_keys() -> Vec<PubKey> {
 /// [`classify_binary_signature`] against explicit lists, so the retired-key case
 /// is testable before any key has actually been retired.
 pub fn classify_data(active: &[PubKey], retired: &[PubKey], data: &[u8], sig: &[u8]) -> SigTrust {
-    if verify_data_slots(active, data, sig) {
-        SigTrust::Active
-    } else if verify_data_slots(retired, data, sig) {
-        SigTrust::RetiredOnly
+    classify_data_detail(active, retired, data, sig).trust
+}
+
+/// A [`SigTrust`] and, when one verified, the key that produced it.
+///
+/// One value rather than two calls, because classifying reads and hashes the whole
+/// ~26 MB binary: asking a second time for the key would double that, and the two
+/// answers can disagree if an update lands between them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SigVerdict {
+    pub trust: SigTrust,
+    /// The key a slot verified under — public, and `None` for
+    /// [`SigTrust::Untrusted`].
+    pub key: Option<PubKey>,
+}
+
+/// [`classify_data`], naming the key that answered.
+pub fn classify_data_detail(
+    active: &[PubKey],
+    retired: &[PubKey],
+    data: &[u8],
+    sig: &[u8],
+) -> SigVerdict {
+    if let Some(key) = verifying_key(active, data, sig) {
+        SigVerdict {
+            trust: SigTrust::Active,
+            key: Some(key),
+        }
+    } else if let Some(key) = verifying_key(retired, data, sig) {
+        SigVerdict {
+            trust: SigTrust::RetiredOnly,
+            key: Some(key),
+        }
     } else {
-        SigTrust::Untrusted
+        SigVerdict {
+            trust: SigTrust::Untrusted,
+            key: None,
+        }
     }
 }
 
@@ -537,6 +791,14 @@ pub fn classify_data(active: &[PubKey], retired: &[PubKey], data: &[u8], sig: &[
 /// window. `veld doctor` additionally knows when an update is in progress and is the
 /// right place to suppress the paragraph outright if this proves not enough.
 pub fn classify_binary_signature(binary: &Path) -> SigTrust {
+    classify_binary_signature_detail(binary).trust
+}
+
+/// [`classify_binary_signature`], naming the key that answered.
+///
+/// The one caller is `veld doctor`'s signature row. Everything that *gates* on a
+/// signature wants the verdict alone and takes [`classify_binary_signature`].
+pub fn classify_binary_signature_detail(binary: &Path) -> SigVerdict {
     classify_with_retry(|| classify_binary_signature_once(binary, MAX_VERIFIED_BINARY_BYTES))
 }
 
@@ -548,25 +810,34 @@ pub fn classify_binary_signature(binary: &Path) -> SigTrust {
 /// every refusal" with nothing red anywhere, handing an attacker a second race per
 /// tick against the pre-`stat` in [`read_regular_file_bounded`].
 /// `only_a_verification_failure_is_retried` counts them.
-fn classify_with_retry(mut pass: impl FnMut() -> Option<SigTrust>) -> SigTrust {
+fn classify_with_retry(mut pass: impl FnMut() -> Option<SigVerdict>) -> SigVerdict {
+    let untrusted = SigVerdict {
+        trust: SigTrust::Untrusted,
+        key: None,
+    };
     match pass() {
         // A read failed. Answer once; do not hand out a second race.
-        None => SigTrust::Untrusted,
-        Some(SigTrust::Untrusted) => pass().unwrap_or(SigTrust::Untrusted),
+        None => untrusted,
+        Some(v) if v.trust == SigTrust::Untrusted => pass().unwrap_or(untrusted),
         Some(settled) => settled,
     }
 }
 
 /// One pass of [`classify_binary_signature`]. `None` means a read failed, which is
 /// what separates a tear from an unreadable path — see there.
-fn classify_binary_signature_once(binary: &Path, limit: u64) -> Option<SigTrust> {
+fn classify_binary_signature_once(binary: &Path, limit: u64) -> Option<SigVerdict> {
     let sig = match read_detached_sig_slots_classified(binary) {
         SigRead::Slots(slots) => slots,
         // Read fine, no whole slot: a **torn** `.sig`, which is what the retry is
         // for. `install.sh` writes the lib-dir copy with `cp`, so the file really
         // does pass through zero length in place. Reporting this as a read failure
         // put it on the wrong side of the rule — see [`SigRead`].
-        SigRead::NoWholeSlot => return Some(SigTrust::Untrusted),
+        SigRead::NoWholeSlot => {
+            return Some(SigVerdict {
+                trust: SigTrust::Untrusted,
+                key: None,
+            });
+        }
         SigRead::Unreadable => return None,
     };
     // Read through the **same** shape as the `.sig` above, and that pairing is the
@@ -594,7 +865,7 @@ fn classify_binary_signature_once(binary: &Path, limit: u64) -> Option<SigTrust>
         // read failure so it is not retried.
         return None;
     }
-    Some(classify_data(
+    Some(classify_data_detail(
         ORG_SIGNING_KEYRING,
         &retired_keys(),
         &data,
@@ -1140,6 +1411,15 @@ mod tests {
         keys.iter().flat_map(|k| k.sign(data).to_bytes()).collect()
     }
 
+    /// A [`SigVerdict`] carrying just a trust level.
+    ///
+    /// The retry rule and the once-pass both branch on the trust level alone —
+    /// the key rides along for `veld doctor` and nothing else reads it — so the
+    /// tests below say what they mean and let this fill in the rest.
+    fn verdict(trust: SigTrust) -> SigVerdict {
+        SigVerdict { trust, key: None }
+    }
+
     /// **The compatibility contract, asserted rather than trusted.**
     ///
     /// Every helper shipped up to v16.59.0 reads exactly bytes `0..64` of the
@@ -1158,24 +1438,371 @@ mod tests {
         );
     }
 
-    /// [`RELEASE_SIG_SLOTS`] is read by two places that cannot evaluate Rust —
-    /// `release.yml`'s key flags and `ci.yml`'s gate on them — so it has to be
-    /// held honest against the lists it summarises.
+    /// The three derived views really are views of [`ORG_KEYS`].
+    ///
+    /// They used to be three hand-kept declarations that a rotation edited
+    /// separately, and the whole point of the table is that they are not any more.
+    /// A `const fn` that quietly dropped or duplicated a row would compile, and the
+    /// symptom would be a release signed by a key no reader expects — so the
+    /// derivations are re-done here the obvious way and compared.
     #[test]
-    fn release_slot_count_matches_the_key_lists() {
-        let mut all: Vec<PubKey> = ORG_SIGNING_KEYRING.to_vec();
-        for key in ORG_REQUIRED_SLOT_KEYS {
-            if !all.contains(key) {
-                all.push(*key);
+    fn the_derived_views_match_the_table() {
+        let all: Vec<PubKey> = ORG_KEYS.iter().map(|k| k.key).collect();
+        assert_eq!(
+            ORG_REQUIRED_SLOT_KEYS, all,
+            "every row of ORG_KEYS gets a slot, in table order"
+        );
+        // Structural, not a check: `RELEASE_SIG_SLOTS` **is** `ORG_KEYS.len()`, so
+        // this cannot fail. Kept as an executable statement of the property, which
+        // the deleted `release_slot_count_matches_the_key_lists` had to assert for
+        // real when the count was a hand-written number beside two independent
+        // lists. Written down because an assertion that cannot fail reads as a
+        // check, and the next reader deserves to know which it is.
+        const _: () = assert!(RELEASE_SIG_SLOTS == ORG_KEYS.len());
+
+        let accepted: Vec<PubKey> = ORG_KEYS
+            .iter()
+            .filter(|k| k.status == KeyStatus::Accepted)
+            .map(|k| k.key)
+            .collect();
+        assert_eq!(
+            ORG_SIGNING_KEYRING, accepted,
+            "the keyring is exactly the accepted rows, in table order"
+        );
+    }
+
+    /// **The Python parser and the compiler agree about `ORG_KEYS`.**
+    ///
+    /// `tests/signing-slots.py` reads this table with regexes so that
+    /// `release.yml` and `ci.yml` — neither of which can evaluate Rust — can know
+    /// what a release must be signed with. That makes it a **second
+    /// implementation** of a value the compiler already has, and the only thing
+    /// standing between the two is this test. Comparing the script's two output
+    /// modes against each other, which is what `ci.yml` used to do here, is
+    /// tautological: the same parse produces both, so a parse that drops a row
+    /// drops it identically on both sides.
+    ///
+    /// What that would cost, concretely: a row the parser misses is a slot the
+    /// release does not carry, while `ORG_REQUIRED_SLOT_KEYS` says it does. One
+    /// release later the generation whose keyring holds only that key finds no slot
+    /// that verifies, refuses every candidate, and needs sudo on every machine.
+    ///
+    /// Skipped rather than failed when `python3` is not on `PATH`, because a
+    /// missing interpreter is not a disagreement — CI has one, and `ci.yml`'s
+    /// slot-layout gate runs the script directly and fails loudly if it cannot.
+    #[test]
+    fn the_slot_script_reads_the_same_table_the_compiler_does() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(|p| p.parent())
+            .expect("workspace root is two levels above this crate")
+            .to_path_buf();
+        let out = match std::process::Command::new("python3")
+            .arg("tests/signing-slots.py")
+            .arg("--tsv")
+            .current_dir(&root)
+            .output()
+        {
+            Ok(out) => out,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // Said out loud. A silent `ok` here is indistinguishable from
+                // having run, and this is the only comparison between the script
+                // and what rustc compiles. CI always has python3, and `ci.yml`'s
+                // slot-layout gate runs the script directly anyway.
+                eprintln!(
+                    "SKIPPED the_slot_script_reads_the_same_table_the_compiler_does: \
+                     no python3 on PATH, so the parser was NOT compared against ORG_KEYS"
+                );
+                return;
+            }
+            Err(e) => panic!("could not run tests/signing-slots.py: {e}"),
+        };
+        assert!(
+            out.status.success(),
+            "tests/signing-slots.py --tsv failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let tsv = String::from_utf8(out.stdout).expect("the script prints UTF-8");
+        let rows: Vec<Vec<&str>> = tsv
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| l.split('\t').collect())
+            .collect();
+
+        assert_eq!(
+            rows.len(),
+            ORG_KEYS.len(),
+            "tests/signing-slots.py sees {} row(s) where rustc sees {}. A row the \
+             script misses is a slot the release does not carry, and one release \
+             later the generation that accepts only that key refuses everything. \
+             Its output was:\n{tsv}",
+            rows.len(),
+            ORG_KEYS.len()
+        );
+        for (i, (row, key)) in rows.iter().zip(ORG_KEYS).enumerate() {
+            let hex: String = key.key.iter().map(|b| format!("{b:02x}")).collect();
+            let status = match key.status {
+                KeyStatus::Accepted => "accepted",
+                KeyStatus::Retired { .. } => "retired",
+            };
+            assert_eq!(
+                row.as_slice(),
+                [hex.as_str(), key.secret, key.added_after, status],
+                "row {i}: the script and the compiler disagree about this key"
+            );
+        }
+    }
+
+    /// Every row names a distinct key and a distinct secret.
+    ///
+    /// Two rows sharing a key would be a release claiming to cover two helper
+    /// generations while covering one — `veld-sign` refuses it outright, but at the
+    /// release, which is push-only and therefore after merge. Two rows sharing a
+    /// secret is the same mistake made by copy-paste: the second row's slot would be
+    /// signed by the first row's key, which is exactly the invisible mis-pairing the
+    /// `secret` field exists to prevent.
+    #[test]
+    fn no_key_and_no_secret_appears_twice() {
+        for (i, a) in ORG_KEYS.iter().enumerate() {
+            for b in &ORG_KEYS[i + 1..] {
+                assert_ne!(a.key, b.key, "ORG_KEYS lists the same public key twice");
+                assert_ne!(
+                    a.secret, b.secret,
+                    "two rows of ORG_KEYS name the same secret ({}), so one slot \
+                     would be signed by the other row's key",
+                    a.secret
+                );
             }
         }
-        assert_eq!(
-            RELEASE_SIG_SLOTS,
-            all.len(),
-            "RELEASE_SIG_SLOTS is what release.yml and ci.yml count key flags \
-             against; a key added to ORG_SIGNING_KEYRING or ORG_REQUIRED_SLOT_KEYS \
-             without bumping it ships a release missing a slot"
+    }
+
+    /// Every secret name carries the prefix the leak gate matches on.
+    ///
+    /// `ci.yml` proves no pull-request-startable job can reach a signing secret by
+    /// matching that prefix across every workflow. That only works if the names
+    /// actually carry it, which used to be prose in a runbook and is now a property
+    /// of the table the workflow reads.
+    #[test]
+    fn every_secret_name_carries_the_signing_prefix() {
+        for k in ORG_KEYS {
+            assert!(
+                k.secret.starts_with("SIGNING_"),
+                "{} does not carry the shared signing-secret prefix; ci.yml's leak \
+                 gate matches on it, so a name without it is a secret that can reach \
+                 a pull-request job unnoticed",
+                k.secret
+            );
+        }
+    }
+
+    /// **The two-release rule, as a test rather than as a warning in a runbook.**
+    ///
+    /// Adding a key and retiring one must be two separate releases. A release that
+    /// does both strands every helper in the field whose only key was the retired
+    /// one: it refuses the very artifact meant to move it forward, and the only
+    /// repair is asking every user for sudo on every machine — the one outcome
+    /// #338's rules forbid.
+    ///
+    /// Nothing used to fail a pull request that did both. It looked like a property
+    /// of the *diff* — removing a key from a flat list destroys, from the resulting
+    /// tree, every trace that the key was ever there — and the tripwire that
+    /// accidentally covered it (`nothing_is_retired_yet`) would have expired the
+    /// first time anything was ever retired.
+    ///
+    /// **What makes it a property of one file instead:** both halves of the edit
+    /// record `Cargo.toml`'s version at the moment they were written, and
+    /// `Cargo.toml` holds the *previous* release until semantic-release bumps it
+    /// after the merge. So the two halves of a combined edit necessarily carry the
+    /// **same** version — the one this tree shows right now — while two edits made
+    /// in two releases cannot. No git history, no merge base, no network: the whole
+    /// check is this tree.
+    ///
+    /// **This is one of two layers, and it is the weaker one.** It catches the
+    /// combined edit written in one sitting, which is the common shape, and it does
+    /// so with no git, no network and no CI — so it also covers a direct push to
+    /// `main`. It does **not** catch a branch whose `Cargo.toml` moved between the
+    /// two edits: those two dates are both honest and both differ from the current
+    /// version, and no test reading only this file can tell that apart from a
+    /// legitimate retirement. `ci.yml`'s *One release never both adds a key and
+    /// retires one* reads the pull request's diff and closes exactly that; see the
+    /// note on [`KeyStatus::Retired`].
+    ///
+    /// `added_after_increases_down_the_table` sits beside this one, refusing row 0's
+    /// `0.0.0` and every earlier row's version as a value for a new row — the stale
+    /// values that are actually lying around to copy.
+    #[test]
+    fn one_release_never_both_adds_a_key_and_retires_one() {
+        let now = env!("CARGO_PKG_VERSION");
+        let added: Vec<&str> = ORG_KEYS
+            .iter()
+            .filter(|k| k.added_after == now)
+            .map(|k| k.secret)
+            .collect();
+        let retired: Vec<&str> = ORG_KEYS
+            .iter()
+            .filter(|k| {
+                matches!(k.status, KeyStatus::Retired { retired_after } if retired_after == now)
+            })
+            .map(|k| k.secret)
+            .collect();
+        assert!(
+            added.is_empty() || retired.is_empty(),
+            "this release adds {added:?} and retires {retired:?}, and it may not do \
+             both. A helper whose only key is a retired one would refuse the very \
+             artifact meant to move it forward, and sudo on every machine is the only \
+             repair. Ship the adding release first, wait for it to reach the fleet, \
+             then retire in a second release. See docs/signing-key-rotation.md"
         );
+    }
+
+    /// A key's position is its row, 1-based, and every row has one.
+    ///
+    /// `veld doctor` prints this number, so it is a string a user pastes into an
+    /// issue and somebody reads a year later. It only means anything because rows
+    /// are append-only — nothing else pins that beyond row 0
+    /// (`org_key_1_holds_slot_zero_forever`), so a future edit that reordered the
+    /// table would silently renumber every key in every report already written.
+    #[test]
+    fn a_keys_position_is_its_row_and_never_moves() {
+        for (i, k) in ORG_KEYS.iter().enumerate() {
+            assert_eq!(
+                org_key_position(&k.key),
+                Some((i + 1, ORG_KEYS.len())),
+                "{} is row {i}, so it is org key {} of {}",
+                k.secret,
+                i + 1,
+                ORG_KEYS.len()
+            );
+        }
+        // A key this build does not carry has no position rather than a wrong one.
+        assert_eq!(org_key_position(&[0xAB; 32]), None);
+    }
+
+    /// `added_after` increases strictly down the table.
+    ///
+    /// **This is what stops the two-release guard being defeated by a paste.** That
+    /// guard compares each row's date against `Cargo.toml`'s version, so any *stale*
+    /// value in a newly added row slips past it — and the two most available stale
+    /// values are sitting in the table being edited: row 0's `0.0.0`, and the
+    /// previous row's version. Requiring each row to be strictly later than the one
+    /// above refuses both, which leaves no value a hurried operator can copy.
+    ///
+    /// Strict rather than non-decreasing: two keys added in one release is two
+    /// rotations at once, which the runbook does not describe and nobody should do
+    /// by accident. It costs nothing to forbid and it closes the equal-to-previous
+    /// paste.
+    #[test]
+    fn added_after_increases_down_the_table() {
+        for pair in ORG_KEYS.windows(2) {
+            let (prev, next) = (&pair[0], &pair[1]);
+            // Parsed before comparing. `Option` orders `None < Some(_)`, so
+            // comparing them directly makes an unparseable value in the *earlier*
+            // row pass vacuously, and an unparseable one in the *later* row fail
+            // with a message about ordering rather than about parsing.
+            // `every_key_lifecycle_date_names_a_release_that_has_happened` is what
+            // rejects the unparseable value itself; this just refuses to guess.
+            let (Some(a), Some(b)) = (
+                version_parts(prev.added_after),
+                version_parts(next.added_after),
+            ) else {
+                continue;
+            };
+            assert!(
+                b > a,
+                "{}'s added_after ({:?}) is not later than {}'s ({:?}). Rows are \
+                 appended in order, so each one was written against a later release \
+                 than the one above it. If you copied this value from another row or \
+                 from row 0's 0.0.0, that is the paste this check exists to refuse — \
+                 use Cargo.toml's version",
+                next.secret,
+                next.added_after,
+                prev.secret,
+                prev.added_after
+            );
+        }
+    }
+
+    /// Every secret name fits the permanent roster in `release.yml`.
+    ///
+    /// That roster is `SIGNING_PRIVATE_KEY` plus `_2`..`_8`, written once and never
+    /// edited — which is the whole promise that rotating needs no workflow change.
+    /// A name outside it (`SIGNING_KEY_2026`, say) passes the prefix rule, then
+    /// fails `ci.yml` with "add an entry to that step's env:" — telling the operator
+    /// to do the one thing the runbook says they never have to. Caught here instead,
+    /// where the name is being chosen.
+    #[test]
+    fn every_secret_name_is_one_of_the_permanent_roster() {
+        for (i, k) in ORG_KEYS.iter().enumerate() {
+            let expected = if i == 0 {
+                "SIGNING_PRIVATE_KEY".to_owned()
+            } else {
+                format!("SIGNING_PRIVATE_KEY_{}", i + 1)
+            };
+            assert_eq!(
+                k.secret, expected,
+                "ORG_KEYS row {i} names {:?}, but release.yml's permanent roster \
+                 calls that slot {expected:?}. Names are positional: the roster is \
+                 written once to the format's slot ceiling and never edited, so a \
+                 row must take the name for its own position",
+                k.secret
+            );
+        }
+    }
+
+    /// Neither half of that rule may cite a release that has not happened.
+    ///
+    /// The fields are `Cargo.toml`'s version at the time of the edit, so a value
+    /// *newer* than this tree is not a mistake with a benign reading — it is the
+    /// shape a combined edit takes when somebody guesses at the version their merge
+    /// will ship as, which is exactly what the rule above is stopping.
+    #[test]
+    fn every_key_lifecycle_date_names_a_release_that_has_happened() {
+        let now = version_parts(env!("CARGO_PKG_VERSION")).expect("our own version parses");
+        for k in ORG_KEYS {
+            let mut dates = vec![("added_after", k.added_after)];
+            if let KeyStatus::Retired { retired_after } = k.status {
+                dates.push(("retired_after", retired_after));
+                // Both parsed first, for the same reason as above: an unparseable
+                // value must be diagnosed by the loop below, which says what is
+                // wrong with it, not here with "older than", which is not.
+                if let (Some(r), Some(a)) =
+                    (version_parts(retired_after), version_parts(k.added_after))
+                {
+                    assert!(
+                        r >= a,
+                        "{}: retired_after {retired_after:?} is older than added_after {:?}",
+                        k.secret,
+                        k.added_after
+                    );
+                }
+            }
+            for (field, value) in dates {
+                let parsed = version_parts(value).unwrap_or_else(|| {
+                    panic!(
+                        "{}'s {field} is {value:?}, which is not an x.y.z version. It is \
+                         Cargo.toml's version at the moment you made the edit — copy it \
+                         verbatim",
+                        k.secret
+                    )
+                });
+                assert!(
+                    parsed <= now,
+                    "{}'s {field} is {value:?}, which is newer than this tree ({}). These \
+                     fields record the release an edit was made AGAINST, and a pull \
+                     request cannot know the version it will itself ship as",
+                    k.secret,
+                    env!("CARGO_PKG_VERSION")
+                );
+            }
+        }
+    }
+
+    /// `x.y.z` as a comparable tuple, or `None` if it is not that shape.
+    fn version_parts(v: &str) -> Option<(u64, u64, u64)> {
+        let mut it = v.split('.');
+        let mut next = || it.next()?.parse::<u64>().ok();
+        let parsed = (next()?, next()?, next()?);
+        it.next().is_none().then_some(parsed)
     }
 
     /// **This is the load-bearing test of the whole slice.**
@@ -1225,28 +1852,34 @@ mod tests {
         assert_eq!(SIG_SLOT_LEN, 64);
     }
 
-    /// **A tripwire, not an invariant — delete it on the release that rotates.**
+    /// The artifact carries exactly one slot per row of [`ORG_KEYS`], and nothing
+    /// else.
     ///
-    /// It asserts that *today's* artifact is byte-identical to the pre-rotation
-    /// one, which is why this mechanism could ship with the format change carrying
-    /// no risk at all: `RELEASE_SIG_SLOTS` is 1, so `veld-sign` writes exactly the
-    /// 64 bytes it always wrote and no shipped helper has anything to notice.
+    /// **This replaces a tripwire, and the replacement is the point.** The previous
+    /// version asserted `RELEASE_SIG_SLOTS * SIG_SLOT_LEN == 64` — i.e. that no
+    /// rotation had happened yet — and its own doc comment told the operator to
+    /// delete it on the release that rotates. A procedure whose step 2 is "delete
+    /// this red test" is a procedure that rehearses deleting red tests on the worst
+    /// day available, next to two permanent invariants that look identical when the
+    /// whole file is red.
     ///
-    /// That stops being true the moment a second key is added, and it goes red for
-    /// a *correct* change — which is the same trap the retirement-day tripwire had
-    /// before it was split out, and it was found the same way: by performing a
-    /// simulated rotation against this file. It is alone in its own function so
-    /// that deleting it takes nothing else with it, and
-    /// `docs/signing-key-rotation.md` step 2 names it.
+    /// What it was actually protecting is that the signing artifact's shape does not
+    /// change by accident, and that is a *relation* between the writer and the
+    /// table — true before any rotation, true after every one, and red for a
+    /// writer that pads, reorders or drops a slot. So it never needs deleting
+    /// again.
     #[test]
-    fn no_rotation_has_happened_yet_so_the_artifact_is_unchanged() {
+    fn the_artifact_carries_exactly_one_slot_per_key() {
+        let keys: Vec<_> = (0..ORG_KEYS.len())
+            .map(|i| gen_key(i as u8 + 1).0)
+            .collect();
+        let refs: Vec<_> = keys.iter().collect();
         assert_eq!(
-            RELEASE_SIG_SLOTS * SIG_SLOT_LEN,
-            64,
-            "a second key has been added, so releases are no longer byte-identical \
-             to the pre-rotation shape. That is expected on a rotation — see \
-             docs/signing-key-rotation.md step 2, then delete THIS test and \
-             nothing else in this file"
+            slots(&refs, b"payload").len(),
+            ORG_KEYS.len() * SIG_SLOT_LEN,
+            "a release must carry one 64-byte slot per row of ORG_KEYS, with no \
+             padding and no holes: slot position is this format's only key \
+             identifier"
         );
     }
 
@@ -1358,27 +1991,10 @@ mod tests {
         );
     }
 
-    /// Nothing is retired yet, so `retired_keys()` is empty.
-    ///
-    /// **This is the one test the runbook's step 3 tells you to delete**, and it
-    /// is alone in its own function for that reason: it used to be bundled with
-    /// the two invariants below, and deleting a red test — the natural reaction
-    /// on the day the runbook itself says you are reading it under pressure —
-    /// would have taken both of them with it silently.
-    #[test]
-    fn nothing_is_retired_yet() {
-        assert!(
-            retired_keys().is_empty(),
-            "a key has left ORG_SIGNING_KEYRING while ORG_REQUIRED_SLOT_KEYS still \
-             names it — that is a retirement. Read docs/signing-key-rotation.md \
-             step 3, then delete THIS test and nothing else in this file"
-        );
-    }
-
     /// The keyring is never empty.
     ///
-    /// **Do not delete this one on retirement day.** The runbook's step 3 is
-    /// literally "remove `ORG_KEY_1` from `ORG_SIGNING_KEYRING`"; doing that on a
+    /// **Do not delete this one on retirement day.** The runbook's retirement is
+    /// one field — the last accepted row's `status`; doing that on a
     /// tree where step 2 was skipped, reverted or mis-merged ships a helper that
     /// trusts nothing — every candidate refused, every relaunch refused, `restart`
     /// and `shutdown` refused, and sudo the only repair. Which is the wedged
@@ -1586,7 +2202,7 @@ mod tests {
                 "{len} bytes is a torn write, not an unreadable path"
             );
             assert_eq!(
-                classify_binary_signature_once(&binary, 4096),
+                classify_binary_signature_once(&binary, 4096).map(|v| v.trust),
                 Some(SigTrust::Untrusted),
                 "{len} bytes must be a verdict, so the retry applies"
             );
@@ -1652,7 +2268,8 @@ mod tests {
             classify_with_retry(|| {
                 calls += 1;
                 None
-            }),
+            })
+            .trust,
             SigTrust::Untrusted
         );
         assert_eq!(calls, 1, "an unreadable path must not get a second race");
@@ -1662,8 +2279,9 @@ mod tests {
         assert_eq!(
             classify_with_retry(|| {
                 calls += 1;
-                Some(SigTrust::Untrusted)
-            }),
+                Some(verdict(SigTrust::Untrusted))
+            })
+            .trust,
             SigTrust::Untrusted
         );
         assert_eq!(calls, 2, "the tear is what the retry is for");
@@ -1674,26 +2292,28 @@ mod tests {
             classify_with_retry(|| {
                 calls += 1;
                 if calls == 1 {
-                    Some(SigTrust::Untrusted)
+                    Some(verdict(SigTrust::Untrusted))
                 } else {
-                    Some(SigTrust::Active)
+                    Some(verdict(SigTrust::Active))
                 }
-            }),
+            })
+            .trust,
             SigTrust::Active
         );
         assert_eq!(calls, 2);
 
         // A settled verdict is never re-read, whichever it is.
-        for verdict in [SigTrust::Active, SigTrust::RetiredOnly] {
+        for trust in [SigTrust::Active, SigTrust::RetiredOnly] {
             let mut calls = 0;
             assert_eq!(
                 classify_with_retry(|| {
                     calls += 1;
-                    Some(verdict)
-                }),
-                verdict
+                    Some(verdict(trust))
+                })
+                .trust,
+                trust
             );
-            assert_eq!(calls, 1, "{verdict:?} is settled on the first pass");
+            assert_eq!(calls, 1, "{trust:?} is settled on the first pass");
         }
 
         // A second pass that cannot read falls back to the refusal rather than
@@ -1703,11 +2323,12 @@ mod tests {
             classify_with_retry(|| {
                 calls += 1;
                 if calls == 1 {
-                    Some(SigTrust::Untrusted)
+                    Some(verdict(SigTrust::Untrusted))
                 } else {
                     None
                 }
-            }),
+            })
+            .trust,
             SigTrust::Untrusted
         );
         assert_eq!(calls, 2);

--- a/crates/veld-sign/src/main.rs
+++ b/crates/veld-sign/src/main.rs
@@ -14,6 +14,18 @@
 //! first, because a wrong key in a later slot ships invisibly and wedges the whole
 //! fleet one release afterwards.
 //!
+//! **`--slots <hex>=<VAR>,…` is the release path**, and it is exactly one
+//! `--key-env <VAR>` per entry plus an `--expect-slot-pubkeys` of the hex halves —
+//! `slots_is_the_same_signature_as_key_env_plus_expected_pubkeys` pins the
+//! equivalence, which is what lets every guard here be written against the older
+//! spelling and still cover the path that ships. It exists because `release.yml`
+//! **derives** that whole argument from `veld_core::signing::ORG_KEYS` at build
+//! time instead of carrying a hand-edited copy: rotating a key is then a source
+//! edit and a new secret, with no workflow edit at all. Pairing the expected key
+//! with the variable that supplies it in one token is what makes the derivation
+//! safe — the two cannot drift apart, and an entry that went missing cannot shift
+//! every later key one slot to the left, which would move slot 0.
+//!
 //! The running root helper (`veld-helper`) verifies that signature against the
 //! keys **it** has compiled in — any slot under any of them — before ever
 //! relaunching onto a changed on-disk binary (see
@@ -59,8 +71,8 @@ use std::process::ExitCode;
 use ed25519_dalek::Signer;
 use ed25519_dalek::pkcs8::DecodePrivateKey;
 
-const USAGE: &str = "usage: veld-sign (--key-env <VAR> | --key-file <path>)... \
-[--expect-slot-pubkeys <hex>[,<hex>...]] <binary>";
+const USAGE: &str = "usage: veld-sign (--slots <hex>=<VAR>[,<hex>=<VAR>...] | \
+(--key-env <VAR> | --key-file <path>)... [--expect-slot-pubkeys <hex>[,<hex>...]]) <binary>";
 
 /// Most keys this will sign with, and therefore most slots it will write.
 ///
@@ -785,6 +797,7 @@ fn sig_path_for(binary: &Path) -> PathBuf {
 fn main() -> ExitCode {
     let mut sources: Vec<KeySource> = Vec::new();
     let mut expect_slots: Option<Vec<String>> = None;
+    let mut slots_given = false;
     let mut binary: Option<PathBuf> = None;
 
     let mut args = std::env::args().skip(1);
@@ -810,6 +823,12 @@ fn main() -> ExitCode {
                 // would be silently ignored — which is the shape of mistake that
                 // puts the wrong key in a slot, the one thing this flag exists to
                 // catch.
+                Some(_) if slots_given => {
+                    return usage(
+                        "--slots already carries the expected key for every slot; \
+                         do not also pass --expect-slot-pubkeys",
+                    );
+                }
                 Some(_) if expect_slots.is_some() => {
                     return usage(
                         "--expect-slot-pubkeys may be given only once; it takes a \
@@ -818,6 +837,66 @@ fn main() -> ExitCode {
                 }
                 Some(v) => expect_slots = Some(v.split(',').map(|h| h.trim().to_owned()).collect()),
                 None => return usage("--expect-slot-pubkeys requires a value"),
+            },
+            // The whole slot layout as one argument: `<expected pubkey>=<VAR>`,
+            // comma-separated, in slot order. Exactly equivalent to one `--key-env
+            // <VAR>` per entry plus an `--expect-slot-pubkeys` of the hex halves —
+            // and that equivalence is the point, so every guard below, and every
+            // test of them, covers this path unchanged.
+            //
+            // It exists because `release.yml` **derives** this argument from
+            // `veld_core::signing::ORG_KEYS` at build time instead of carrying a
+            // hand-edited copy. Pairing each expected key with the secret that
+            // signs its slot in ONE token is what makes that derivation safe: the
+            // two halves cannot drift out of step with each other, and a missing
+            // secret cannot silently shift every later key one slot to the left —
+            // which would re-shear slot 0, the one thing the format cannot survive.
+            "--slots" => match args.next() {
+                // Refused a second time for the same reason
+                // `--expect-slot-pubkeys` is: a step carrying two is a
+                // half-finished edit whose first list would be silently ignored.
+                Some(_) if slots_given => {
+                    return usage(
+                        "--slots may be given only once; it takes a comma-separated \
+                         list of <hex>=<VAR>, one per slot, in slot order",
+                    );
+                }
+                Some(v) => {
+                    slots_given = true;
+                    if expect_slots.is_some() {
+                        return usage(
+                            "--slots already carries the expected key for every slot; \
+                             do not also pass --expect-slot-pubkeys",
+                        );
+                    }
+                    let mut expected = Vec::new();
+                    for entry in v.split(',') {
+                        // `split_once`, not `split`: a hex key cannot contain `=`,
+                        // so the first one is the separator. A *second* `=` is
+                        // absorbed into the variable name rather than refused —
+                        // exactly as `--key-env "V=X"` would be, so the two
+                        // spellings stay equivalent. Nothing automated can produce
+                        // one: `tests/signing-slots.py` holds every secret name to
+                        // an environment-variable charset.
+                        let Some((hex, var)) = entry.trim().split_once('=') else {
+                            // Neither half is echoed. The right half could be a
+                            // variable name, but the left half is 64 characters that
+                            // this tool cannot tell apart from a hex-encoded private
+                            // seed — and an entry that failed to split is one whose
+                            // halves are not identified at all.
+                            return usage(
+                                "every --slots entry must be written <hex>=<VAR>: the \
+                                 expected 32-byte public key as 64 hexadecimal \
+                                 characters, then the name of the environment \
+                                 variable holding that key's PKCS#8 PEM",
+                            );
+                        };
+                        expected.push(hex.trim().to_owned());
+                        sources.push(KeySource::Env(var.trim().to_owned()));
+                    }
+                    expect_slots = Some(expected);
+                }
+                None => return usage("--slots requires a value"),
             },
             // A PEM begins with `-`, so a key handed over positionally lands
             // here rather than as the <binary> argument.
@@ -834,7 +913,18 @@ fn main() -> ExitCode {
     };
 
     if sources.is_empty() {
-        return usage("provide --key-env or --key-file");
+        return usage("provide --slots, --key-env or --key-file");
+    }
+    // `--slots` carries the whole layout, so anything adding to `sources` beside it
+    // is a half-finished edit. Refused by name rather than left to the count check
+    // below, which would report "--expect-slot-pubkeys names 1 key(s) but 2 were
+    // given" — naming a flag the caller never passed, on a release path where the
+    // first place anyone looks is the signing secret.
+    if slots_given && sources.len() != expect_slots.as_ref().map_or(0, Vec::len) {
+        return usage(
+            "--slots carries every slot's key and secret; do not also pass --key-env \
+             or --key-file",
+        );
     }
     // Kept a usage error, as it always was. With one key it meant "which one?";
     // with several the order would answer that, but a step naming both flags is
@@ -883,13 +973,29 @@ fn main() -> ExitCode {
             .iter()
             .all(|h| h.len() == 64 && h.chars().all(|c| c.is_ascii_hexdigit()))
     {
-        return usage(
-            "every entry in --expect-slot-pubkeys needs exactly 64 hexadecimal characters (a \
-             raw 32-byte ed25519 public key), comma-separated in slot order. No value is \
-             repeated here because a 64-character hex argument cannot be told apart from a \
-             private seed; derive each one with `openssl pkey -in <key>.pem -pubout -outform \
-             DER | tail -c 32 | xxd -p -c 32`",
-        );
+        // Blamed on the flag the caller actually passed. `--slots` desugars into
+        // this list, so without the branch a mistyped `<hex>=<VAR>` was reported as
+        // a malformed `--expect-slot-pubkeys`, describing a comma-separated shape
+        // the caller never wrote. Same class as the `--slots`-plus-key-flag case
+        // above: a message naming a flag nobody passed sends the reader to the
+        // signing secret, which is the expensive place to look first.
+        let derive = "derive each one with `openssl pkey -in <key>.pem -pubout -outform DER \
+                      | tail -c 32 | xxd -p -c 32`";
+        return usage(&if slots_given {
+            format!(
+                "the key half of every --slots entry needs exactly 64 hexadecimal characters \
+                 (a raw 32-byte ed25519 public key), written <hex>=<VAR>. No value is repeated \
+                 here because a 64-character hex argument cannot be told apart from a private \
+                 seed; {derive}"
+            )
+        } else {
+            format!(
+                "every entry in --expect-slot-pubkeys needs exactly 64 hexadecimal characters \
+                 (a raw 32-byte ed25519 public key), comma-separated in slot order. No value \
+                 is repeated here because a 64-character hex argument cannot be told apart \
+                 from a private seed; {derive}"
+            )
+        });
     }
 
     // Read every key before signing anything, so a failure on the last one costs

--- a/crates/veld-sign/tests/smoke.rs
+++ b/crates/veld-sign/tests/smoke.rs
@@ -1109,3 +1109,235 @@ fn adhoc_sign(path: &Path) {
         stderr_of(&out)
     );
 }
+
+/// `--slots` is exactly `--key-env` per entry plus `--expect-slot-pubkeys`.
+///
+/// This is the flag `release.yml` uses, and it uses it because the whole argument
+/// is **derived** from `veld_core::signing::ORG_KEYS` at build time rather than
+/// hand-edited — which is what removed all three of the workflow edits a rotation
+/// used to need. The equivalence is what makes that safe to rely on: every guard
+/// in this file is written against the older spelling, and they only cover the
+/// release path if the two spellings really do produce the same thing.
+#[test]
+fn slots_is_the_same_signature_as_key_env_plus_expected_pubkeys() {
+    let dir = scratch("slots-flag");
+    let binary = dir.join("veld-helper");
+    let payload = b"macho/elf payload signed two ways";
+    std::fs::write(&binary, payload).unwrap();
+
+    let keys: Vec<SigningKey> = (0..3).map(|_| throwaway_key()).collect();
+    let vars: Vec<String> = (0..3).map(|i| format!("SIGNING_PRIVATE_KEY_{i}")).collect();
+    let spec = keys
+        .iter()
+        .zip(&vars)
+        .map(|(k, v)| format!("{}={v}", pubkey_hex(k)))
+        .collect::<Vec<_>>()
+        .join(",");
+
+    let mut cmd = veld_sign();
+    cmd.args(["--slots", &spec]).arg(&binary);
+    for (k, v) in keys.iter().zip(&vars) {
+        cmd.env(v, k.to_pkcs8_pem(LineEnding::LF).unwrap().as_str());
+    }
+    let out = cmd.output().expect("run veld-sign");
+    assert!(out.status.success(), "signing failed: {}", stderr_of(&out));
+
+    let via_slots = std::fs::read(sig_path_for(&binary)).expect("signature written");
+    assert_eq!(via_slots.len(), 3 * SIG_SLOT_LEN);
+
+    // The same three keys through the older spelling must produce the same bytes.
+    let mut cmd = veld_sign();
+    for v in &vars {
+        cmd.args(["--key-env", v]);
+    }
+    cmd.args([
+        "--expect-slot-pubkeys",
+        &keys.iter().map(pubkey_hex).collect::<Vec<_>>().join(","),
+    ])
+    .arg(&binary);
+    for (k, v) in keys.iter().zip(&vars) {
+        cmd.env(v, k.to_pkcs8_pem(LineEnding::LF).unwrap().as_str());
+    }
+    let out = cmd.output().expect("run veld-sign");
+    assert!(out.status.success(), "signing failed: {}", stderr_of(&out));
+    let via_flags = std::fs::read(sig_path_for(&binary)).expect("signature written");
+    assert_eq!(
+        via_slots, via_flags,
+        "--slots must produce byte-identical output to the flags it stands for"
+    );
+
+    // And slot order is entry order, which is the compatibility contract.
+    for (i, key) in keys.iter().enumerate() {
+        let slot = &via_slots[i * SIG_SLOT_LEN..(i + 1) * SIG_SLOT_LEN];
+        assert!(
+            verify_data(&key.verifying_key().to_bytes(), payload, slot),
+            "slot {i} is not signed by --slots entry {i}"
+        );
+    }
+}
+
+/// A `--slots` entry whose secret holds a different key fails, naming neither.
+///
+/// The wrong-secret guard, reached through the release path. It is the check
+/// nothing else in the pipeline can make: a signature by a valid-but-unintended key
+/// is indistinguishable from a correct one without knowing which key was meant.
+#[test]
+fn a_slots_entry_whose_secret_holds_another_key_is_refused() {
+    let dir = scratch("slots-wrong-key");
+    let binary = dir.join("veld-helper");
+    std::fs::write(&binary, b"payload").unwrap();
+
+    let meant = throwaway_key();
+    let actual = throwaway_key();
+    let out = veld_sign()
+        .args([
+            "--slots",
+            &format!("{}=SIGNING_PRIVATE_KEY", pubkey_hex(&meant)),
+        ])
+        .arg(&binary)
+        .env(
+            "SIGNING_PRIVATE_KEY",
+            actual.to_pkcs8_pem(LineEnding::LF).unwrap().as_str(),
+        )
+        .output()
+        .expect("run veld-sign");
+
+    assert!(!out.status.success(), "a wrong key must fail the release");
+    assert!(
+        !sig_path_for(&binary).exists(),
+        "no .sig may be written when any slot's key is wrong"
+    );
+    let err = stderr_of(&out);
+    // The key the secret turned out to hold IS named — a public key, and the only
+    // way an operator can tell which key a secret holds without reading it. The
+    // **expected** value is not, because 64 hex characters cannot be told apart
+    // from a private seed, and neither is any part of the PEM.
+    assert!(
+        err.contains(&pubkey_hex(&actual)),
+        "the found public key is what tells the operator which key the secret \
+         holds: {err}"
+    );
+    assert!(
+        !err.contains(&pubkey_hex(&meant)),
+        "the expected value must never be echoed: {err}"
+    );
+    for line in actual
+        .to_pkcs8_pem(LineEnding::LF)
+        .unwrap()
+        .lines()
+        .filter(|l| !l.starts_with("-----"))
+    {
+        assert!(!err.contains(line), "veld-sign echoed key material: {err}");
+    }
+}
+
+/// A malformed `--slots` argument is a usage error that echoes neither half.
+///
+/// The left half of an entry is 64 characters this tool cannot tell apart from a
+/// hex-encoded private seed, and an entry that failed to split is one whose halves
+/// are not identified at all — so nothing from it is quoted back.
+#[test]
+fn a_malformed_slots_entry_echoes_nothing_from_it() {
+    let dir = scratch("slots-malformed");
+    let binary = dir.join("veld-helper");
+    std::fs::write(&binary, b"payload").unwrap();
+
+    let key = throwaway_key();
+    let pem = key.to_pkcs8_pem(LineEnding::LF).unwrap().to_string();
+    // No `=`: the whole entry is unidentified, and here it happens to be a PEM.
+    let out = veld_sign()
+        .args(["--slots", pem.trim()])
+        .arg(&binary)
+        .output()
+        .expect("run veld-sign");
+
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "a bad command line is EXIT_USAGE"
+    );
+    let err = stderr_of(&out);
+    for line in pem.lines().filter(|l| !l.starts_with("-----")) {
+        assert!(
+            !err.contains(line),
+            "veld-sign echoed a --slots entry: {err}"
+        );
+    }
+    assert!(
+        !sig_path_for(&binary).exists(),
+        "a usage error must not reach the signing path at all"
+    );
+}
+
+/// `--slots` and `--expect-slot-pubkeys` together is a usage error, in both orders.
+///
+/// `--slots` already carries the expected key for every slot. A step passing both
+/// is a half-finished edit, and letting one silently win is how a slot ends up
+/// checked against the wrong key — the mistake the expected list exists to catch.
+#[test]
+fn slots_and_expect_slot_pubkeys_together_is_refused() {
+    let dir = scratch("slots-both");
+    let binary = dir.join("veld-helper");
+    std::fs::write(&binary, b"payload").unwrap();
+    let hex = pubkey_hex(&throwaway_key());
+
+    for args in [
+        vec![
+            "--slots".to_owned(),
+            format!("{hex}=SIGNING_PRIVATE_KEY"),
+            "--expect-slot-pubkeys".to_owned(),
+            hex.clone(),
+        ],
+        vec![
+            "--expect-slot-pubkeys".to_owned(),
+            hex.clone(),
+            "--slots".to_owned(),
+            format!("{hex}=SIGNING_PRIVATE_KEY"),
+        ],
+    ] {
+        let out = veld_sign()
+            .args(&args)
+            .arg(&binary)
+            .output()
+            .expect("run veld-sign");
+        assert_eq!(
+            out.status.code(),
+            Some(2),
+            "both flags together must be EXIT_USAGE: {}",
+            stderr_of(&out)
+        );
+    }
+}
+
+/// `--slots` plus `--key-env` is a usage error that says so.
+///
+/// `--slots` carries every slot's key and secret, so a `--key-env` beside it is a
+/// half-finished edit. Without its own message it fell through to the count check
+/// and reported `--expect-slot-pubkeys names 1 key(s) but 2 were given` — naming a
+/// flag the caller never passed, on a release path where the first thing anyone
+/// suspects is the signing secret.
+#[test]
+fn slots_mixed_with_a_key_flag_names_the_right_flag() {
+    let dir = scratch("slots-mixed");
+    let binary = dir.join("veld-helper");
+    std::fs::write(&binary, b"payload").unwrap();
+    let hex = pubkey_hex(&throwaway_key());
+
+    for extra in [
+        vec!["--key-env".to_owned(), "SIGNING_PRIVATE_KEY_2".to_owned()],
+        vec!["--key-file".to_owned(), "/etc/veld/signing.pem".to_owned()],
+    ] {
+        let out = veld_sign()
+            .args(["--slots", &format!("{hex}=SIGNING_PRIVATE_KEY")])
+            .args(&extra)
+            .arg(&binary)
+            .output()
+            .expect("run veld-sign");
+        let err = stderr_of(&out);
+        assert_eq!(out.status.code(), Some(2), "must be EXIT_USAGE: {err}");
+        assert!(
+            err.contains("--slots carries every slot's key and secret"),
+            "the message must name --slots, not the flag the caller never passed: {err}"
+        );
+    }
+}

--- a/crates/veld/src/commands/doctor.rs
+++ b/crates/veld/src/commands/doctor.rs
@@ -682,11 +682,24 @@ impl Diagnostics {
             // can disagree if an update lands between them, splicing the
             // retired-key sentence into the middle of the tampering paragraph or
             // printing "not signed" for a file that now verifies.
-            let verdict = veld_core::signing::classify_binary_signature(&path);
-            match verdict {
+            let verdict = veld_core::signing::classify_binary_signature_detail(&path);
+            match verdict.trust {
+                // Names the key, not just the verdict. During a rotation a helper's
+                // keyring and a release's slots move at different times, and "OK" is
+                // the same word whether this machine is on the key before the
+                // rotation or the one after — so the one row that could say where in
+                // the window a machine sits used to say nothing. The number is the
+                // key's row in `ORG_KEYS`, which is permanent: rows are appended and
+                // never reordered, so "org key 2 of 3" in an issue means the same
+                // thing a year later. Public keys, so there is nothing here that
+                // must not be printed.
                 veld_core::signing::SigTrust::Active => self.checks.push(Check {
                     pass: true,
-                    label: format!("Helper binary signature OK ({})", tilde_path(&path)),
+                    label: format!(
+                        "Helper binary signature OK ({}, signed by {})",
+                        tilde_path(&path),
+                        describe_org_key(verdict.key)
+                    ),
                 }),
                 // Says what *this CLI* concluded, not what the running helper will
                 // do. The two can disagree: this row is judged against the key list
@@ -698,8 +711,8 @@ impl Diagnostics {
                 veld_core::signing::SigTrust::RetiredOnly => self.checks.push(Check {
                     pass: false,
                     label: format!(
-                        "The helper at {} is signed with an org key that THIS veld ({}) has \
-                         retired. The binary itself is genuine: this happens when the helper \
+                        "The helper at {} is signed with {}, an org key that THIS veld ({}) \
+                         has retired. The binary itself is genuine: this happens when the helper \
                          that installed it predated key rotation and kept only the first \
                          signature slot. If the running helper is this same release it will \
                          refuse to relaunch onto it, and refuse `restart` and `shutdown`, until \
@@ -707,6 +720,7 @@ impl Diagnostics {
                          with `{}` — no password, and not `veld update`, which does nothing when \
                          you are already on the latest release",
                         tilde_path(&path),
+                        describe_org_key(verdict.key),
                         env!("CARGO_PKG_VERSION"),
                         veld_core::signing::INSTALLER_COMMAND
                     ),
@@ -1952,6 +1966,30 @@ fn helper_dir_is_locked(helper: &Path) -> bool {
     helper
         .parent()
         .is_some_and(veld_core::helper_store::is_root_owned_and_locked)
+}
+
+/// Name an org signing key for a `veld doctor` row.
+///
+/// `org key 2 of 3` — the position in `veld_core::signing::ORG_KEYS`, which is the
+/// key's permanent identity (rows are appended, never reordered), plus a short hex
+/// prefix so the row can be matched against the table without counting. Public
+/// keys, so none of this is material that must not be printed.
+///
+/// `None` reaches here only for a verdict that verified under nothing, which the
+/// callers below do not pass; the fallback exists so a future third caller cannot
+/// print an empty parenthesis.
+fn describe_org_key(key: Option<veld_core::signing::PubKey>) -> String {
+    let Some(key) = key else {
+        return "no org key".to_owned();
+    };
+    let hex: String = key.iter().take(4).map(|b| format!("{b:02x}")).collect();
+    match veld_core::signing::org_key_position(&key) {
+        Some((n, total)) => format!("org key {n} of {total} ({hex}\u{2026})"),
+        // A key that verified but is not in this build's table cannot happen: the
+        // keyring IS the table. Reported rather than unwrapped, because the honest
+        // answer to "this should not happen" is to print what was seen.
+        None => format!("an org key not in this build's table ({hex}\u{2026})"),
+    }
 }
 
 fn tilde_path(path: &Path) -> String {

--- a/docs/signing-key-rotation.md
+++ b/docs/signing-key-rotation.md
@@ -16,35 +16,302 @@ the operating manual.
 > is asking every user to run `sudo`. That is the outcome the whole #338 chain
 > exists to prevent, and this is the mechanism most able to cause it.
 
-## The 60-second version
+## The whole rotation, in order
+
+**Two releases. Never one.** This list is complete on its own — everything below it
+is the reasoning, not more steps. Every step here was executed against this repo,
+twice in a row, before it was written down.
+
+> A note on numbering, because a comment in the source will send you looking. The
+> `## Step 1/2/3` headings further down are the **three phases** — make the key,
+> add it, retire the old one — and that is what "step 2" or "step 3" means wherever
+> `crates/veld-core/src/signing.rs` and `.github/workflows/ci.yml` mention one. The
+> numbers in the list below are just the order of doing things. They are not the
+> same numbering, and nothing outside this file refers to them.
+>
+> Test-failure messages name **tests**, never step numbers, precisely so that this
+> cannot go stale: grep the name the failure gives you.
+
+Against the four-edits-plus-two-test-deletions procedure this replaces, what a
+rotation costs now:
+
+| | before | now |
+|---|---|---|
+| `crates/veld-core/src/signing.rs` | 3 edits (key constant, two lists, slot count) | **1 row appended** |
+| `.github/workflows/release.yml` | 3 edits (`--key-env`, its `env:` entry, the expected-key hex) | **none** |
+| tests to delete | 2, one per release | **none** |
+| GitHub secrets to set | 1 | 1 |
+| releases | 2 | 2 |
+
+### Release 1 — teach every helper the new key
+
+**1. Make the key, on a machine that is not the one that leaked.** macOS's
+`/usr/bin/openssl` is LibreSSL and **cannot do this**; use an OpenSSL 3.
 
 ```sh
-# 1. Generate the new key, air-gapped, and add its private half as a NEW secret.
-#    macOS's /usr/bin/openssl is LibreSSL and CANNOT do this — see step 1.
-openssl genpkey -algorithm ed25519 -out veld-signing-2.pem
-openssl pkey -in veld-signing-2.pem -pubout -outform DER | tail -c 32 | xxd -p -c 32
+OPENSSL=/opt/homebrew/opt/openssl@3/bin/openssl   # Intel Mac: /usr/local/opt/openssl@3/bin/openssl
+                                                  # Linux: openssl
+"$OPENSSL" version                                # must say OpenSSL, not LibreSSL
 
-# 2. ONE release that ADDS it — FOUR edits:
-#    - crates/veld-core/src/signing.rs: add ORG_KEY_2, put it in BOTH
-#      ORG_SIGNING_KEYRING and ORG_REQUIRED_SLOT_KEYS, bump RELEASE_SIG_SLOTS to 2
-#    - .github/workflows/release.yml: a second --key-env line BELOW the first
-#    - .github/workflows/release.yml: the matching entry in that step's env:
-#      block. Easy to miss; veld-sign reads a key by variable NAME, so a flag
-#      with no env: entry looks exactly like an unset secret.
-#    - .github/workflows/release.yml: APPEND the new public key hex to
-#      --expect-slot-pubkeys, comma-separated, in slot order. Not optional:
-#      it is what stops a secret holding the wrong key shipping invisibly.
-#    Then: cargo fmt --all, and delete ONE test —
-#    no_rotation_has_happened_yet_so_the_artifact_is_unchanged — and nothing
-#    else. Step 2 below says why.
-#
-# 3. Wait for that release to reach the fleet. Then a SECOND release that RETIRES
-#    the old key: remove ORG_KEY_1 from ORG_SIGNING_KEYRING only. It stays in
-#    ORG_REQUIRED_SLOT_KEYS and keeps its slot.
+"$OPENSSL" genpkey -algorithm ed25519 -out "$PWD/veld-signing-2.pem"
+"$OPENSSL" pkey -in "$PWD/veld-signing-2.pem" -pubout -outform DER \
+  | tail -c 32 | xxd -p -c 32
 ```
 
-Two releases. Never one. The reason is in [Why retirement is a separate
+That hex is the **new public key**. You paste it once, into the key constant in
+step 4. The same 32 bytes in the form `signing.rs` wants:
+
+```sh
+python3 -c "
+import sys, textwrap
+h = sys.argv[1]
+print(chr(10).join(textwrap.wrap(', '.join(f'0x{h[i:i+2]}' for i in range(0, len(h), 2)), 96)))
+" <the hex>
+```
+
+**2. Put the private half in the org vault, beside the original key.** Before the
+GitHub secret, not after. A repository secret **cannot be read back**, so the vault
+is the only copy anything can ever recover — and a retired key's slot keeps being
+signed forever (step 9), so losing its private half is a flag day, not an
+inconvenience. Delete the local `.pem` once the vault has it and the secret in
+step 3 is set.
+
+**3. Put the private half in a GitHub secret named `SIGNING_PRIVATE_KEY_2`.** This
+is the only step that is not a code change, and it needs **repository admin**. It
+is a **repository** secret — not an environment secret, not an org secret;
+`release.yml`'s `build` job has no `environment:`, so an environment secret would
+simply not be there.
+
+```sh
+# The whole PEM, including the BEGIN/END lines. `gh` reads the file, so nothing
+# lands in your shell history.
+gh secret set SIGNING_PRIVATE_KEY_2 < "$PWD/veld-signing-2.pem"
+
+gh secret list          # you see the NAME and a timestamp; never the value
+```
+
+By hand instead: **Settings → Secrets and variables → Actions → New repository
+secret**. Name `SIGNING_PRIVATE_KEY_2`, value = the entire file contents.
+
+**The name is not yours to choose, and it is not descriptive — it is positional.**
+`release.yml` carries a permanent roster of eight names,
+`SIGNING_PRIVATE_KEY` through `SIGNING_PRIVATE_KEY_8`, written once and never
+edited again. Take the next free number. Three things follow:
+
+- **Never re-upload `SIGNING_PRIVATE_KEY`.** It holds the org's *original* key and
+  it is slot 0, which every helper shipped up to v16.59.0 verifies bytes `0..64`
+  against and nothing else. Overwriting it is the single most expensive mistake
+  available in this procedure.
+- **Do not invent a name like `SIGNING_PRIVATE_KEY_OLD`.** A name relative to *now*
+  reads as the obvious scheme and is fatal on the **second** rotation: the second
+  key would land in slot 0, where no already-shipped helper has ever trusted it,
+  and the original key would have no slot at all. Positional names cannot do that.
+- **Setting the secret early is safe.** Nothing reads it until step 4's row names
+  it, so
+  releases in between are unaffected.
+
+**You cannot read a secret back**, so nothing can confirm the upload by inspection.
+What confirms it is the expected-key check at the **release** — step 7, after the
+merge, because that is the only moment anything can read the secret. If it holds a
+different key the release fails rather than publishing an artifact no installed
+helper would accept. **A green pull request says nothing about the secret**, which
+is why the local probe below is worth the one command. Check the file itself first — this is the last moment it is
+inspectable. **Run it from your veld checkout** (`-p veld-sign` resolves through
+the workspace):
+
+```sh
+# An ABSOLUTE path to the key: step 1 may have made it on another machine, and this
+# has to run from your veld checkout. The probe target needs a `.` in its name —
+# veld-sign will not print a path segment that could be a chunk of encoded key
+# material, so a bare /tmp/probe comes back as `<redacted: …>` in the SUCCESS line.
+printf 'x' > /tmp/veld-probe.bin
+cargo run -q -p veld-sign -- --key-file /absolute/path/to/veld-signing-2.pem \
+  /tmp/veld-probe.bin
+```
+
+It prints the public key of each slot it signed. That hex must equal the one from
+step 1. Any other outcome — wrong PEM label, encrypted key, OpenSSH format, a
+byte-order mark, the `.pub` by mistake — is named exactly by the error.
+
+**4. Append one row to `ORG_KEYS` in `crates/veld-core/src/signing.rs`.** This is
+the entire code change, and it is the only edit a rotation makes:
+
+```rust
+pub const ORG_KEY_2: PubKey = [
+    /* the 32 bytes from step 1 */
+];
+
+pub const ORG_KEYS: &[OrgKey] = &[
+    OrgKey {
+        key: ORG_KEY_1,
+        secret: "SIGNING_PRIVATE_KEY",
+        added_after: "0.0.0",
+        status: KeyStatus::Accepted,
+    },
+    OrgKey {
+        key: ORG_KEY_2,
+        secret: "SIGNING_PRIVATE_KEY_2",
+        // Cargo.toml's `version` right now — read it, do not copy this line.
+        added_after: "<Cargo.toml's version>",
+        status: KeyStatus::Accepted,
+    },
+];
+```
+
+**Append. Never reorder, never delete a row.** A row's position in this table *is*
+its slot in `<binary>.sig`, and slot position is the format's only key identifier.
+
+`added_after` is `Cargo.toml`'s `version` at the moment you write the row — the
+last release before the one this change will become. You can always know it, and
+that is what makes it useful: `Cargo.toml` still holds the *previous* release until
+semantic-release bumps it after your merge, so it is the one thing about the future
+release you can state truthfully. [The two-release rule, and its
+guard](#the-two-release-rule-and-its-guard) is what it is for.
+
+**5. `cargo fmt --all`.** A hand-written 32-byte array will not match rustfmt, and
+CI's `fmt --check` is a hard failure.
+
+**6. Open the pull request. Nothing else needs editing — check that nothing was.**
+
+```sh
+cargo test --workspace          # no test is deleted by a rotation any more
+python3 tests/signing-slots.py  # what release.yml will pass to veld-sign
+git status --short              # signing.rs, and nothing else
+```
+
+`tests/signing-slots.py` prints `<public key>=<secret name>` per slot, in slot
+order. Read it: the first entry must still be the original key and
+`SIGNING_PRIVATE_KEY`, and the new entry's hex must match step 1. That string is
+literally what `release.yml` hands `veld-sign`, derived from the table you just
+edited — which is why there is nothing to edit in the workflow, and why the
+workflow and the source cannot disagree.
+
+If something *is* wrong, a gate names the edit you missed. The ones you can hit:
+a secret name the permanent roster does not carry; a table row this repo's parser
+cannot read; `ORG_KEY_1` no longer first; two rows sharing a key or a secret; a
+secret name without the `SIGNING_` prefix the leak gate matches on.
+
+**7. Merge — and `feat:` or `fix:` in the squashed subject, or nothing ships.**
+Merging **is** releasing here: semantic-release cuts the version from the commit
+subject. A `chore:` or `docs:` subject publishes nothing, silently, with CI green,
+and you will believe the key is deployed when it is not. Check the Releases page
+before you go any further.
+
+At the release, `veld-sign` prints one line per slot naming the public key it
+signed with. That log is the record of which keys a published artifact is
+verifiable under.
+
+After this release:
+
+- helpers still on the old release accept it via slot 0 (the original key), install
+  it, and relaunch onto it — nothing is asked of any user;
+- helpers on this release accept anything signed by either key;
+- `veld doctor` on a machine that has taken it says which key verified — `signed by
+  org key 2 of 2`, the row number in `ORG_KEYS`.
+
+Nothing is retired yet, and nothing is safe yet. The leaked key still works. That
+is the point of the step: it moves the *knowledge* of the new key onto machines,
+using the only channel those machines trust.
+
+### Release 2 — stop accepting the old key
+
+**8. Wait.** Until you are willing to say the previous release has reached the
+machines you care about. There is no telemetry and this is not a check you can
+automate — see [Why retirement is a separate
 release](#why-retirement-is-a-separate-release).
+
+**9. Change the old key's `status`, in a second pull request.** One field:
+
+```rust
+    OrgKey {
+        key: ORG_KEY_1,
+        secret: "SIGNING_PRIVATE_KEY",
+        added_after: "0.0.0",
+        status: KeyStatus::Retired {
+            // Cargo.toml's `version` right now — which, because release 1 has
+            // shipped, is no longer what release 1's row says.
+            retired_after: "<Cargo.toml's version>",
+        },
+    },
+```
+
+The row stays. Its slot keeps being produced — harmless, since anyone holding the
+old key already holds it — and helpers on this release stop *accepting* it. Then
+`cargo fmt --all`, and `cargo test --workspace`, which is green: **no test is
+deleted here either.**
+
+> **Never delete a retired key's GitHub secret.** A retired row still gets a slot,
+> so `SIGNING_PRIVATE_KEY` is still read on every release *after* you retire it,
+> forever. Deleting it — the instinctive tidy-up on the day a key leaked, which is
+> the day you are reading this — makes every subsequent release die at the signing
+> step, push-only, after merge. And **nothing can warn you**: secrets cannot be
+> enumerated, which is the same limit the permanent roster exists to work around.
+> The key is already leaked; leaving it in the secret store costs nothing, because
+> what made it dangerous was helpers accepting it, and that is what you just
+> stopped.
+
+From here a leaked copy of the old key is no longer a way past the install gate or
+the relaunch gate.
+
+### The two-release rule, and its guard
+
+A release that both adds a key and retires one strands every helper whose only key
+was the retired one: it refuses the very artifact meant to move it forward, and the
+only repair is sudo on every machine.
+
+It is guarded twice, in two different places, because neither layer alone is
+enough. Both are worth knowing, because they fail differently.
+
+**Layer 1 — a plain unit test, no git, runs everywhere.**
+`one_release_never_both_adds_a_key_and_retires_one` reads the two dates. Both halves
+of the edit record `Cargo.toml`'s version at the time they were written, and
+`Cargo.toml` holds the *previous* release until semantic-release bumps it after the
+merge — so a combined edit written in one sitting puts the **same** version in both
+fields, and the test fails. `added_after_increases_down_the_table` stops the obvious
+way around it: a new row's date must be strictly later than the row above, which
+refuses row 0's `0.0.0` and every earlier row's version, the two stale values
+actually lying around to copy. This layer runs in `cargo test --workspace`, on your
+machine, and on a direct push to `main`.
+
+**Its hole, named rather than glossed:** if the branch's `Cargo.toml` moves between
+the two edits — an unrelated release lands, you update the branch, then retire — the
+two dates are both *honest* and *different*, neither equals the current version, and
+layer 1 sees nothing. The tree cannot tell "added last release" from "added in this
+pull request". Nothing written in the file can close that.
+
+**Layer 2 — the pull request's own diff.** `ci.yml`'s *One release never both adds a
+key and retires one* fails if this pull request's change to `signing.rs` both
+introduces an `OrgKey` row and introduces a `KeyStatus::Retired`. That is exact, and
+it is the layer that closes layer 1's hole. It reads the merge commit's own parents
+(`HEAD^1` is the base GitHub merged against, `HEAD` the result), which the job's
+`fetch-depth: 2` checkout already has — no fetch, and nothing from the event payload,
+whose `base.sha` goes stale exactly when the base branch moves mid-review, which is
+the situation this step is for. It does not run on a direct push to `main`, which is
+precisely the case layer 1 does cover.
+
+**What neither catches:** a value invented for `added_after` that is neither the
+truth nor anything already written down — a version between the previous row's and
+the current one. Nothing in the tree can prove a date honest, and a pull request that
+deletes a row rather than retiring it is a [flag day](#the-flag-day-probably-never)
+by another name. Closing those needs evidence only the release infrastructure can
+mint; that is a follow-up, not something this file pretends to have.
+
+### What is still not "just set a secret", and why
+
+Two things, and neither is an oversight:
+
+- **The `signing.rs` row.** A helper accepts a signature by a key **compiled into
+  it**; the only way to teach it a new key is to ship a binary carrying that key.
+  So the *signing* side can be entirely secret-driven and the *accepting* side is a
+  source change by construction. `release.yml` could be made to derive the keyring
+  from the secrets at build time — that is the tempting way to reach "that's it",
+  and it moves the trust root out of git, where a reviewer can see which keys a
+  release trusts, and into the CI secret store, where a compromised Actions run can
+  mint a keyring. It was considered and rejected. The trust root is still in git.
+- **The second release.** A machine that never installs release 1 lands in
+  `SigTrust::RetiredOnly` — see [The truncation
+  window](#the-truncation-window-and-why-it-is-fine). That is a property of
+  software already in the field, not a policy choice.
 
 ## What you are working with
 
@@ -72,9 +339,24 @@ Two facts about slot 0 that are not conventions but contracts:
   in the field; see [The truncation
   window](#the-truncation-window-and-why-it-is-fine).
 
-`RELEASE_SIG_SLOTS` in `crates/veld-core/src/signing.rs` is the number of slots a
-release must carry. `ci.yml`'s `schema` job fails a **pull request** if it stops
-matching the number of key flags in `release.yml`, so the two cannot drift.
+**`ORG_KEYS` in `crates/veld-core/src/signing.rs` is the single table all of this
+is read from.** One row per key, in slot order, each row carrying the public key,
+the GitHub secret whose private half signs that slot, when the row was added, and
+whether this build still accepts it. Everything else is a view of it:
+
+- `ORG_SIGNING_KEYRING` — the rows this build accepts. The trust root, compiled in.
+- `ORG_REQUIRED_SLOT_KEYS` — every row, in order. A release must carry a slot for
+  each, accepted or not.
+- `RELEASE_SIG_SLOTS` — `ORG_KEYS.len()`.
+- what `release.yml` passes `veld-sign` — derived at build time by
+  `tests/signing-slots.py`, which `ci.yml` runs on every pull request too.
+
+It is a table of records rather than two lists of keys for a reason worth knowing:
+two flat lists can only express *state*, so removing a key from a keyring destroyed
+every trace that the key was ever there, and a release that both added and retired
+one was undetectable in principle. A row that survives its own retirement is where
+that evidence lives — see [The two-release rule, and its
+guard](#the-two-release-rule-and-its-guard).
 
 ## Step 1 — generate the new key, off CI
 
@@ -97,8 +379,9 @@ OPENSSL=/opt/homebrew/opt/openssl@3/bin/openssl
 
 "$OPENSSL" genpkey -algorithm ed25519 -out "$PWD/veld-signing-2.pem"
 
-# The 32 raw public bytes as hex. This is the value --expect-slot-pubkeys takes
-# and the value veld-sign prints per slot, so all three must agree:
+# The 32 raw public bytes as hex. This is what goes in the ORG_KEYS row, what
+# veld-sign prints per slot, and what the derived --slots argument carries, so
+# all of them must agree:
 "$OPENSSL" pkey -in "$PWD/veld-signing-2.pem" -pubout -outform DER \
   | tail -c 32 | xxd -p -c 32
 
@@ -133,6 +416,12 @@ cargo run -q -p veld-sign -- --key-file /absolute/path/to/veld-signing-2.pem \
   --expect-slot-pubkeys <the hex> /tmp/veld-probe.bin
 ```
 
+(`--key-file` plus `--expect-slot-pubkeys` is the hand spelling. The release path
+uses `--slots <hex>=<VAR>`, which is exactly one of each per entry — the
+equivalence is pinned by `slots_is_the_same_signature_as_key_env_plus_expected_pubkeys`
+in `crates/veld-sign/tests/smoke.rs`, so probing this way really does exercise the
+path that ships.)
+
 (The filename needs a `.` in it. `veld-sign` will not print a path segment that
 could be a chunk of encoded key material, so a bare `/tmp/probe` comes back as
 `<redacted: …>` in the success line — nothing is wrong, but it reads alarmingly at
@@ -145,73 +434,72 @@ derived from the private key by the same code that signs releases.
 If you have an OpenSSH key, `ssh-keygen -p -m PKCS8 -f <key>` converts it; the
 tool will tell you so if you get it wrong.
 
-Add the private half as a **new** repository secret. Name it with the
-`SIGNING_` prefix — `SIGNING_PRIVATE_KEY_2` — because `ci.yml`'s
-"no PR-startable job reaches a signing secret" gate matches that prefix and will
-therefore cover the new secret automatically. A name without it is a secret
-nothing checks.
+Add the private half as a **new** repository secret, taking the next free number
+in the permanent roster: `SIGNING_PRIVATE_KEY_2`, then `_3`, up to `_8`. The
+`SIGNING_` prefix is not decoration — `ci.yml`'s "no PR-startable job reaches a
+signing secret" gate matches it, so every name in the roster is covered without an
+edit, and a name without it is a secret nothing checks. `release.yml` already lists
+all eight; you are filling one in, not adding one.
 
-**Do not overwrite `SIGNING_PRIVATE_KEY`.** The old key must keep signing slot 0.
-Overwriting it is the single most expensive mistake available here, and it is why
-`release.yml` passes `--expect-slot-pubkeys`: the release fails rather than
-publishing an artifact no installed helper can accept.
+**Do not overwrite `SIGNING_PRIVATE_KEY`.** It holds the original key, which must
+keep signing slot 0. Overwriting it is the single most expensive mistake available
+here, and it is why the release checks each slot's expected public key: the release
+fails rather than publishing an artifact no installed helper can accept.
 
 ## Step 2 — the release that adds the key
 
-One PR, **four** edits, one release:
+One PR, **one** edit, one release: append a row to `ORG_KEYS` in
+`crates/veld-core/src/signing.rs`, then `cargo fmt --all`. The exact shape is in
+[The whole rotation, in order](#the-whole-rotation-in-order) above; this section is
+why it is only one edit and what each part of it is load-bearing for.
 
-1. `crates/veld-core/src/signing.rs`
-   - add `pub const ORG_KEY_2: PubKey = [ ... ];` with the hex from step 1
-   - add it to `ORG_SIGNING_KEYRING` **and** to `ORG_REQUIRED_SLOT_KEYS`
-   - bump `RELEASE_SIG_SLOTS` to `2`
-2. `.github/workflows/release.yml`, in `Package client binaries`: add
-   `--key-env SIGNING_PRIVATE_KEY_2 \` **below** the existing `--key-env` line.
-   Order is slot order. Below, never above.
-3. `.github/workflows/release.yml`, in the **same step's `env:` block**: add
-   `SIGNING_PRIVATE_KEY_2: ${{ secrets.SIGNING_PRIVATE_KEY_2 }}`.
+```rust
+OrgKey {
+    key: ORG_KEY_2,                        // the constant you added above the table
+    secret: "SIGNING_PRIVATE_KEY_2",       // the secret from step 1
+    added_after: "<Cargo.toml's version>", // read it; a pasted literal is refused
+    status: KeyStatus::Accepted,
+}
+```
 
-   **This is the edit that gets forgotten**, and the symptom is the release dying
-   at the signing step *after* the PR has merged. GitHub does not expose
-   repository secrets as environment variables on their own, and `veld-sign` reads
-   a key by variable **name** — so a `--key-env` with no matching `env:` entry is
-   indistinguishable from a secret that never arrived. `ci.yml`'s `schema` job
-   fails a pull request for exactly this, and for a secret whose name does not
-   carry the `SIGNING_` prefix the leak gate matches on.
+- **`key`'s position in the table is its slot.** Append; never reorder. Slot 0 is a
+  contract with every already-shipped helper, and slot position is this format's
+  only key identifier, so moving a row silently re-points a signature at a
+  different key.
+- **`secret` binds the key to the private half that signs its slot, in source.**
+  This used to be implicit in the order of flags in `release.yml`, which is exactly
+  the kind of positional coupling this format keeps producing bugs from. `ci.yml`
+  checks every name here against the workflow's permanent `env:` roster on each
+  pull request, so a name the roster does not carry fails a PR rather than the
+  release.
+- **`added_after` is `Cargo.toml`'s version right now** — see [The two-release
+  rule, and its guard](#the-two-release-rule-and-its-guard).
+- **`status`** is `Accepted` here. Retirement is release 2 and nothing else.
 
-4. `.github/workflows/release.yml`, on the `--expect-slot-pubkeys` line:
-   **append the new key's hex**, comma-separated, in slot order —
-   `--expect-slot-pubkeys <ORG_KEY_1 hex>,<ORG_KEY_2 hex>`.
+**Three things that used to be edits and are not any more.** `RELEASE_SIG_SLOTS`,
+the `--key-env` flag and its `env:` entry, and the `--expect-slot-pubkeys` hex were
+all transcriptions of what the table already said. `RELEASE_SIG_SLOTS` is
+`ORG_KEYS.len()`; `release.yml` derives the whole slot layout with
+`tests/signing-slots.py` and lists the eight secret names permanently. A
+transcription in two files is a transcription that drifts, and the symptom of drift
+here is a release no privileged install can accept.
 
-   This is not optional and it is not cosmetic. That flag is the only thing that
-   catches a signing secret holding a valid key which is *not* the one you pasted
-   into the keyring — and for a **later** slot, that mistake ships invisibly,
-   because every already-shipped helper still verifies the release through slot 0.
-   It would then wedge every privileged install one release later, when that key
-   becomes the only one a helper accepts: fleet-wide, sudo-only. `ci.yml` compares
-   this list element-wise against `ORG_REQUIRED_SLOT_KEYS`, so leaving it at one
-   entry fails the pull request with `1 declared vs 2 required`.
+**And no test is deleted.** There used to be one —
+`no_rotation_has_happened_yet_so_the_artifact_is_unchanged` — that went red for a
+*correct* rotation and whose own doc comment told you to delete it. Which meant
+step 2 of a rotation was "delete a red test", rehearsed on the worst day available,
+next to permanent invariants that look identical when the whole file is red. It has
+been restated as `the_artifact_carries_exactly_one_slot_per_key`, which is true
+before and after every rotation. **If a test in `signing.rs` is red, the answer is
+never to delete it.**
 
-   Order matters: slot position is this format's only key identifier, and the gate
-   checks the order too.
-
-Then two housekeeping steps, both of which a simulated run of this procedure
-found the hard way:
-
-- **`cargo fmt --all`.** A hand-written 32-byte array will not match rustfmt, and
-  CI's `fmt --check` is a hard failure.
-- **Delete `no_rotation_has_happened_yet_so_the_artifact_is_unchanged`** from
-  `crates/veld-core/src/signing.rs`, and nothing else. It asserts that releases are
-  still byte-identical to the pre-rotation shape, which is exactly what you have
-  just stopped being true; it goes red for a correct change. It sits alone in its
-  own function for that reason. `a_one_key_signature_is_exactly_64_bytes` beside it
-  is a permanent invariant about the format and must survive.
-
-`cargo test -p veld-core -p veld-sign` should then be green, and `ci.yml`'s
-slot-layout gate should report `signature slots: 2`.
+`cargo test --workspace` should be green, and
+`python3 tests/signing-slots.py` should print your new key as the last entry with
+the original still first.
 
 After this release:
 
-- helpers still on the old release accept it via slot 0 (old key), install it,
+- helpers still on the old release accept it via slot 0 (the old key), install it,
   and relaunch onto it — nothing is asked of any user;
 - helpers on this release accept anything signed by either key.
 
@@ -221,34 +509,37 @@ using the only channel those machines trust.
 
 ## Step 3 — the release that retires the old key
 
-Wait until you are willing to say the previous release has reached the machines
-you care about. Then, one edit:
+Wait until you are willing to say the previous release has reached the machines you
+care about. Then, one field:
 
-- `crates/veld-core/src/signing.rs`: remove `ORG_KEY_1` from
-  `ORG_SIGNING_KEYRING`. **Leave it in `ORG_REQUIRED_SLOT_KEYS`, and leave
-  `RELEASE_SIG_SLOTS` at 2.**
+```rust
+    status: KeyStatus::Retired {
+        retired_after: "<Cargo.toml's version>", // read it; a pasted literal is refused
+    },
+```
 
-That is the whole retirement. Releases keep carrying a slot 0 signed by the old
-key — which is harmless, since anyone holding it already holds it — and helpers
-on this release stop *accepting* it. From here a leaked copy of the old key is no
-longer a way past the install gate or the relaunch gate.
+That is the whole retirement. **The row stays** — releases keep carrying a slot 0
+signed by the old key, which is harmless since anyone holding it already holds it —
+and helpers on this release stop *accepting* it. `ORG_REQUIRED_SLOT_KEYS` is every
+row of the table, so keeping the retired key's slot is not something you can forget;
+it is unrepresentable to drop it without deleting the row, which is [the flag
+day](#the-flag-day-probably-never) and not something a rotation does.
 
-Then `cargo fmt --all` again — removing an element can reflow the list — and
-`cargo test -p veld-core -p veld-sign`, which should be green apart from the one
-test named below.
+Then `cargo fmt --all` and `cargo test --workspace`, which is **green**. No test is
+deleted here either. `nothing_is_retired_yet` used to fail at exactly this point,
+with a comment telling you to delete it and nothing else in the file — a red test
+whose remedy was deletion, on the day this document says you are reading it under
+pressure. Its successor,
+`one_release_never_both_adds_a_key_and_retires_one`, goes red when a retirement is
+*unsafe* rather than whenever one happens, so it never needs deleting and it
+actually catches something. See [The two-release rule, and its
+guard](#the-two-release-rule-and-its-guard).
 
-`nothing_is_retired_yet` in `signing.rs` fails as soon as you do this, with a
-message pointing back here. That is deliberate. **Delete that one test function
-and nothing else in the file.**
-
-It is alone in its own function precisely so that this instruction is safe.
 `the_keyring_is_never_empty` and `every_accepted_key_is_one_releases_are_signed_by`
 sit beside it and must survive: the first is what catches a step 3 performed on a
 tree where step 2 was skipped, reverted or mis-merged, which ships a helper that
 trusts nothing — every candidate refused, every relaunch refused, `restart` and
-`shutdown` refused, and `sudo` the only repair. All three used to be one test, and
-deleting a red test is the natural reaction on the day this document says you are
-reading it under pressure.
+`shutdown` refused, and `sudo` the only repair.
 
 ## Why retirement is a separate release
 
@@ -363,24 +654,28 @@ slot 0.
 ## Things that will bite
 
 - **`release.yml`'s signing step is push-only.** Nothing in it runs on a pull
-  request. Everything that *can* be checked at PR time is:
-  `ci.yml`'s `schema` job pins the slot count against `RELEASE_SIG_SLOTS`; that
-  every `--key-env NAME` is written with a space and has a matching entry in that
-  step's `env:` block; that every such NAME carries the `SIGNING_` prefix the leak
-  gate matches on; **every** slot's expected key, element-wise and in order,
-  against `ORG_REQUIRED_SLOT_KEYS`, plus that `ORG_KEY_1` is still first;
-  `veld-sign`'s slot ceiling against `veld-core`'s; and the existence of each
+  request. Everything that *can* be checked at PR time is: every secret `ORG_KEYS`
+  names having an entry in that step's permanent `env:` roster; that roster
+  covering all `MAX_SIG_SLOTS` names, so a rotation never has to touch the workflow;
+  that the step still *derives* its slot layout and still passes `--slots`, rather
+  than hard-coding something; `ORG_KEY_1` still first; no two rows sharing a key or
+  a secret; every secret name carrying the `SIGNING_` prefix the leak gate matches
+  on; `veld-sign`'s slot ceiling against `veld-core`'s; and the existence of each
   rotation test in `crates/veld-sign/tests/smoke.rs` and of each rotation invariant
   in `crates/veld-core/src/signing.rs`. If you add a release-time guard, pin it
   there too.
-- **One thing is *not* gated, deliberately, and it is the rule this document
-  repeats most.** Nothing fails a pull request that both adds a key to
-  `ORG_SIGNING_KEYRING` and removes one in the same release — that is a property of
-  the *diff*, not of the tree, so checking it needs the merge base in a job that is
-  otherwise static checkout-only validation. Until the first retirement,
-  `nothing_is_retired_yet` catches it. **After that, review is the only thing
-  standing between you and it**, so if you are the reviewer of a rotation PR, this
-  is the line to check.
+- **The two-release rule now has a guard — two layers of one — and it is worth
+  knowing which layer covers what.** It used to be ungated entirely, and after the
+  first retirement nothing at all would have caught it. Layer 1 is
+  `one_release_never_both_adds_a_key_and_retires_one`, a plain test over the two
+  date fields: no git, runs locally and on a direct push to `main`, catches the
+  combined edit written in one sitting. Layer 2 is `ci.yml`'s *One release never
+  both adds a key and retires one*, which reads the pull request's own diff (the
+  merge commit against its first parent) and catches the case layer 1 structurally
+  cannot — a branch whose `Cargo.toml` moved
+  between the two edits, where both dates are honest. Neither catches an *invented*
+  `added_after`. Full account: [The two-release rule, and its
+  guard](#the-two-release-rule-and-its-guard).
 - **`veld doctor` judges by the CLI's key list, not the helper's, and after a
   rotation those can disagree.** They ship together so they normally match, but an
   update whose helper half was refused — or an `install.sh` run with `VELD_VERSION`
@@ -400,7 +695,19 @@ slot 0.
     Installation block before trusting this row.
 - **`veld-sign` writes nothing unless every key parses.** A half-written `.sig`
   would verify for one generation and no other, which no reader can detect, so it
-  fails before the first byte lands.
+  fails before the first byte lands. The same is true of a secret that is simply
+  not set: a key `ORG_KEYS` names and CI cannot read fails the release, naming the
+  variable. That is the loud half of the design — the source decides which slots
+  exist, and the secrets must be there to fill them.
+- **A secret set under a name `ORG_KEYS` does not name is simply unused**, so
+  uploading the new key before the source change merges cannot break an unrelated
+  release in between. Nothing warns about it either, so a typo in the secret's name
+  surfaces as "the release could not read `SIGNING_PRIVATE_KEY_2`", not as "you set
+  `SIGNING_PRIVATE_KEY_5`".
+- **The converse is the dangerous one: a retired key's secret is still read.** Its
+  row still gets a slot. Deleting the secret after retiring the key breaks every
+  release from then on, at the push-only signing step, and nothing can catch it at
+  pull-request time because secrets cannot be enumerated.
 - **The same key in two slots is refused.** It would be a release claiming to
   cover two generations while covering one.
 - **No error from `veld-sign` may contain key material, and a second key doubles

--- a/justfile
+++ b/justfile
@@ -403,6 +403,11 @@ build:
     cargo build
 
 test:
+    # The org key table's parser, before the Rust tests that compare against it.
+    # `just workflow-gates` also runs it, but a change to tests/signing-slots.py
+    # alone touches no workflow, so nothing would prompt that recipe and the first
+    # run would be after the PR is marked ready.
+    python3 tests/signing-slots.py --selftest
     {{clear_instance_env}} cargo test --workspace
     cd crates/veld-daemon/frontend && npm test
     cd crates/veld-daemon/ui && npm test
@@ -477,6 +482,12 @@ workflow-gates:
     # gate out of the publish script and asserts the suite goes red.
     python3 tests/validate-release-publish.py --selftest
     python3 tests/validate-release-publish.py
+    # The parser release.yml and ci.yml both read the org key table with. Its own
+    # failure mode is a mis-parse that produces a SHORTER list than the table has,
+    # which is a release missing a slot — so its fixtures are mis-parses it must
+    # refuse, and they run before it is trusted for anything.
+    python3 tests/signing-slots.py --selftest
+    python3 tests/signing-slots.py
 
 # Check commit subjects against the pattern the `commits` job enforces. That job
 # is draft-guarded too, so without this a malformed subject is discovered only

--- a/tests/signing-slots.py
+++ b/tests/signing-slots.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Read the org signing-key table out of `crates/veld-core/src/signing.rs`.
+
+`veld_core::signing::ORG_KEYS` is the one place that says which keys a release is
+signed by, in which slot, and which GitHub secret supplies each private half.
+**Two files that cannot evaluate Rust have to read it**: `release.yml`'s
+`Package client binaries` step, which turns it into `veld-sign --slots`, and
+`ci.yml`'s `schema` job, which checks the same table against that step's `env:`
+block on every pull request.
+
+It is one script rather than two regexes for the obvious reason — a parser
+duplicated in two workflows is a parser that drifts, and the symptom of drift here
+is a release no privileged install can accept, repairable only with sudo on every
+machine.
+
+    python3 tests/signing-slots.py            # the --slots argument for veld-sign
+    python3 tests/signing-slots.py --json     # the whole table, for ci.yml
+    python3 tests/signing-slots.py --tsv      # the same, for the Rust cross-check
+    python3 tests/signing-slots.py --selftest # the parser's own fixtures
+
+The Rust side compares `--tsv` against `ORG_KEYS` itself
+(`the_slot_script_reads_the_same_table_the_compiler_does`), which is the only
+check that this parser and rustc see the same table. Tab-separated rather than
+JSON so that comparison needs no JSON crate in the trust root.
+
+**Every mis-parse must fail loudly rather than quietly produce a shorter list**,
+because a dropped row is a dropped slot and a dropped slot strands a helper
+generation. So the parser brace-matches rather than pattern-matching row shapes,
+insists on exactly the four fields it knows, and re-checks the invariants the
+Rust tests also assert — here they are assertions about *this parse*, not a second
+copy of the rules.
+"""
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+SIGNING_RS = "crates/veld-core/src/signing.rs"
+
+# Hand-kept equal to `veld_core::signing::MAX_SIG_SLOTS`. A `const _: () =
+# assert!(ORG_KEYS.len() <= MAX_SIG_SLOTS)` in that file is the compiler's copy of
+# this rule; this one catches a table that grew past what any reader looks at in
+# the two places that cannot run the compiler.
+MAX_SLOTS = 8
+
+# The prefix `ci.yml`'s leak gate matches on to prove no pull-request-startable job
+# can reach a signing secret.
+SECRET_PREFIX = "SIGNING_"
+
+
+class TableError(Exception):
+    """A table this script will not guess about."""
+
+
+def _balanced(text, open_at):
+    """The index just past the `]` or `}` matching the bracket at `open_at`.
+
+    Brace-matching rather than a non-greedy regex: a row's `status` field can
+    itself carry braces (`KeyStatus::Retired { retired_after: "…" }`), and a
+    regex that stopped at the first `}` would silently truncate the row — which is
+    the class of mis-parse this whole file exists to make impossible.
+    """
+    pairs = {"[": "]", "{": "}"}
+    closer = pairs[text[open_at]]
+    depth = 0
+    for i in range(open_at, len(text)):
+        if text[i] == text[open_at]:
+            depth += 1
+        elif text[i] == closer:
+            depth -= 1
+            if depth == 0:
+                return i
+    raise TableError(f"{SIGNING_RS}: unbalanced {text[open_at]!r} in ORG_KEYS")
+
+
+def _strip_comments(text):
+    """Drop `//` line comments, leaving anything inside a string literal alone.
+
+    Not cosmetic. The field patterns below take the **first** match in a row, so a
+    stale commented-out `secret: "…"` above the live one would be read instead of
+    it — silently, and with the two halves of a slot then coming from different
+    places. That failure surfaces at the release (push-only, after merge) as an
+    expected-key mismatch, which is loud but is the most expensive place to learn
+    it. A `//` with an odd number of quotes before it on the line is inside a
+    string literal and is left alone.
+    """
+    out = []
+    for line in text.splitlines():
+        cut = -1
+        for i in range(len(line) - 1):
+            if line[i : i + 2] == "//" and line[:i].count('"') % 2 == 0:
+                cut = i
+                break
+        out.append(line if cut < 0 else line[:cut])
+    return "\n".join(out)
+
+
+def _rows(body):
+    """Split the table body into `OrgKey { … }` blocks."""
+    out = []
+    for m in re.finditer(r"OrgKey\s*\{", body):
+        open_at = body.index("{", m.start())
+        close_at = _balanced(body, open_at)
+        out.append(body[open_at + 1 : close_at])
+    return out
+
+
+def _key_hex(name, source):
+    """`pub const <name>: PubKey = [ … ];` as 64 lowercase hex characters."""
+    m = re.search(rf"pub const {re.escape(name)}: PubKey = \[(.*?)\];", source, re.S)
+    if not m:
+        raise TableError(
+            f"{SIGNING_RS}: ORG_KEYS names `{name}`, which is not defined as a "
+            "`pub const <name>: PubKey = [ … ];`"
+        )
+    hexes = re.findall(r"0x([0-9a-fA-F]{2})", m.group(1))
+    if len(hexes) != 32:
+        raise TableError(
+            f"{SIGNING_RS}: `{name}` parsed as {len(hexes)} bytes, expected 32. An "
+            "ed25519 public key is 32 bytes written as 0xNN literals."
+        )
+    return "".join(h.lower() for h in hexes)
+
+
+def parse(source):
+    """`ORG_KEYS` as a list of `{index, key, pubkey, secret, added_after, status}`."""
+    # Once, up front, so that BOTH the table rows and the `pub const ORG_KEY_N`
+    # definitions they name are read from the same stripped text. Stripping only
+    # the rows left `_key_hex` searching the raw source, where a commented-out key
+    # constant above the live one wins — the derived `--slots` would then carry a
+    # hex the compiled keyring does not name. That fails safe (veld-sign refuses)
+    # but at the push-only release step, which is the failure class this whole
+    # script exists to move to pull-request time.
+    source = _strip_comments(source)
+    m = re.search(r"pub const ORG_KEYS: &\[OrgKey\] = &\[", source)
+    if not m:
+        raise TableError(
+            f"{SIGNING_RS}: `ORG_KEYS` is gone. It is the single table that says "
+            "which keys a release is signed by and which secret signs each slot; "
+            "release.yml and ci.yml both read it."
+        )
+    open_at = source.index("[", m.end() - 1)
+    body = source[open_at + 1 : _balanced(source, open_at)]
+
+    rows = []
+    for index, row in enumerate(_rows(body)):
+        fields = {}
+        for field, pattern in (
+            ("key", r"\bkey:\s*([A-Za-z_][A-Za-z0-9_]*)\s*,"),
+            ("secret", r'\bsecret:\s*"([^"]*)"\s*,'),
+            ("added_after", r'\badded_after:\s*"([^"]*)"\s*,'),
+            ("status", r"\bstatus:\s*KeyStatus::([A-Za-z_][A-Za-z0-9_]*)"),
+        ):
+            found = re.search(pattern, row)
+            if not found:
+                raise TableError(
+                    f"{SIGNING_RS}: ORG_KEYS row {index} has no readable `{field}`. "
+                    "Every row is written `key: ORG_KEY_N, secret: \"SIGNING_…\", "
+                    "added_after: \"x.y.z\", status: KeyStatus::…` — a row this script "
+                    "cannot read is a slot release.yml would not sign."
+                )
+            fields[field] = found.group(1)
+        if fields["status"] not in ("Accepted", "Retired"):
+            raise TableError(
+                f"{SIGNING_RS}: ORG_KEYS row {index} has status "
+                f"`KeyStatus::{fields['status']}`, which this script does not know. "
+                "Teach it here and in ci.yml's gate before adding a variant."
+            )
+        rows.append(
+            {
+                "index": index,
+                "key": fields["key"],
+                "pubkey": _key_hex(fields["key"], source),
+                "secret": fields["secret"],
+                "added_after": fields["added_after"],
+                "status": fields["status"].lower(),
+            }
+        )
+
+    _check(rows, source)
+    return rows
+
+
+def _check(rows, source):
+    """Invariants that make a *parse* trustworthy, checked before it is used."""
+    if not rows:
+        raise TableError(f"{SIGNING_RS}: ORG_KEYS is empty; a release would be unsigned")
+    if len(rows) > MAX_SLOTS:
+        raise TableError(
+            f"{SIGNING_RS}: ORG_KEYS has {len(rows)} rows but no reader looks past "
+            f"slot {MAX_SLOTS - 1}. Raising the ceiling means raising MAX_SIG_SLOTS, "
+            "veld-sign's MAX_SLOTS and this script together."
+        )
+    if rows[0]["pubkey"] != _key_hex("ORG_KEY_1", source):
+        raise TableError(
+            f"{SIGNING_RS}: ORG_KEY_1 is no longer row 0 of ORG_KEYS. Every helper "
+            "shipped up to v16.59.0 verifies bytes 0..64 against it and nothing "
+            "else, so moving it is a release none of them can relaunch onto."
+        )
+    for field, what in (("pubkey", "public key"), ("secret", "secret name")):
+        seen = {}
+        for row in rows:
+            if row[field] in seen:
+                raise TableError(
+                    f"{SIGNING_RS}: ORG_KEYS rows {seen[row[field]]} and "
+                    f"{row['index']} share a {what}. Slot position is this format's "
+                    "only key identifier, so two slots that share one are a release "
+                    "claiming to cover two helper generations while covering one."
+                )
+            seen[row[field]] = row["index"]
+    for row in rows:
+        # The whole slot layout travels to veld-sign as one `<hex>=<NAME>,…`
+        # argument, so a name carrying a comma or an `=` would re-cut the list and
+        # re-point a slot at another row's key. veld-sign refuses the malformed
+        # entry rather than acting on it, but that refusal is at the release, which
+        # is push-only. Held to the charset an environment variable can have.
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", row["secret"]):
+            raise TableError(
+                f"{SIGNING_RS}: ORG_KEYS row {row['index']} names the secret "
+                f"{row['secret']!r}, which is not a valid environment-variable name. "
+                "The slot layout is one comma-separated `<hex>=<NAME>` argument, so a "
+                "name carrying a comma or an `=` would re-cut it."
+            )
+        if not row["secret"].startswith(SECRET_PREFIX):
+            raise TableError(
+                f"{SIGNING_RS}: ORG_KEYS row {row['index']} names the secret "
+                f"{row['secret']!r}, which does not carry the shared signing-secret "
+                "prefix. ci.yml's leak gate matches that prefix to prove no "
+                "pull-request job can reach a signing secret; a name without it is a "
+                "secret nothing checks."
+            )
+
+
+def slot_spec(rows):
+    """The `--slots` argument: `<hex>=<VAR>`, comma-separated, in slot order."""
+    return ",".join(f"{r['pubkey']}={r['secret']}" for r in rows)
+
+
+# ── Self-test ───────────────────────────────────────────────────────────
+# Each fixture is a mis-parse this script must refuse rather than quietly
+# shorten. A parser that returns a shorter list is a release missing a slot.
+_K1 = "pub const ORG_KEY_1: PubKey = [\n" + ", ".join(["0x11"] * 32) + ",\n];\n"
+_K2 = "pub const ORG_KEY_2: PubKey = [\n" + ", ".join(["0x22"] * 32) + ",\n];\n"
+
+
+def _table(*rows):
+    return _K1 + _K2 + "pub const ORG_KEYS: &[OrgKey] = &[\n" + "".join(rows) + "];\n"
+
+
+def _row(
+    key="ORG_KEY_1",
+    secret="SIGNING_PRIVATE_KEY",
+    status="KeyStatus::Accepted",
+    added_after="0.0.0",
+):
+    return (
+        f"    OrgKey {{\n        key: {key},\n        secret: {secret!r},\n"
+        f"        added_after: {added_after!r},\n        status: {status},\n    }},\n"
+    ).replace("'", '"')
+
+
+_GOOD = _table(
+    _row(),
+    _row(
+        "ORG_KEY_2",
+        "SIGNING_PRIVATE_KEY_2",
+        'KeyStatus::Retired {\n            retired_after: "16.62.0",\n        }',
+        "16.61.0",
+    ),
+)
+
+_BAD = [
+    ("no table", _K1, "ORG_KEYS` is gone"),
+    ("empty table", _K1 + "pub const ORG_KEYS: &[OrgKey] = &[];\n", "is empty"),
+    (
+        "row with no secret",
+        _table(
+            "    OrgKey {\n        key: ORG_KEY_1,\n"
+            '        added_after: "0.0.0",\n        status: KeyStatus::Accepted,\n    },\n'
+        ),
+        "no readable `secret`",
+    ),
+    (
+        "row with no added_after",
+        _table(
+            "    OrgKey {\n        key: ORG_KEY_1,\n"
+            '        secret: "SIGNING_PRIVATE_KEY",\n        status: KeyStatus::Accepted,\n    },\n'
+        ),
+        "no readable `added_after`",
+    ),
+    (
+        "key constant missing",
+        "pub const ORG_KEYS: &[OrgKey] = &[\n" + _row() + "];\n",
+        "not defined",
+    ),
+    (
+        "short key constant",
+        "pub const ORG_KEY_1: PubKey = [0x11, 0x22];\n"
+        + "pub const ORG_KEYS: &[OrgKey] = &[\n"
+        + _row()
+        + "];\n",
+        "expected 32",
+    ),
+    ("ORG_KEY_1 not first", _table(_row("ORG_KEY_2", "SIGNING_PRIVATE_KEY_2")), "row 0"),
+    ("duplicate key", _table(_row(), _row(secret="SIGNING_PRIVATE_KEY_2")), "share a public key"),
+    ("duplicate secret", _table(_row(), _row("ORG_KEY_2")), "share a secret name"),
+    ("secret without prefix", _table(_row(secret="ORG_KEY_2_PEM")), "shared signing-secret prefix"),
+    (
+        "secret name with a comma",
+        _table(_row(secret="SIGNING_A,SIGNING_B")),
+        "not a valid environment-variable name",
+    ),
+    (
+        "stale commented-out key constant above the live one",
+        "// pub const ORG_KEY_1: PubKey = [\n" + ", ".join(["0x99"] * 32) + ",\n];\n"
+        + _K1
+        + "pub const ORG_KEYS: &[OrgKey] = &[\n"
+        + _row()
+        + "];\n",
+        None,  # must PARSE, and must read the live constant
+    ),
+    (
+        "stale commented-out secret above the live one",
+        _table(
+            "    OrgKey {\n        key: ORG_KEY_1,\n"
+            '        // secret: "SIGNING_PRIVATE_KEY_2",\n'
+            '        secret: "SIGNING_PRIVATE_KEY",\n'
+            '        added_after: "0.0.0",\n        status: KeyStatus::Accepted,\n    },\n'
+        ),
+        None,  # must PARSE, and must read the live field
+    ),
+    ("unknown status", _table(_row(status="KeyStatus::Provisional")), "does not know"),
+    (
+        "too many rows",
+        _K1 + "pub const ORG_KEYS: &[OrgKey] = &[\n" + _row() + (_row() * MAX_SLOTS) + "];\n",
+        "no reader looks past",
+    ),
+]
+
+
+def selftest():
+    rows = parse(_GOOD)
+    assert len(rows) == 2, rows
+    assert rows[0]["status"] == "accepted" and rows[1]["status"] == "retired", rows
+    # The multi-line `Retired { … }` field must not truncate the row: its `secret`
+    # is read after `key`, and a regex stopping at the first `}` would lose it.
+    assert rows[1]["secret"] == "SIGNING_PRIVATE_KEY_2", rows
+    assert slot_spec(rows) == f"{'11' * 32}=SIGNING_PRIVATE_KEY,{'22' * 32}=SIGNING_PRIVATE_KEY_2"
+
+    refused = 0
+    for name, source, needle in _BAD:
+        if needle is None:
+            # Not a refusal: a shape that must parse, and parse to the right thing.
+            rows = parse(source)
+            assert rows[0]["secret"] == "SIGNING_PRIVATE_KEY", f"{name}: read {rows[0]}"
+            assert rows[0]["pubkey"] == "11" * 32, f"{name}: read {rows[0]}"
+            continue
+        try:
+            parse(source)
+        except TableError as e:
+            assert needle in str(e), f"{name}: message was {e!r}, wanted {needle!r}"
+            refused += 1
+        else:
+            sys.exit(f"selftest: {name} parsed cleanly; it must be refused")
+    print(f"signing-slots selftest: {refused} mis-parses refused, {len(_BAD) - refused} shapes accepted")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--json", action="store_true", help="the whole table")
+    ap.add_argument("--tsv", action="store_true", help="the whole table, one row per line")
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+    if args.selftest:
+        selftest()
+        return
+    try:
+        rows = parse(pathlib.Path(SIGNING_RS).read_text())
+    except TableError as e:
+        sys.exit(str(e))
+    if args.json:
+        print(json.dumps(rows))
+    elif args.tsv:
+        for r in rows:
+            print("\t".join((r["pubkey"], r["secret"], r["added_after"], r["status"])))
+    else:
+        print(slot_spec(rows))
+
+
+if __name__ == "__main__":
+    main()

--- a/website/llms-full.txt
+++ b/website/llms-full.txt
@@ -28,6 +28,12 @@ reboot. Updates still need no sudo — the installer hands the new binary to the
 running root helper, which verifies its signature and refuses anything older than
 the newer of what is running and what is already installed.
 
+That signature is checked against a list of org keys compiled into the helper, so
+the key can be **replaced without asking anyone to run anything** — two releases,
+and the old key keeps working until the second one. If you hold the key, the
+procedure is `docs/signing-key-rotation.md`, and it is two releases, one new
+GitHub secret and one row of Rust.
+
 No sudo required. Ensure `~/.local/bin` is on your `PATH`.
 
 **Upgrading from an older veld:** `veld.json` must declare `"schemaVersion": "3"`; `"1"` and `"2"` no longer load. The load error names every change needed. See `docs/migrating-to-v3.md` for the complete rule set, then `veld lint` to verify. There is no v4: what v3 gained after shipping (`long_running`, port-less long-running nodes, `protocol`/`host` on a named port, the `settle` probe, per-port sharing consent) is additive, and `docs/adopting-long-running-and-ports.md` covers adopting it.


### PR DESCRIPTION
Rotating the org's helper signing key was **four file edits plus two test deletions,
done twice**. It is now **one row of Rust plus one GitHub secret, done twice**, and
`release.yml` is never edited again.

The mechanism underneath (#261 slice C, `ccb7648`) is unchanged: `<binary>.sig` is a
concatenation of raw 64-byte ed25519 signatures, one slot per key, and a helper
accepts the binary if any slot verifies under any key compiled into it. What changed
is the procedure around it, and one thing that was not guarded at all.

## What a rotation costs now

| | before | now |
|---|---|---|
| `crates/veld-core/src/signing.rs` | 3 edits — the key constant, two lists, the slot count | **1 row appended** |
| `.github/workflows/release.yml` | 3 edits — `--key-env`, its `env:` entry, the expected-key hex | **none** |
| tests to delete | 2, one per release | **none** |
| GitHub secrets to set | 1 | 1 |
| releases | 2 | 2 |

Retirement, the second release, is **one field**.

## What I could not reach, and why

Your words were *"someone sets `SIGNING_PRIVATE_KEY_OLD` and `SIGNING_PRIVATE_KEY`
… that's it … the rest is handled by presence of the `_OLD` variant."* Three parts
of that did not survive contact. Stated plainly rather than quietly redefined:

**1. `_OLD` cannot mean "the previous key". Worked through, not asserted.**
Names: `_OLD` = previous, plain = current.

- Start: plain = K1. Slots `[K1]`. Slot 0 = K1. Fine.
- Rotation 1: `_OLD` = K1, plain = K2. Slots `[K1, K2]`. Slot 0 = K1. Fine.
- Retire K1. Helpers built from here accept `{K2}` only.
- **Rotation 2:** `_OLD` = K2, plain = K3. Slots `[K2, K3]`. **Slot 0 is now K2** —
  which no helper shipped up to v16.59.0 has ever trusted — and K1 has no slot at
  all. Every one of those installs refuses the release. Sudo on every machine, which
  #338 forbids absolutely.

So the trap you flagged is real, and it is worse than "badly named": **no fixed pair
of secrets can work.** After *n* rotations a release must be signed by all *n+1* keys
ever generated, because a helper generation exists whose keyring is exactly `{K2}`.
The count of secret *values* must grow. The count of *names in the workflow* need
not — so `release.yml` carries a permanent roster of eight, the signature format's
own slot ceiling, written once. Names are **positional and immortal**:
`SIGNING_PRIVATE_KEY` is the original key forever and is never re-uploaded; a new key
takes the next free number.

That is one secret to set per rotation, not two. Better than the goal, by not
touching the one secret whose slot is a compatibility contract.

**2. One source edit remains, and it is not removable.** A helper accepts a signature
by a key **compiled into it**. The only way to teach it a new key is to ship a binary
carrying that key, so the *signing* side can be entirely secret-driven and the
*accepting* side is a source change by construction.

**3. The second release remains.** A machine that skips the transition window lands
in `SigTrust::RetiredOnly`. That is a property of software already in the field.

So: **2 secrets set, 2 rows edited, 2 releases** — against 8 edits and 4 test
deletions before. Not "that's it", and I am not going to call it that.

## Where the trust root lives

**Still in git.** `ORG_SIGNING_KEYRING` is a reviewed value in
`crates/veld-core/src/signing.rs`, exactly as before.

`--expect-slot-pubkeys` is not deleted to get there — it is **derived from that same
source at build time**, which reads git, not the secret store. It still catches the
thing it exists for: a secret whose content is a key the source does not name. And it
is now impossible for the workflow and the source to disagree, because there is only
one of them.

The tempting version — deriving the keyring from the secrets and stamping it in — was
named and forbidden before any code was written. So was its costume: *"accept a key
that signed a recent release."* That one presents as fully compliant (the accepted set
is computed from committed git objects) and is the forbidden answer with a delay
bolted on — the *content* of that history is authored by the secret store, so one
compromised Actions run mints a slot that becomes compiled-in trust a few releases
later, approved by no human.

Also rejected, with reasons, so nobody has to regenerate them:

- **A roster directory of per-key files plus a generator.** Reduces keystrokes, and
  pays by putting a code generator between reviewed source and the compiled trust
  root. "Add one file" is the easiest diff in the world to approve unread, and it is
  the one file that decides what root executes.
- **Pipeline-stamped lifecycle fields** (the release job rewriting a `Pending`
  sentinel). Cleaner for the operator; the artifact would then be built from a tree
  that differs from the tree that was reviewed.
- **Pre-publishing the next public key one release early** to make rotation day a
  zero-edit day. Costs a second private key that must exist now, survive untouched
  for years, and never be lost — which is the already-rejected `H(next_key)` design.
- **Automating retirement.** "The fleet has adopted release A" is not a property of
  the repository. The *check* could be mechanised against tagged history plus a
  declared minimum supported helper; the *premise* cannot. Follow-up, not built.

## The shape: one table instead of three constants

```rust
pub const ORG_KEYS: &[OrgKey] = &[OrgKey {
    key: ORG_KEY_1,
    secret: "SIGNING_PRIVATE_KEY",
    added_after: "0.0.0",
    status: KeyStatus::Accepted,
}];
```

`ORG_SIGNING_KEYRING`, `ORG_REQUIRED_SLOT_KEYS` and `RELEASE_SIG_SLOTS` are const-fn
views of it. `release.yml` derives the whole slot layout with `tests/signing-slots.py`
and passes `veld-sign --slots <hex>=<VAR>,…`.

Two reasons it is a table of records and not two sets of keys:

- **It binds the public key to the secret that signs its slot, in source.** That
  mapping used to be positional and implicit across two files, which is exactly the
  class of bug this format keeps producing — slot position is its only key identifier.
- **Two flat lists can only express state.** Removing a key from a keyring destroys
  every trace that the key was ever there, so a release that both added and retired
  one was undetectable *in principle*. A row that survives its own retirement is the
  only place that evidence can live — which is what made the next section possible.

## The two-release rule: yes, it has a durable guard now

> **Corrected in #347.** The description of *what a combined release costs* in this
> section — and in four places in the code — was wrong: it said such a release
> strands helpers and needs sudo. It does not. The retired key keeps its slot, so
> every helper still accepts it; the real cost is the truncation window on
> pre-v16.60.0 installers (`RetiredOnly` — restart/shutdown refused, no password,
> healed by the next release). "sudo" belongs to the neighbouring mistake of
> *deleting* a row. #347 fixes the wording and makes it executable. The rule and the
> guard below are unchanged and correct.

You asked me to say whether it does. It does, in **two layers**, and each layer's
hole is named rather than glossed.

**Layer 1 — `one_release_never_both_adds_a_key_and_retires_one`,** a plain unit test.
Both halves of the edit record `Cargo.toml`'s version at the time they were written,
and `Cargo.toml` holds the *previous* release until semantic-release bumps it after
the merge — so a combined edit written in one sitting puts the same version in both
fields. No git, no network, runs in `cargo test --workspace` locally **and on a direct
push to `main`**. `added_after_increases_down_the_table` sits beside it and refuses
row 0's `0.0.0` and every earlier row's version, which are the stale values actually
lying around to copy.

**Its hole** — found by the review, not by me: if the branch's `Cargo.toml` moves
between the two edits (an unrelated release lands, you update the branch, then
retire), both dates are *honest* and *different*, and layer 1 sees nothing. The tree
cannot tell "added last release" from "added in this pull request".

**Layer 2 — a `ci.yml` step that reads the pull request's own diff** and fails if it
both introduces an `OrgKey` row and introduces a `KeyStatus::Retired`. It reads the
merge commit's own parents (`HEAD^1` is the base GitHub merged against), which
`fetch-depth: 2` already provides — no fetch, and deliberately not
`github.event.pull_request.base.sha`, which goes stale exactly when the base branch
moves mid-review, i.e. in the situation the gate is for. It does not run on a direct
push to `main`, which is precisely what layer 1 covers.

**What neither catches:** an *invented* `added_after` — a version between the previous
row's and the current one, which is neither the truth nor anything written down.
Nothing in the tree can prove a date honest. Closing that needs evidence only the
release infrastructure can mint; named as a follow-up, not claimed here.

Tested against real merge commits, all four ways: add-only quiet, retire-only after an
intervening release quiet, add-and-retire fires, unrelated edit quiet.

## Demonstrated, not asserted

Two full rotations — four releases — performed against this repo with real ed25519
keys and the real `veld-sign`, then repeated against the final code after review:

- **Each release changed exactly one file**, `signing.rs`. Zero workflow edits, zero
  test deletions, at every step.
- **Slot 0 verified against the original key in all four artifacts**, checked with
  `openssl pkeyutl -verify` against the raw bytes — 2 slots after the first rotation,
  3 after the second, slot 0 unmoved.
- Every generation's key verifies its own slot; a stranger key verifies none.
- A secret holding a key the table does not name → **release fails, no `.sig`
  written**.
- A secret name the roster does not carry → **pull request fails**.
- A missing secret → release fails, naming the variable.
- Add-and-retire in one release → the guard fires.

The second rotation is the one that matters, and it is what proves `_OLD` had to go.

## Adjacent-but-necessary: the `paths.rs` test fix

**Unrelated to rotation. Deliberately included, because `cargo test --workspace` is
red on your machine without it.**

`crates/veld-core/src/paths.rs` asserted `!bin.exists()` as a *precondition*, with the
message "this test assumes no store on the test machine". The privileged helper's own
self-migration (#262) creates `/var/db/veld-helper` on any machine with a privileged
install, so the test was on a timer, and this machine has one.

You asked me to check the reasoning rather than trust it. **The rewrite alone was not
enough**, and the gap was invisible: with the precondition simply dropped, the test can
no longer fail on a machine that *has* a store. A canonicalising implementation — the
actual regression, since `canonicalize` errors on a missing path — answers `true` for
the present store path and `false` for the absent sibling, which is what the rewritten
test wants. It passes. The regression would then be caught only by a machine with no
privileged install, which is the same machine-dependence pointing the other way.

Fixed properly: `names_the_same_binary(path, bin)` is split out as a seam, so
`the_comparison_never_asks_the_filesystem` can hand it two paths that exist nowhere
and still demand `true` — which canonicalising cannot produce, on any machine.

Mutation-proven on this machine, which has the store: with the comparison replaced by
a canonicalising one, `the_store_path_reads_as_migrated_either_way` **passes** and
`the_comparison_never_asks_the_filesystem` **fails**.

## Also here: `veld doctor` names the key that verified

Small, and it came out of a question mid-flight: should an update say a rotation
happened? Not on the update path — a line on every update forever, for a two-release
window every few years, and it is not telemetry either. But *which key verified* was
genuinely missing, and this change makes rotations cheaper, so the question gets asked
more. It belongs on the row that already exists.

`Helper binary signature OK (~/.local/lib/veld/veld-helper, signed by org key 1 of 1
(9d75a4c5…))`. The number is the row in `ORG_KEYS`, which is permanent because rows
are append-only — so a number pasted into an issue means the same thing a year later.
The retired-key row names its key too. Public keys; nothing here must not be printed.

## Review

Standard loop at stakes-elevated, three stages plus two fix-delta rounds; 9 subagents
(6 opus, 3 sonnet) after a §0 design-divergence stage on the trust-root fork.

One 🔴 was found by all three Stage A angles independently and it was mine: my own edit
to `release.yml` left a stray `dist/veld-helper` line, so the step would have **executed
the freshly signed root helper** on the runner, in the step holding every signing
secret. Push-only, so it would have broken every release after merge, and no gate saw
it. The gate that should have — my rewritten gate 3 — only grepped for two substrings;
it now also forbids the flags `--slots` replaced.

Other findings worth naming because they changed the design rather than the wording:
the CI gate comparing the parser against *itself* (tautological — replaced by
`the_slot_script_reads_the_same_table_the_compiler_does`, which compares it to what
rustc compiles, and which catches a real divergence the review constructed); layer 1's
hole above; and **the runbook's own example version literals**, which were themselves
the paste that defeated the guard — now `"<Cargo.toml's version>"`, which does not
parse.

`ci.yml`'s leak gate fired twice on my own gate comments, for spelling out a constant
name that contains the signing-secret prefix. It is a real gate and it catches prose.

Angle 6 verified the invariance by measurement rather than argument: 502 generated key
tables against the const fns, 1004 against the parser, and 78,975 cases comparing the
new `verifying_key` against the old `verify_data_slots` for both verdict *and*
verification count (292,140 calls each, identical). The `.sig` bytes and `veld-sign`'s
stdout are byte-identical pre- and post-diff for the same key and payload.

## Housekeeping

- **Core, not customization** — the signing mechanism is a universal primitive with no
  provider surface, so nothing goes in `docs/extensions-vision.md`.
- **No promotion.** Maintainer-only infrastructure; nobody's day changes.
  `crates/veld-daemon/ui/src/promotions/content.ts` untouched.
- **Website:** `website/index.html` does not mention signing, so no change there.
  `README.md` and `website/llms-full.txt` carry the one sentence that does.
- No config fields, CLI flags or subcommands, so the schema/`SKILL.md`/
  `configuration.md` rows of the docs checklist do not apply. No keyboard shortcuts.

## Follow-ups (not in this PR)

- **Evidence only the release infrastructure can mint**, to close the invented-date
  hole in the two-release guard — a token the release job signs, cited by the
  retirement.
- **Upgrade rehearsal**: verify the new artifact with the *previous* release's
  verifier before publishing. It is the only thing that would catch stranding caused by
  the signing infrastructure rather than by a source edit. It only ever tests N against
  N−1, so it does not survive two rotations in a row, and it fails after
  semantic-release has already tagged.
- **Retirement's check** against tagged history plus a declared minimum supported
  helper. Automates the consequence; the premise stays a human declaration.
- **The ninth key.** The roster is the format's 8-slot ceiling. Going past it means
  raising `MAX_SIG_SLOTS`, `veld-sign`'s `MAX_SLOTS`, `tests/signing-slots.py`'s copy
  (all three are now pinned to each other) and the roster — or a flag day that lets
  `ORG_REQUIRED_SLOT_KEYS` shrink.