### PR TITLE
docs(ci): record why the ship check is not required, where the harness is edited

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,12 @@ jobs:
   # `no-ship` label is the only other way through, and applying it needs write
   # access.
   #
+  # **This job is not a required status check, and that is deliberate** — making
+  # it one would reject semantic-release's push to `main`, and the GitHub Actions
+  # identity cannot be exempted by a repository ruleset's bypass list. The
+  # measurements and the two changes that would make it requirable are in
+  # AGENTS.md → Agent Skills. Do not "fix" this by enabling the ruleset.
+  #
   # **Do not convert this job to `pull_request_target`.** It executes a script
   # from the checkout, which is harmless here — a fork PR gets a read-only token
   # and no secrets — and becomes arbitrary code with the repository's own token

--- a/tests/validate-ship-stamp.sh
+++ b/tests/validate-ship-stamp.sh
@@ -32,6 +32,12 @@
 #     gate that cannot run is neither. Collapsing them meant a mid-PR branch
 #     rename produced "you skipped the workflow" — a false accusation, on a
 #     message that tells the reader not to investigate.
+# One thing this gate deliberately is NOT: a required status check on `main`.
+# Requiring it would reject `@semantic-release/git`'s direct push, and the
+# GitHub Actions identity cannot be put on a repository ruleset's bypass list.
+# So a red result here blocks nothing by itself — it is a signal a maintainer
+# acts on. AGENTS.md → Agent Skills carries the measurements and what it would
+# take to change that; do not enable the ruleset without reading it.
 set -euo pipefail
 
 HELPER=scripts/dev/prmeta.sh


### PR DESCRIPTION
## What changed

Twelve lines of comment, two files, no behaviour change.

`AGENTS.md` already records why the `ship` check is deliberately not a required
status check — with the measurements behind it — but the two files an agent
actually opens when it touches this machinery did not point at them:

- `.github/workflows/ci.yml`'s `ship` job — read when editing CI
- `tests/validate-ship-stamp.sh`'s header — read when editing the gate

So the obvious-looking "improvement" of enabling the ruleset sat one step away
with no warning at the point of edit. Both now say the check is deliberately not
required, that requiring it would reject semantic-release's push to `main`, and
where the reasoning lives.

## Why this exists at all

Shipped as a follow-up to #352, where the maintainer asked for the constraint to
be marked "in the docs/harness". The docs half was already done in that PR; this
is the harness half.

## Test evidence

```
shellcheck --severity=warning       clean
tests/validate-ship-stamp.sh        --selftest, 17/17 fixtures
just workflow-gates                 0
just ship-stamp                     ✅ Ship stamp verified
```

That last line is the notable one: **this is the first PR the gate verifies for
real.** #352 had to carry a `no-ship` waiver, because the gate reads its helper
from the base commit and the helper did not exist on `main` yet. It does now, so
this PR is stamped and checked with no fallback and no waiver — which is also the
first end-to-end confirmation that the mechanism works rather than merely
self-tests.

## Reviewer scope

Comments only. No Rust, no TypeScript, no shell logic. Review depth was the
agentic-review trivia clause (§11) rather than the standard loop, on the grounds
that the diff adds no executable line — stated here so the choice is visible
rather than assumed.

---
🚢 Carried by the ship workflow (`docs/ship.md`).

| Setting | This run |
|---|---|
| Review depth | Super light — trivia clause, comment-only diff |
| Merge policy | Bypass-merge on green CI (carried over from #352) |
| Hands-on checkpoints | None |
| Docs & tests | Internal — AGENTS.md checklist N/A |
| Promotion | No |
