### PR TITLE
feat(terminal): add a switch for a font's programming ligatures

### DIFF
--- a/crates/veld-core/src/db/settings.rs
+++ b/crates/veld-core/src/db/settings.rs
@@ -644,6 +644,7 @@ pub enum SettingKey {
     TerminalShell,
     TerminalFontSize,
     TerminalFontFamily,
+    TerminalLigatures,
     TerminalCursorStyle,
     TerminalCursorBlink,
     TerminalScrollback,
@@ -754,6 +755,11 @@ impl SettingKey {
         // ── Terminal › Appearance ────────────────────────────────────────────
         Self::TerminalFontSize,
         Self::TerminalFontFamily,
+        // Directly under the font, because it is a property *of* the font rather
+        // than of the terminal: it does nothing on a font without the tables, and
+        // the client hides it for the fonts it knows do not have them. Anything
+        // between the two would read as unrelated.
+        Self::TerminalLigatures,
         Self::TerminalCursorStyle,
         Self::TerminalCursorBlink,
         // ── Terminal › Behaviour ─────────────────────────────────────────────
@@ -822,6 +828,7 @@ impl SettingKey {
             Self::TerminalShell => "terminal.shell",
             Self::TerminalFontSize => "terminal.fontSize",
             Self::TerminalFontFamily => "terminal.fontFamily",
+            Self::TerminalLigatures => "terminal.ligatures",
             Self::TerminalCursorStyle => "terminal.cursorStyle",
             Self::TerminalCursorBlink => "terminal.cursorBlink",
             Self::TerminalScrollback => "terminal.scrollback",
@@ -891,6 +898,7 @@ impl SettingKey {
             "terminal.shell" => Self::TerminalShell,
             "terminal.fontSize" => Self::TerminalFontSize,
             "terminal.fontFamily" => Self::TerminalFontFamily,
+            "terminal.ligatures" => Self::TerminalLigatures,
             "terminal.cursorStyle" => Self::TerminalCursorStyle,
             "terminal.cursorBlink" => Self::TerminalCursorBlink,
             "terminal.scrollback" => Self::TerminalScrollback,
@@ -1034,6 +1042,7 @@ impl SettingKey {
                 clamp_i64(value, MIN_RUN_HISTORY_DAYS, MAX_RUN_HISTORY_DAYS).ok_or_else(bad)?,
             ),
             Self::TerminalCursorBlink
+            | Self::TerminalLigatures
             | Self::TerminalShiftEnterNewline
             | Self::TerminalOpenUrlsInApp
             | Self::TerminalInterceptSystemOpen
@@ -1589,6 +1598,10 @@ pub fn defaults() -> BTreeMap<String, Value> {
             SettingKey::TerminalFontFamily,
             Value::from("\"JetBrains Mono Variable\", \"JetBrains Mono\", ui-monospace, monospace"),
         ),
+        // Off, and this one is not the "match the previous release" rule talking —
+        // ligatures are a taste, and the two bundled fonts both have them, so
+        // defaulting on would redraw every existing user's terminal unasked.
+        (SettingKey::TerminalLigatures, Value::from(false)),
         (SettingKey::TerminalCursorStyle, Value::from("block")),
         (SettingKey::TerminalCursorBlink, Value::from(true)),
         (
@@ -2824,6 +2837,34 @@ mod tests {
                 "{key} accepted a string"
             );
         }
+    }
+
+    /// Ligatures default **off** and take a bool.
+    ///
+    /// The default is the assertion worth pinning. Both bundled fonts ship the
+    /// ligatures, so flipping this default is not a no-op for anybody — it would
+    /// redraw every existing user's terminal on upgrade, unasked. There is no
+    /// accessor to read it through: the key is consumed only by the client, like
+    /// `terminal.cursorBlink`, so the effective document is the observable.
+    #[test]
+    fn ligatures_default_off_and_reject_a_non_bool() {
+        let (_dir, db) = test_db();
+        assert_eq!(
+            db.settings().unwrap().get("terminal.ligatures"),
+            Some(&Value::from(false))
+        );
+
+        db.patch_settings(&patch(&[("terminal.ligatures", Value::from(true))]))
+            .unwrap();
+        assert_eq!(
+            db.settings().unwrap().get("terminal.ligatures"),
+            Some(&Value::from(true))
+        );
+
+        let err = db
+            .patch_settings(&patch(&[("terminal.ligatures", Value::from("calt"))]))
+            .unwrap_err();
+        assert!(matches!(err, DbError::InvalidSetting { .. }));
     }
 
     #[test]

--- a/crates/veld-core/src/db/settings_catalog.rs
+++ b/crates/veld-core/src/db/settings_catalog.rs
@@ -30,7 +30,14 @@
 //!   **unvalidated**, since `Unknown` accepts anything within its size bounds.
 //!
 //! The dialog then renders it and `veld settings` lists, gets, sets and describes
-//! it, with no further change anywhere. A shape the bundle has never heard of
+//! it, with no further change anywhere — for a setting whose row is a control over
+//! a value. A row whose *visibility* turns on something no catalog can state is
+//! the standing exception, and it is a bundle-side edit: a battery-only row is
+//! filtered in the dialog's `HARDWARE_GATES`, and one that depends on a property of
+//! a chosen value — whether the selected font can draw ligatures, which the daemon
+//! cannot know, since it stores a font-family string and never sees a font file —
+//! in its capability gates. Both are keyed by the strings this module owns, which
+//! is what `every_setting_the_dialog_names_by_hand_exists` below is guarding. A shape the bundle has never heard of
 //! renders as a visible "unsupported control" row rather than vanishing — the one
 //! failure mode worth engineering against here is a setting that exists in Rust
 //! and is *invisible* in the UI.
@@ -1673,16 +1680,19 @@ mod bundle_tests {
     /// exists in the catalog.
     ///
     /// **The one drift this change did not remove, gated.** The dialog now takes
-    /// every title, help string, bound and allowed value off the wire — but four
+    /// every title, help string, bound and allowed value off the wire — but five
     /// of its maps are still keyed by Rust-owned *strings*: `OVERRIDES` and
-    /// `TRAILING_ROWS` by setting key, `HARDWARE_GATES` by setting key, and
-    /// `SECTION_BLURBS` by section heading **prose**. Nothing in TypeScript can
-    /// check them, and every failure is silent in the worst direction:
+    /// `TRAILING_ROWS` by setting key, `HARDWARE_GATES` and `CAPABILITY_GATES` by
+    /// setting key, and `SECTION_BLURBS` by section heading **prose**. Nothing in
+    /// TypeScript can check them, and every failure is silent in the worst
+    /// direction:
     ///
     /// - a renamed key drops a bespoke control back to the generic one, so
     ///   `terminal.shell` would render as a plain text box;
     /// - a renamed key drops a hardware gate, so a battery-only row appears on a
     ///   desktop;
+    /// - a renamed key drops a capability gate, so the ligature row appears on
+    ///   every font — Menlo included — offering a switch that cannot do anything;
     /// - a reworded heading drops its explanatory blurb, and the section still
     ///   renders, so nothing looks broken.
     ///
@@ -1701,6 +1711,7 @@ mod bundle_tests {
             ("OVERRIDES", &keys, "setting"),
             ("TRAILING_ROWS", &keys, "setting"),
             ("HARDWARE_GATES", &keys, "setting"),
+            ("CAPABILITY_GATES", &keys, "setting"),
             ("SECTION_BLURBS", &sections, "section heading"),
         ] {
             let body = dialog

--- a/crates/veld-core/src/db/settings_catalog.rs
+++ b/crates/veld-core/src/db/settings_catalog.rs
@@ -865,6 +865,32 @@ impl SettingKey {
                 },
                 requires: None,
             },
+            // Sits under the font rather than beside the cursor: it configures what
+            // the *font* does, and the client hides it for a font it knows cannot.
+            // See `SettingKey::ALL`.
+            //
+            // `!=` and `===` rather than the obvious `->`: the UI font combines the
+            // dash-arrow family itself, so a literal `->` reaches the reader as `→`
+            // — one example already combined, in the help for a switch that is off.
+            // Both bundled terminal fonts combine these two and the UI font leaves
+            // them alone, so the sentence shows what it says.
+            //
+            // "symbol", not "glyph": in both bundled faces `calt` reaches only
+            // `SingleSubst` lookups, so `!=` becomes two alternate glyphs — a left
+            // half and a right half — rather than one merged glyph. That is exactly
+            // why the advance widths hold and the grid stays still. So these are
+            // strictly contextual alternates and not ligatures at all; the title
+            // keeps the word anyway, because that is what the font vendors and
+            // every editor call them and it is the word somebody hunting for this
+            // setting knows. Phrased as JetBrains' IDEs phrase it, which is where
+            // most people will have met the option — the "Enable" is redundant
+            // beside a switch, and is the price of matching what they searched for.
+            Self::TerminalLigatures => toggle_in(
+                "Enable font ligatures",
+                "Whether sequences like != and === are drawn as one combined symbol.",
+                Terminal,
+                APPEARANCE,
+            ),
             Self::TerminalCursorStyle => Spec {
                 title: "Cursor",
                 help: "The shape of a terminal's cursor. A full-screen program that sets its own \
@@ -884,7 +910,6 @@ impl SettingKey {
                 Terminal,
                 APPEARANCE,
             ),
-
             // ── Terminal › Behaviour ─────────────────────────────────────────
             Self::TerminalShell => Spec {
                 title: "Shell",

--- a/crates/veld-daemon/ui/src/components/SettingsDialog.tsx
+++ b/crates/veld-daemon/ui/src/components/SettingsDialog.tsx
@@ -27,6 +27,11 @@
  * - **Hardware facts.** Whether this machine has a battery is not a preference and
  *   no daemon catalog describes it as one, so the battery rows are filtered
  *   client-side in {@link HARDWARE_GATES}.
+ * - **Facts about a chosen value that only the client can know.** Whether the
+ *   selected font can draw ligatures is a property of a font file the daemon never
+ *   sees — it stores a CSS font-family string — so that row is filtered in
+ *   {@link CAPABILITY_GATES}. Same shape as the hardware gates and the same rule:
+ *   an unknown answer shows the row rather than hiding it.
  *
  * A shape this build has never heard of renders as a visible "cannot show this"
  * row rather than vanishing (`Unsupported` below). That is the one failure mode
@@ -105,8 +110,8 @@ import { searchTarget } from "../panes/model";
 import { Modal } from "./dialogs";
 import {
   availableFonts,
-  fontHasLigatures,
   matchFont,
+  showsLigatureRow,
   type TerminalFont,
 } from "../shared/terminalFonts";
 import {
@@ -1282,20 +1287,27 @@ const HARDWARE_GATES: Record<string, (m: Machine) => boolean> = {
  * as it was when a font that has them is selected again, which is better than
  * silently rewriting a preference the user set.
  */
-const CAPABILITY_GATES: Record<
-  string,
-  (settings: SettingsDoc | null, fonts: TerminalFont[]) => boolean
-> = {
-  // `!== false` rather than `=== true`: an unclassifiable custom family answers
-  // `null`, and unknown has to show the row. See `fontHasLigatures`.
-  //
-  // `?? ""` covers the document not having arrived yet, and lands on that same
-  // side: an empty stack matches nothing, so it reads as unknown and shows.
+type CapabilityGate = (
+  settings: SettingsDoc | null,
+  fonts: TerminalFont[],
+) => boolean;
+
+// The type is named rather than inlined so the declaration fits on one line, like
+// the four maps above it — and it has to. The Rust tripwire that checks these keys
+// (`every_setting_the_dialog_names_by_hand_exists`) finds a map by its declaration
+// and then skips exactly the *first* line to reach the entries. A multi-line
+// `Record<…>` type would leave a colon-bearing type line where an entry belongs,
+// and that tripwire fails loudly on a shape it cannot parse rather than skipping
+// it. For the same reason, do not write this map's name after the word `const`
+// anywhere above — including in a comment, which is how this note first broke it.
+const CAPABILITY_GATES: Record<string, CapabilityGate> = {
+  // The three-way rule and its `!== false` comparison live in `showsLigatureRow`,
+  // which is exported and tested; what belongs here is only the reach into the
+  // settings document. `?? ""` covers the document not having arrived yet, and an
+  // empty stack matches nothing — so a not-yet-loaded dialog reads as unknown and
+  // shows the row, the same side every other unknown lands on.
   "terminal.ligatures": (settings, fonts) =>
-    fontHasLigatures(
-      asString(settings?.["terminal.fontFamily"] ?? ""),
-      fonts,
-    ) !== false,
+    showsLigatureRow(asString(settings?.["terminal.fontFamily"] ?? ""), fonts),
 };
 
 /**

--- a/crates/veld-daemon/ui/src/components/SettingsDialog.tsx
+++ b/crates/veld-daemon/ui/src/components/SettingsDialog.tsx
@@ -105,6 +105,7 @@ import { searchTarget } from "../panes/model";
 import { Modal } from "./dialogs";
 import {
   availableFonts,
+  fontHasLigatures,
   matchFont,
   type TerminalFont,
 } from "../shared/terminalFonts";
@@ -1259,6 +1260,45 @@ const HARDWARE_GATES: Record<string, (m: Machine) => boolean> = {
 };
 
 /**
+ * Settings that only apply to what the *current* settings have selected.
+ *
+ * A third gate, beside the catalog's `requires` and {@link HARDWARE_GATES}, and it
+ * exists because neither of those can ask this question. `requires` compares
+ * another setting's stored value for equality — but "the chosen font can draw
+ * them" is not a value of any setting, it is a property of the font behind one.
+ * And the daemon cannot answer it: it stores a CSS font-family string and never
+ * sees a font file, so the knowledge has to sit next to the font list, which is
+ * here in the bundle.
+ *
+ * **Unmounts rather than disables**, which is the `worktree.storageDir` direction
+ * and not the `backup.enabled` one: a ligature switch under Menlo is not a
+ * disabled control, it is a question with nowhere to land — the same reading
+ * {@link HARDWARE_GATES} takes for a battery setting on a desktop. The daemon
+ * still stores and validates the key, so `veld settings set terminal.ligatures`
+ * works whatever font is selected; this hides a control, never a capability.
+ *
+ * A hidden row can therefore sit over a stored `true`. That is deliberate and
+ * harmless — the value is inert on a font that cannot draw them, and it comes back
+ * as it was when a font that has them is selected again, which is better than
+ * silently rewriting a preference the user set.
+ */
+const CAPABILITY_GATES: Record<
+  string,
+  (settings: SettingsDoc | null, fonts: TerminalFont[]) => boolean
+> = {
+  // `!== false` rather than `=== true`: an unclassifiable custom family answers
+  // `null`, and unknown has to show the row. See `fontHasLigatures`.
+  //
+  // `?? ""` covers the document not having arrived yet, and lands on that same
+  // side: an empty stack matches nothing, so it reads as unknown and shows.
+  "terminal.ligatures": (settings, fonts) =>
+    fontHasLigatures(
+      asString(settings?.["terminal.fontFamily"] ?? ""),
+      fonts,
+    ) !== false,
+};
+
+/**
  * The panel scrolls, the sidebar and the footnote do not — the same inner-scroll
  * shape `NewWorktreeDialog` uses, and for the same reason: with the modal body as
  * the scroller, choosing a group would scroll the sidebar out of reach of the next
@@ -1415,6 +1455,8 @@ export function SettingsDialog(props: {
       if (entry.group !== groupId) continue;
       const hardware = HARDWARE_GATES[entry.key];
       if (hardware && !hardware(machine)) continue;
+      const capable = CAPABILITY_GATES[entry.key];
+      if (capable && !capable(settings, fonts)) continue;
 
       // Two shapes of dependency, two behaviours — today's, decided from the
       // catalog rather than from a list of keys kept in step by hand. A boolean

--- a/crates/veld-daemon/ui/src/panes/terminalHost.ts
+++ b/crates/veld-daemon/ui/src/panes/terminalHost.ts
@@ -257,6 +257,54 @@ export function applyTerminalTheme(theme: "dark" | "light"): void {
 }
 
 /**
+ * Ligatures, as a CSS font-feature rule on the host element.
+ *
+ * Not an xterm option (there isn't one) and not `@xterm/addon-ligatures`, which
+ * parses the font binary through `font-finder`/`font-ligatures` and so needs
+ * Node's `fs` — unavailable on the browser path, which is the same bundle the
+ * desktop shell loads by URL.
+ *
+ * Both halves are written explicitly, and the `off` half is the load-bearing one.
+ * xterm's DOM renderer always sets a `letter-spacing` on its row container to
+ * absorb DPR rounding (`DomRenderer._setDefaultSpacing`), and a non-zero
+ * letter-spacing makes Blink and WebKit drop ligatures on their own. So "on" has
+ * to override that suppression, and "off" cannot simply be `normal` — at a
+ * font/DPR combination where the residual lands on exactly 0, `normal` would let
+ * ligatures through with the switch off.
+ *
+ * `calt` is the whole switch; `liga` and `clig` are held at 0 in *both* halves.
+ * Programming fonts put these substitutions in `calt` — both bundled faces ship
+ * `calt` and neither has a `liga` table — and pixel-comparing the four
+ * combinations at the renderer's own metrics says so outright: `liga`+`clig`
+ * with `calt` off renders identically to everything off, and `calt` alone
+ * renders identically to all three on. Naming them bought nothing.
+ *
+ * Naming them also cost something. `liga` is where a text-derived monospace font
+ * keeps its `fi`/`fl`/`ff` ligatures, and *those* are not width-preserving: with
+ * the letter-spacing taken away, `office difficult fluffy affix` measures 963px
+ * in Menlo against 1117px unligated. The non-zero letter-spacing above is what
+ * suppresses them today — but it is a residual derived from font metrics, and
+ * the font/DPR combination that lands it on exactly 0 is the same edge the `off`
+ * half is written out for. There, tagging `liga` would trade a broken grid for
+ * glyphs no font we offer even has.
+ *
+ * Set on the host element rather than on `.xterm`, so it also inherits into the
+ * renderer's own hidden measuring container — measurement and painting must not
+ * disagree about which glyphs they are looking at. Enabling this changes no
+ * advance width in either bundled font, and a GSUB dump says why rather than
+ * leaving it to luck: `calt` reaches only `SingleSubst` lookups in both faces —
+ * neither contains a `LigatureSubst` at all — so `!=` stays two glyphs, a left
+ * half and a right half, instead of collapsing into one. The cell box and the
+ * grid are unaffected; only the painted shapes differ.
+ */
+const LIGATURES_ON = '"liga" 0, "clig" 0, "calt" 1';
+const LIGATURES_OFF = '"liga" 0, "clig" 0, "calt" 0';
+
+function applyLigatures(container: HTMLElement, on: boolean): void {
+  container.style.fontFeatureSettings = on ? LIGATURES_ON : LIGATURES_OFF;
+}
+
+/**
  * Re-style every live terminal and re-measure each one.
  *
  * **Every** session, not only the visible one. Hidden terminals stay in the
@@ -286,6 +334,7 @@ export function applyTerminalPrefs(next: TerminalPrefs): void {
     s.term.options.fontFamily = next.fontFamily;
     s.term.options.cursorStyle = next.cursorStyle;
     s.term.options.cursorBlink = next.cursorBlink;
+    applyLigatures(s.container, next.ligatures);
     // Lowering scrollback drops the oldest lines immediately, which is what the
     // settings copy promises.
     s.term.options.scrollback = next.scrollback;
@@ -718,6 +767,7 @@ function ensure(
 
   const container = document.createElement("div");
   container.className = "term-host";
+  applyLigatures(container, p.ligatures);
 
   const s: Session = {
     id,

--- a/crates/veld-daemon/ui/src/shared/settings.test.ts
+++ b/crates/veld-daemon/ui/src/shared/settings.test.ts
@@ -42,6 +42,7 @@ describe("terminalPrefs", () => {
       "terminal.fontFamily": "Fira Code",
       "terminal.cursorStyle": "bar",
       "terminal.cursorBlink": false,
+      "terminal.ligatures": true,
       "terminal.scrollback": 1000,
       "terminal.bellVolume": 60,
       "terminal.shiftEnterNewline": false,
@@ -54,6 +55,7 @@ describe("terminalPrefs", () => {
       fontFamily: "Fira Code",
       cursorStyle: "bar",
       cursorBlink: false,
+      ligatures: true,
       scrollback: 1000,
       bellVolume: 60,
       shiftEnterNewline: false,
@@ -81,6 +83,7 @@ describe("terminalPrefs", () => {
     expect(p.fontSize).toBe(12);
     expect(p.scrollback).toBe(10000);
     expect(p.cursorStyle).toBe("block");
+    expect(p.ligatures).toBe(false);
   });
 
   it("rejects a wrong-typed value rather than passing it to xterm", () => {
@@ -88,10 +91,12 @@ describe("terminalPrefs", () => {
       "terminal.fontSize": "big" as unknown as number,
       "terminal.cursorBlink": 1 as unknown as boolean,
       "terminal.cursorStyle": "wobble",
+      "terminal.ligatures": "yes" as unknown as boolean,
     });
     expect(p.fontSize).toBe(12);
     expect(p.cursorBlink).toBe(true);
     expect(p.cursorStyle).toBe("block");
+    expect(p.ligatures).toBe(false);
   });
 
   it("rejects a non-finite font size", () => {

--- a/crates/veld-daemon/ui/src/shared/settings.ts
+++ b/crates/veld-daemon/ui/src/shared/settings.ts
@@ -78,6 +78,9 @@ const FALLBACK = {
     '"JetBrains Mono Variable", "JetBrains Mono", ui-monospace, monospace',
   cursorStyle: "block" as CursorStyle,
   cursorBlink: true,
+  // Off is both the shipped default and every previous release's behaviour, so
+  // this one needs none of the exception reasoning the switches below carry.
+  ligatures: false,
   scrollback: 10000,
   bellVolume: 75,
   shiftEnterNewline: true,
@@ -247,6 +250,9 @@ export interface TerminalPrefs {
   fontFamily: string;
   cursorStyle: CursorStyle;
   cursorBlink: boolean;
+  /** Draw sequences like `->` and `!=` as one combined symbol, where the font
+   *  has them. Applied as a CSS font-feature rule, not an xterm option. */
+  ligatures: boolean;
   scrollback: number;
   bellVolume: number;
   shiftEnterNewline: boolean;
@@ -271,6 +277,7 @@ export function terminalPrefs(doc: SettingsDoc): TerminalPrefs {
       FALLBACK.cursorStyle,
     ),
     cursorBlink: bool(doc, "terminal.cursorBlink", FALLBACK.cursorBlink),
+    ligatures: bool(doc, "terminal.ligatures", FALLBACK.ligatures),
     scrollback: num(doc, "terminal.scrollback", FALLBACK.scrollback),
     bellVolume: num(doc, "terminal.bellVolume", FALLBACK.bellVolume),
     shiftEnterNewline: bool(

--- a/crates/veld-daemon/ui/src/shared/terminalFonts.test.ts
+++ b/crates/veld-daemon/ui/src/shared/terminalFonts.test.ts
@@ -8,6 +8,7 @@ import {
   fontAvailable,
   fontHasLigatures,
   matchFont,
+  showsLigatureRow,
 } from "./terminalFonts";
 
 describe("font lists", () => {
@@ -87,7 +88,9 @@ describe("fontHasLigatures", () => {
     // Both bundled fonts, and exactly one system font, are the ligature-capable
     // ones. Asserted through the resolver rather than by reading the flag, so the
     // stack-matching is covered too.
-    expect(fontHasLigatures(BUNDLED_FONTS[0].stack, BUNDLED_FONTS)).toBe(true);
+    for (const f of BUNDLED_FONTS) {
+      expect(fontHasLigatures(f.stack, BUNDLED_FONTS)).toBe(true);
+    }
     expect(fontHasLigatures("Menlo, ui-monospace, monospace", SYSTEM_FONTS)).toBe(
       false,
     );
@@ -117,5 +120,29 @@ describe("fontHasLigatures", () => {
   it("ignores quoting and case in the family name", () => {
     expect(fontHasLigatures("menlo", SYSTEM_FONTS)).toBe(false);
     expect(fontHasLigatures("'Cascadia Code'", SYSTEM_FONTS)).toBe(true);
+  });
+});
+
+describe("showsLigatureRow", () => {
+  it("hides the row only for a font we classify as incapable", () => {
+    expect(showsLigatureRow("Menlo, ui-monospace, monospace", SYSTEM_FONTS)).toBe(
+      false,
+    );
+    expect(showsLigatureRow(BUNDLED_FONTS[0].stack, BUNDLED_FONTS)).toBe(true);
+  });
+
+  it("shows the row for a family it cannot classify", () => {
+    // The assertion that makes `!== false` load-bearing. Tightening the gate to
+    // `=== true` passes every test above and fails these two: a ligature font we
+    // do not list would lose its control, along with any stored preference.
+    expect(showsLigatureRow("Iosevka, monospace", SYSTEM_FONTS)).toBe(true);
+    expect(showsLigatureRow('"Victor Mono", monospace', SYSTEM_FONTS)).toBe(true);
+  });
+
+  it("shows the row before the settings document has arrived", () => {
+    // The dialog passes `""` while `/api/settings` is still in flight. That is an
+    // unknown font, not an incapable one, so it takes the showing side — the same
+    // direction as every other unknown here.
+    expect(showsLigatureRow("", SYSTEM_FONTS)).toBe(true);
   });
 });

--- a/crates/veld-daemon/ui/src/shared/terminalFonts.test.ts
+++ b/crates/veld-daemon/ui/src/shared/terminalFonts.test.ts
@@ -6,6 +6,7 @@ import {
   availableFonts,
   firstFamily,
   fontAvailable,
+  fontHasLigatures,
   matchFont,
 } from "./terminalFonts";
 
@@ -78,5 +79,43 @@ describe("matchFont", () => {
 
   it("returns null for a custom value", () => {
     expect(matchFont("Comic Mono, monospace", opts)).toBeNull();
+  });
+});
+
+describe("fontHasLigatures", () => {
+  it("answers from the flag for a font we offer", () => {
+    // Both bundled fonts, and exactly one system font, are the ligature-capable
+    // ones. Asserted through the resolver rather than by reading the flag, so the
+    // stack-matching is covered too.
+    expect(fontHasLigatures(BUNDLED_FONTS[0].stack, BUNDLED_FONTS)).toBe(true);
+    expect(fontHasLigatures("Menlo, ui-monospace, monospace", SYSTEM_FONTS)).toBe(
+      false,
+    );
+    expect(
+      fontHasLigatures('"Cascadia Code", ui-monospace, monospace', SYSTEM_FONTS),
+    ).toBe(true);
+  });
+
+  it("answers null — never false — for a family it cannot classify", () => {
+    // The load-bearing case. Nothing in a browser can read a font's OpenType
+    // tables, and these ligatures are width-preserving so measuring cannot
+    // substitute. `null` is what keeps the dialog showing the control for
+    // Iosevka, Monaspace, a Nerd-Font patch — all of which do have ligatures.
+    expect(fontHasLigatures("Iosevka, monospace", SYSTEM_FONTS)).toBeNull();
+    expect(fontHasLigatures("", SYSTEM_FONTS)).toBeNull();
+  });
+
+  it("matches the first family, so an added fallback still counts", () => {
+    // A user who appends a fallback to a listed font has still chosen that font;
+    // `matchFont` would call the stack custom, which would lose the answer.
+    expect(matchFont('"Fira Code Variable", Menlo', BUNDLED_FONTS)).toBeNull();
+    expect(fontHasLigatures('"Fira Code Variable", Menlo', BUNDLED_FONTS)).toBe(
+      true,
+    );
+  });
+
+  it("ignores quoting and case in the family name", () => {
+    expect(fontHasLigatures("menlo", SYSTEM_FONTS)).toBe(false);
+    expect(fontHasLigatures("'Cascadia Code'", SYSTEM_FONTS)).toBe(true);
   });
 });

--- a/crates/veld-daemon/ui/src/shared/terminalFonts.ts
+++ b/crates/veld-daemon/ui/src/shared/terminalFonts.ts
@@ -37,11 +37,21 @@ export interface TerminalFont {
    *
    * A **static claim about the published font**, and it has to be: nothing in the
    * browser can read a font's OpenType tables. Measuring is not a way around it
-   * either: the substitution is glyph-for-glyph (`calt` into `SingleSubst`, never
-   * a `LigatureSubst`), so it is width-preserving by construction — which is what
-   * keeps the terminal grid still, and which leaves the one quantity the DOM
-   * exposes blind to it (measured: `=> != === ->` is 460.8047px in JetBrains Mono
-   * and 462.375px in Menlo, each identical with the features on and off).
+   * either — for the sequences this setting is about, the substitution is
+   * glyph-for-glyph, so it is width-preserving and the one quantity the DOM
+   * exposes is blind to it (measured: `=> != === ->` is 460.8047px in JetBrains
+   * Mono and 462.375px in Menlo, each identical with the features on and off).
+   *
+   * That width-preservation is **verified for the two bundled faces, not assumed
+   * of every font this flag is `true` for**. In both bundled faces `calt` reaches
+   * `SingleSubst` lookups only. Cascadia Code is the counterexample worth knowing:
+   * its `calt` also reaches a `MultipleSubst` and a `LigatureSubst` — but both are
+   * Arabic-script only (a lam-lam-heh ligature collapsing four cells into one, and
+   * a connector splitting one into two), and neither is reachable from ASCII. So
+   * the grid holds for the programming sequences this setting exists for, and a
+   * terminal rendering Arabic *in Cascadia Code with the switch on* is the one
+   * combination where it may not. Off is the default, and the off half pins `calt`
+   * to 0, so nothing here changes unless somebody asks for it.
    *
    * So the honest scope of this flag is the fonts *we* offer. A family the user
    * typed themselves is not classified at all — see {@link fontHasLigatures},
@@ -96,9 +106,17 @@ export const SYSTEM_FONTS: TerminalFont[] = [
     label: "Cascadia Code",
     stack: `"Cascadia Code", ${TAIL}`,
     bundled: false,
-    // The one ligature-capable font on this list. Microsoft ships the no-ligature
-    // cut under a *different* family name — Cascadia Mono — so this flag does not
-    // have to guess which build is installed.
+    // The one ligature-capable font on this list, and the only `true` here that
+    // is not a face we bundle — so it got the same GSUB dump rather than a
+    // reputation: `calt` present, `liga`/`clig`/`dlig` absent, which is what makes
+    // the `calt`-only rule in `terminalHost.ts` actually reach it. Its `calt` does
+    // also reach two width-changing lookups, but both are Arabic-only and
+    // unreachable from ASCII — see the note on {@link TerminalFont.ligatures}.
+    //
+    // Microsoft ships the no-ligature cut under a *different* family name —
+    // Cascadia Mono, confirmed as family `"Cascadia Mono"` against `"Cascadia
+    // Code"` in the release binaries — so this flag does not have to guess which
+    // build is installed. JetBrains does the same thing (`JetBrains Mono NL`).
     ligatures: true,
   },
   { label: "IBM Plex Mono", stack: `"IBM Plex Mono", ${TAIL}`, bundled: false, ligatures: false },

--- a/crates/veld-daemon/ui/src/shared/terminalFonts.ts
+++ b/crates/veld-daemon/ui/src/shared/terminalFonts.ts
@@ -88,6 +88,15 @@ export const BUNDLED_FONTS: TerminalFont[] = [
 /**
  * Monospace fonts common enough to be worth offering, in rough order of how likely
  * a developer is to have one. Zero bytes; availability is checked at render time.
+ *
+ * The `ligatures: false` entries are two different strengths of claim, and it is
+ * worth knowing which is which. Three are read from the binaries macOS ships: SF
+ * Mono carries no `liga`/`clig`/`dlig`/`calt` at all, and Menlo and Monaco have no
+ * `GSUB` table whatsoever. The other five — Source Code Pro, Consolas, IBM Plex
+ * Mono, DejaVu Sans Mono, Ubuntu Mono — rest on those families not shipping
+ * programming ligatures, not on a dump of a file we had to hand. That weaker claim
+ * is tolerable here and would not be for a `true`: a wrong `false` hides a control,
+ * while a wrong `true` offers a switch that does nothing.
  */
 export const SYSTEM_FONTS: TerminalFont[] = [
   { label: "SF Mono", stack: `"SF Mono", ${TAIL}`, bundled: false, ligatures: false },
@@ -188,6 +197,15 @@ export function availableFonts(): TerminalFont[] {
  * Matched on the **first family** rather than the whole stack, because a user who
  * appends a fallback to a listed font ("Fira Code", "Menlo", monospace) has still
  * chosen Fira Code, and {@link matchFont} would call that stack custom.
+ *
+ * So this deliberately disagrees with {@link matchFont}, which is what the font
+ * picker uses to choose between a preset and "Custom…". A stored `Menlo, monospace`
+ * reads as *custom* in the picker and as *Menlo* here, and both are right: they
+ * answer different questions — which preset this is, versus which font will
+ * actually draw. The disagreement stays safe in the hiding direction because the
+ * options handed in are already filtered by {@link availableFonts}: a first family
+ * that is not installed is not among them, so it answers `null` and shows the row,
+ * rather than answering `false` for a font the browser was never going to reach.
  */
 export function fontHasLigatures(
   stack: string,
@@ -198,6 +216,28 @@ export function fontHasLigatures(
     (f) => firstFamily(f.stack).replace(/["']/g, "").toLowerCase() === want,
   );
   return hit ? hit.ligatures : null;
+}
+
+/**
+ * Whether the settings dialog should show the ligature row for a stored stack.
+ *
+ * The whole rule is the comparison: `!== false`, never `=== true`. Three answers
+ * come back from {@link fontHasLigatures} and only one of them may hide the row —
+ * a font we classify and know cannot draw them. *Unknown* has to show, or every
+ * user of a ligature font we do not list (Iosevka, Monaspace, Victor Mono, a
+ * Nerd-Font patch) loses the control, and with it any way to reach a preference
+ * they may already have stored.
+ *
+ * A function of its own, and exported, so that comparison is pinned by a test.
+ * Tightening it to `=== true` compiles clean, passes every other test, and breaks
+ * exactly the case this setting was designed around — which is the kind of silent
+ * inversion the rest of this file's tripwires exist to catch.
+ */
+export function showsLigatureRow(
+  stack: string,
+  options: TerminalFont[] = availableFonts(),
+): boolean {
+  return fontHasLigatures(stack, options) !== false;
 }
 
 /**

--- a/crates/veld-daemon/ui/src/shared/terminalFonts.ts
+++ b/crates/veld-daemon/ui/src/shared/terminalFonts.ts
@@ -31,6 +31,23 @@ export interface TerminalFont {
   stack: string;
   /** Bundled in the binary (always available) vs relying on the OS. */
   bundled: boolean;
+  /**
+   * Whether the font as published draws programming ligatures and contextual
+   * alternates (`calt`) — `=>`, `!=`, `===`.
+   *
+   * A **static claim about the published font**, and it has to be: nothing in the
+   * browser can read a font's OpenType tables. Measuring is not a way around it
+   * either: the substitution is glyph-for-glyph (`calt` into `SingleSubst`, never
+   * a `LigatureSubst`), so it is width-preserving by construction — which is what
+   * keeps the terminal grid still, and which leaves the one quantity the DOM
+   * exposes blind to it (measured: `=> != === ->` is 460.8047px in JetBrains Mono
+   * and 462.375px in Menlo, each identical with the features on and off).
+   *
+   * So the honest scope of this flag is the fonts *we* offer. A family the user
+   * typed themselves is not classified at all — see {@link fontHasLigatures},
+   * which answers `null` there rather than guessing.
+   */
+  ligatures: boolean;
 }
 
 /**
@@ -41,15 +58,20 @@ export interface TerminalFont {
 const TAIL = "ui-monospace, monospace";
 
 export const BUNDLED_FONTS: TerminalFont[] = [
+  // Both `true` from the font files themselves rather than from their reputation:
+  // a GSUB dump of the two woff2s we ship shows `calt` and no `liga` table in
+  // either, which is also why the renderer tags `calt` and not only `liga`.
   {
     label: "JetBrains Mono",
     stack: `"JetBrains Mono Variable", "JetBrains Mono", ${TAIL}`,
     bundled: true,
+    ligatures: true,
   },
   {
     label: "Fira Code",
     stack: `"Fira Code Variable", "Fira Code", ${TAIL}`,
     bundled: true,
+    ligatures: true,
   },
 ];
 
@@ -58,19 +80,35 @@ export const BUNDLED_FONTS: TerminalFont[] = [
  * a developer is to have one. Zero bytes; availability is checked at render time.
  */
 export const SYSTEM_FONTS: TerminalFont[] = [
-  { label: "SF Mono", stack: `"SF Mono", ${TAIL}`, bundled: false },
+  { label: "SF Mono", stack: `"SF Mono", ${TAIL}`, bundled: false, ligatures: false },
   {
     label: "Source Code Pro",
     stack: `"Source Code Pro", ${TAIL}`,
     bundled: false,
+    // The upstream family has no programming ligatures; the fork that added them
+    // is Fira Code, which is its own entry above.
+    ligatures: false,
   },
-  { label: "Menlo", stack: `Menlo, ${TAIL}`, bundled: false },
-  { label: "Monaco", stack: `Monaco, ${TAIL}`, bundled: false },
-  { label: "Consolas", stack: `Consolas, ${TAIL}`, bundled: false },
-  { label: "Cascadia Code", stack: `"Cascadia Code", ${TAIL}`, bundled: false },
-  { label: "IBM Plex Mono", stack: `"IBM Plex Mono", ${TAIL}`, bundled: false },
-  { label: "DejaVu Sans Mono", stack: `"DejaVu Sans Mono", ${TAIL}`, bundled: false },
-  { label: "Ubuntu Mono", stack: `"Ubuntu Mono", ${TAIL}`, bundled: false },
+  { label: "Menlo", stack: `Menlo, ${TAIL}`, bundled: false, ligatures: false },
+  { label: "Monaco", stack: `Monaco, ${TAIL}`, bundled: false, ligatures: false },
+  { label: "Consolas", stack: `Consolas, ${TAIL}`, bundled: false, ligatures: false },
+  {
+    label: "Cascadia Code",
+    stack: `"Cascadia Code", ${TAIL}`,
+    bundled: false,
+    // The one ligature-capable font on this list. Microsoft ships the no-ligature
+    // cut under a *different* family name — Cascadia Mono — so this flag does not
+    // have to guess which build is installed.
+    ligatures: true,
+  },
+  { label: "IBM Plex Mono", stack: `"IBM Plex Mono", ${TAIL}`, bundled: false, ligatures: false },
+  {
+    label: "DejaVu Sans Mono",
+    stack: `"DejaVu Sans Mono", ${TAIL}`,
+    bundled: false,
+    ligatures: false,
+  },
+  { label: "Ubuntu Mono", stack: `"Ubuntu Mono", ${TAIL}`, bundled: false, ligatures: false },
 ];
 
 /**
@@ -111,6 +149,37 @@ export function availableFonts(): TerminalFont[] {
     ...BUNDLED_FONTS,
     ...SYSTEM_FONTS.filter((f) => fontAvailable(firstFamily(f.stack))),
   ];
+}
+
+/**
+ * Whether the stored font stack draws ligatures — `null` when we cannot tell.
+ *
+ * Three answers, not two, and the third is the important one. A stack that
+ * matches an offered font answers from that font's {@link TerminalFont.ligatures}
+ * flag. A stack the user typed themselves matches nothing, and there is no way to
+ * inspect it (see that flag's note), so it answers `null` — *unknown*, never
+ * `false`.
+ *
+ * Callers must let unknown mean "show the control". Hiding it would strand every
+ * user of a ligature font we happen not to list — Iosevka, Monaspace, Victor
+ * Mono, a Nerd-Font patch — with a stored preference they can no longer reach,
+ * and the setting they wanted silently unavailable. That is the same direction
+ * `fontAvailable` takes for a missing API, and the same rule the dialog's
+ * hardware gates state for a probe that has not answered.
+ *
+ * Matched on the **first family** rather than the whole stack, because a user who
+ * appends a fallback to a listed font ("Fira Code", "Menlo", monospace) has still
+ * chosen Fira Code, and {@link matchFont} would call that stack custom.
+ */
+export function fontHasLigatures(
+  stack: string,
+  options: TerminalFont[] = availableFonts(),
+): boolean | null {
+  const want = firstFamily(stack).replace(/["']/g, "").toLowerCase();
+  const hit = options.find(
+    (f) => firstFamily(f.stack).replace(/["']/g, "").toLowerCase() === want,
+  );
+  return hit ? hit.ligatures : null;
 }
 
 /**


### PR DESCRIPTION
Adds `terminal.ligatures` — a boolean, **off by default** — that makes terminal
panes draw `=>`, `!=`, `===` as one combined symbol where the selected font can.
The row sits in Settings → Terminal directly under the font picker it configures,
and is hidden for a font known not to support them.

Off by default deliberately: both bundled fonts can do this, so defaulting on
would redraw every existing user's terminal unasked.

## `calt` alone, and why that is the whole feature

Applied as a CSS `font-feature-settings` rule on the pane host. xterm has no
option for font features, and `@xterm/addon-ligatures` is unusable here — it
reads the font binary through Node's `fs`, which the browser bundle does not have.

The rule sets `"calt" 1` and holds `liga`/`clig` at **0 in both halves**. Three
measurements decided that, rather than taste:

| check | result |
|---|---|
| GSUB dump, both bundled faces | `calt` present; `liga`/`clig`/`dlig` absent; `calt` reaches only `SingleSubst`, **no `LigatureSubst` anywhere** |
| pixel-compare, 4 feature combinations, at the renderer's real metrics | `liga`+`clig` with `calt` off ≡ everything off; `calt` alone ≡ all three on |
| `office difficult fluffy affix`, Menlo, letter-spacing removed | 963px ligated vs 1117px unligated |
| GSUB dump, Cascadia Code (the one offered system font flagged capable) | `calt` present; `liga`/`clig`/`dlig` absent — so the `calt`-only rule does reach it. Its `calt` *does* reach a `MultipleSubst` and a `LigatureSubst`, but both are **Arabic-only and unreachable from ASCII** (a lam-lam-heh collapsing four cells to one, and a connector splitting one into two) |
| GSUB dump, the faces macOS ships | SF Mono has no `liga`/`clig`/`dlig`/`calt` at all; **Menlo and Monaco have no `GSUB` table whatsoever** |

Row 1 is why the grid does not move: `!=` becomes two alternate half-glyphs, not
one merged glyph, so advance widths are preserved by construction. Row 4 is the
honest boundary on that — width-preservation is **verified for the faces we dumped,
not assumed of every font the flag is `true` for**. The one exception found is
Arabic in Cascadia Code with the switch on, which is not reachable from the
programming sequences this setting exists for; off is the default, and the off half
pins `calt` to 0. (Strictly,
then, these are contextual alternates and not ligatures at all. The setting keeps
the word, because it is what the font vendors and every editor call them, and it
is the word somebody hunting for this setting will search for.)

Row 2 is why naming `liga`/`clig` buys nothing. Row 3 is why naming them would
have **cost** something: `liga` is where a text-derived monospace font keeps its
`fi`/`fl`/`ff`, and those are not width-preserving. What suppresses them today is
xterm's `letter-spacing`, which is a font-metric residual (`0.0125px` here) — and
a residual can land on exactly 0, which is the same edge the explicit `off` half
exists for. Pinning them to 0 closes that unconditionally at zero cost.

## Hidden, not disabled, for a font that cannot draw them

A third gate beside the catalog's `requires` and the dialog's `HARDWARE_GATES`,
because neither can ask this question: the daemon stores a CSS font-family string
and never sees a font file. A static per-font flag answers for the fonts we offer
and `null` — never `false` — for a family the user typed, so an unclassifiable
custom font always shows the control. That is the house rule for these gates:
**unknown shows the row, never hides it.** Hiding on unknown would strand every
Iosevka / Monaspace / Victor Mono / Nerd-Font user with a preference they cannot
reach.

A hidden row can sit over a stored `true`. Deliberate: the value is inert on a
font that cannot draw them, and returns as it was when a capable font is picked
again. `veld settings set terminal.ligatures` keeps working whatever font is
selected — this hides a control, never a capability.

## Rejected alternatives

**Shape of the setting**

| candidate | why not |
|---|---|
| enum `off` / `standard` / `all` | the middle value has no referent — there is no second tier to opt into once `liga`/`clig` are pinned off, so two of three values would mean the same thing |
| a raw CSS `font-feature-settings` string | hands the user a syntax with no validation story and an unbounded blast radius on the grid; the width-preserving guarantee above only holds for the features we chose |
| an integer bitmask | unreadable in the DB and in `veld settings get`, for one bit of information |
| two keys day one (`ligatures` + `contextualAlternates`) | one is inert, and a key is forever |

**Mechanism**

| candidate | why not |
|---|---|
| `@xterm/addon-ligatures` | reads the font file via Node `fs`; there is no `fs` in the browser bundle |
| `registerCharacterJoiner` | joins cells for *selection/link* purposes; does not change what the renderer paints |
| calibrating font-size so the letter-spacing residual lands on 0 | fixes the symptom by moving a number nobody asked us to own, and breaks the user's chosen size |
| forking `DomRendererRowFactory` | vendors a renderer internal into our tree for one CSS property |
| a decorative overlay drawing the glyphs | two sources of truth for what the terminal says |

**Capability gating**

| candidate | why not |
|---|---|
| disable the row with a reason instead of hiding it | a disabled control with "your font can't do this" is a worse answer than the control not being part of that font's settings — and it would have to lie for the `null` case |
| daemon-side OpenType/GSUB inspection to classify custom fonts truthfully | the honest fix, and genuinely better; it needs a font-file locator per platform and a GSUB parser in `veld-core`. Out of scope here — the `null` path already lands on the safe side. Worth a ticket. |
| detecting capability in the browser | not possible. `ctx.fontFeatureSettings` does not exist; `new FontFace(…, {featureSettings})` over `src: local(…)` throws `NetworkError`; SVG `foreignObject` → canvas taints; width measurement is blind *because* the substitution is width-preserving |

## Testing

Hand-driven against a dev stack: the row's title, position and alignment; the
`!=`/`===` examples rendering unligated in the UI font as intended; and the gate
in all three states — Menlo → hidden, Iosevka (unlisted, custom) → shown,
Fira Code → shown. Ligatures confirmed visually on and off in a pane.

Unit: `settings.rs` covers the default and rejects a non-bool; `terminalFonts.test.ts`
covers `fontHasLigatures` including the `null`-for-unknown path, and pins the gate's
`!== false` through the exported `showsLigatureRow` — tightening it to `=== true`
fails two assertions rather than passing the suite, which is what it used to do.

Tripwire: `every_setting_the_dialog_names_by_hand_exists` now reads
`CAPABILITY_GATES` as its fifth map, so renaming `terminal.ligatures` in the catalog
fails a Rust test instead of silently showing the row on every font. Negative-tested
in both directions.

## Review

Standard autonomous loop (`docs/agentic-review.md`), 8 spawns over 2 rounds, angles
1/2/3/4/5/6/7. Zero critical. Findings that changed the diff:

- **The Cascadia Code width claim** (🟠, angles 1 and 4 independently, same stage).
  Both flagged it as the only `ligatures: true` not backed by a dump, and both named
  the dump as the settling check. Running it *refuted* the feared failure — the
  `calt`-only rule does reach Cascadia — but falsified the code comment's universal
  "never a `LigatureSubst`". Scoped the claim; no behaviour change.
- **The capability gate was outside the tripwire** (🟠). `CAPABILITY_GATES` was the
  fifth bundle-owned map keyed by a Rust-owned string and the only one the existing
  guard did not read. Adding the arm needed the declaration on one line first —
  that test reaches a map's entries by skipping exactly one line, so the inlined
  multi-line `Record<…>` type made it *fail* rather than pass.
- **The gate's polarity was untested** (🟠). `!== false` is the whole design, and
  `=== true` used to pass the entire suite.
- Four doc claims corrected, including a pre-existing "no further change anywhere"
  in `settings_catalog.rs` that `OVERRIDES` and `HARDWARE_GATES` already
  contradicted, and the eight uncited `ligatures: false` flags.

Two findings were judged **not defects** and documented instead of changed: the
deliberate first-family/`matchFont` divergence (matching the whole stack would show
a dead switch on `Menlo, monospace`), and a first-load visibility flicker where every
alternative merely moves the transition. Both reasonings are now in the code.
