### PR TITLE
fix(signing): stop the version-record needle being const-folded into the helper

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,20 +220,24 @@ jobs:
           # Mirrors `veld_core::signing::parse_version_field`: a hit whose field
           # is not printable ASCII followed by NUL padding is NOT a record, and
           # the Rust reader skips it. Counting every occurrence of the magic
-          # instead would let one unlucky 16-byte sequence in a dependency fail a
-          # release the runtime would read perfectly.
+          # instead would let one unlucky 16-byte sequence in a dependency — or
+          # a const-folded copy of the needle on some target — fail a release the
+          # runtime would read perfectly.
           #
-          # The tolerance stops there, and deliberately. A *const-folded copy of
-          # the needle* is not a false alarm to be waved through: v16.66.0 failed
-          # here because the `x86_64-unknown-linux-gnu` helper carried one
-          # immediately before a `rustls` error string, whose text is printable
-          # ASCII and therefore a perfectly well-formed field. The runtime reader
-          # would not have "read it perfectly" — it would have seen two
-          # disagreeing records, returned `None`, and refused to install the
-          # helper on every privileged machine. This step is the only gate that
-          # catches that, so widening the tolerance to make it quiet is the one
-          # edit to never make here; fix the binary instead (see
-          # `veld_core::signing::version_record_magic_at_runtime`).
+          # That reasoning holds, and v16.66.0 is the case it does not cover. A
+          # const-folded needle is benign only while whatever the linker parked
+          # behind it is *not* a well-formed field, and that is luck, not a rule:
+          # the `x86_64-unknown-linux-gnu` helper folded one immediately before a
+          # `rustls` error string, whose text is printable ASCII and therefore a
+          # perfectly good field. Two records, two versions, and the runtime
+          # reader would have returned `None` and refused the install on every
+          # privileged machine — so the release failing here was correct.
+          #
+          # The lesson is about which side to fix. When this step fires, remove
+          # the second record from the binary (see
+          # `veld_core::signing::version_record_magic_at_runtime`); do not widen
+          # the tolerance to quiet it, because this is the only gate that can see
+          # the difference between the benign case above and that one.
           def field_version(raw):
               end = raw.find(b"\0")
               end = len(raw) if end < 0 else end

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,9 +220,20 @@ jobs:
           # Mirrors `veld_core::signing::parse_version_field`: a hit whose field
           # is not printable ASCII followed by NUL padding is NOT a record, and
           # the Rust reader skips it. Counting every occurrence of the magic
-          # instead would let one unlucky 16-byte sequence in a dependency — or
-          # a const-folded copy of the needle on some target — fail a release the
-          # runtime would read perfectly.
+          # instead would let one unlucky 16-byte sequence in a dependency fail a
+          # release the runtime would read perfectly.
+          #
+          # The tolerance stops there, and deliberately. A *const-folded copy of
+          # the needle* is not a false alarm to be waved through: v16.66.0 failed
+          # here because the `x86_64-unknown-linux-gnu` helper carried one
+          # immediately before a `rustls` error string, whose text is printable
+          # ASCII and therefore a perfectly well-formed field. The runtime reader
+          # would not have "read it perfectly" — it would have seen two
+          # disagreeing records, returned `None`, and refused to install the
+          # helper on every privileged machine. This step is the only gate that
+          # catches that, so widening the tolerance to make it quiet is the one
+          # edit to never make here; fix the binary instead (see
+          # `veld_core::signing::version_record_magic_at_runtime`).
           def field_version(raw):
               end = raw.find(b"\0")
               end = len(raw) if end < 0 else end

--- a/crates/veld-core/src/signing.rs
+++ b/crates/veld-core/src/signing.rs
@@ -1068,9 +1068,15 @@ const VERSION_FIELD_LEN: usize = 32;
 /// Total size of an embedded version record: 16 magic + 32 version.
 pub const VERSION_RECORD_LEN: usize = 16 + VERSION_FIELD_LEN;
 
-/// The plaintext magic. `const` so [`version_record`] can build it at compile
-/// time, and used at runtime by [`version_in_signed_bytes`] — one definition,
-/// both directions.
+/// The plaintext magic, at compile time. `const` so [`version_record`] can build
+/// a record into a `#[used] static` — the one place the plaintext is *supposed*
+/// to end up in the file.
+///
+/// **Nothing that runs at run time may call this.** The scanner has its own
+/// half, [`version_record_magic_at_runtime`], and the two being separate
+/// functions is the fix for a shipped bug rather than duplication somebody
+/// forgot to fold together. `the_runtime_magic_matches_the_record_magic` in this
+/// module's tests is what holds them to the same 16 bytes.
 const fn version_record_magic() -> [u8; 16] {
     let mut magic = [0u8; 16];
     let mut i = 0;
@@ -1111,7 +1117,8 @@ pub const fn version_record(version: &str) -> [u8; VERSION_RECORD_LEN] {
     out
 }
 
-/// The plaintext magic, recovered at run time behind an optimisation barrier.
+/// The plaintext magic, recovered at run time behind a barrier the optimiser is
+/// not allowed to see through.
 ///
 /// [`version_record_magic`] is a `const fn`, and calling it from a *non*-const
 /// context is not enough to keep it out of the binary: on some targets LLVM
@@ -1129,23 +1136,40 @@ pub const fn version_record(version: &str) -> [u8; VERSION_RECORD_LEN] {
 /// source built for `aarch64-apple-darwin` carried exactly one. Nothing about
 /// the source changed; the optimiser's mind did.
 ///
-/// [`std::hint::black_box`] on the key is what stops the fold. The key stops
-/// being a value the optimiser may assume, so the XOR cannot be performed before
-/// the program runs, and the plaintext exists only in this function's stack
-/// frame — never in the file.
+/// A **volatile read of the key** is what stops the fold. A volatile load may not
+/// be elided, reordered away or constant-folded, so the XOR cannot be performed
+/// before the program runs and the plaintext is built in this function's stack
+/// frame every call. The only plaintext magic left in a shipped file is the one
+/// inside `VELD_HELPER_VERSION_RECORD`, which is the whole point of the record.
 ///
-/// `black_box` is documented as best-effort, so this is a barrier and not a
-/// proof, and no test here can speak for it: the tests in this crate and in
+/// **The barrier has to sit on the key, before the XOR.** Wrapping the *result*
+/// instead — `black_box(version_record_magic())`, the obvious simplification —
+/// does not work: the constant is folded first and the barrier then guards a
+/// value that is already in `.rodata`. Measured at `-O` on
+/// `aarch64-apple-darwin`: barrier-on-result still leaves one plaintext hit in
+/// the binary, barrier-on-key leaves none. `std::hint::black_box` on the key
+/// measures the same as the volatile read, and is the more idiomatic spelling,
+/// but it is documented as best-effort with no guarantee — for an invariant
+/// whose only other detector is a failed release, the guaranteed load is worth
+/// three lines of `unsafe`.
+///
+/// No test in this repo can catch a recurrence, which is why the guarantee
+/// matters rather than the barrier merely working today: the tests here and in
 /// `crates/veld-helper/tests/version_record.rs` build the **host** arch in the
-/// **debug** profile, and the fold happened in release on another target. What
-/// makes that acceptable is the direction of the failure. If a future toolchain
-/// folds through the barrier anyway, `release.yml`'s `Package client binaries`
-/// step counts the records in the cross-compiled artifact and fails the release
-/// — before publishing, not after installing. Fail-closed, and the only check
-/// that can see it, which is why that step's tolerance must never be widened to
-/// silence a second record.
+/// **debug** profile, where nothing folds, and the host *release* build did not
+/// fold either. The backstop is `release.yml`'s `Package client binaries` step,
+/// which counts records in the cross-compiled artifact and fails the `build` job
+/// — so a fold that ever gets through fails closed, before publishing rather
+/// than after installing. That is also why that step's tolerance must never be
+/// widened to silence a second record.
 fn version_record_magic_at_runtime() -> [u8; 16] {
-    let key = std::hint::black_box(VERSION_MAGIC_KEY);
+    // Derived from the same constant `version_record_magic` uses, so the two
+    // halves cannot drift; `static` only so there is an address to read from.
+    static KEY_CELL: u8 = VERSION_MAGIC_KEY;
+    // SAFETY: `KEY_CELL` is a live, initialised, correctly-aligned `u8` in this
+    // binary's static data. The read is volatile purely to deny the optimiser
+    // the constant, not because the location is special.
+    let key = unsafe { std::ptr::read_volatile(&KEY_CELL) };
     let mut magic = [0u8; 16];
     for (out, obfuscated) in magic.iter_mut().zip(VERSION_MAGIC_OBFUSCATED) {
         *out = obfuscated ^ key;
@@ -1436,6 +1460,12 @@ mod tests {
     /// other must be — see [`version_record_magic_at_runtime`]. Nothing in the
     /// compiler ties them together, and if they ever drift the helper stops
     /// finding its own record: no test of either half alone would notice.
+    ///
+    /// This asserts the values agree. It does **not** assert the property that
+    /// actually broke v16.66.0 — that the plaintext is absent from the built
+    /// binary — and no test in this repo can: this one runs at `opt-level = 0`,
+    /// and the host release build did not fold either. `release.yml`'s
+    /// `Package client binaries` step is the only gate that sees it.
     #[test]
     fn the_runtime_magic_matches_the_record_magic() {
         assert_eq!(version_record_magic_at_runtime(), version_record_magic());

--- a/crates/veld-core/src/signing.rs
+++ b/crates/veld-core/src/signing.rs
@@ -1047,7 +1047,9 @@ pub fn relaunch_guard(binary: &Path) -> Option<String> {
 /// other and reproduced the exact byte sequence anyway
 /// (`the_scanners_own_needle_is_not_a_second_record` is what found it). That
 /// mitigation depended on layout; this one depends on arithmetic. The plaintext
-/// appears only where [`version_record`] writes it.
+/// appears only where [`version_record`] writes it — provided nothing hands the
+/// arithmetic to the optimiser, which is the third way this has now failed; see
+/// [`version_record_magic_at_runtime`].
 const VERSION_MAGIC_OBFUSCATED: [u8; 16] = [
     0xff, 0xa3, 0x29, 0x7e, 0x79, 0x3e, 0xed, 0xb2, 0x0f, 0x11, 0x20, 0xc7, 0xf7, 0x9c, 0x5c, 0xc2,
 ];
@@ -1109,6 +1111,48 @@ pub const fn version_record(version: &str) -> [u8; VERSION_RECORD_LEN] {
     out
 }
 
+/// The plaintext magic, recovered at run time behind an optimisation barrier.
+///
+/// [`version_record_magic`] is a `const fn`, and calling it from a *non*-const
+/// context is not enough to keep it out of the binary: on some targets LLVM
+/// evaluates it at compile time anyway and materialises the plaintext needle as
+/// a 16-byte constant in the scanner's own `.rodata` — precisely what
+/// [`VERSION_MAGIC_OBFUSCATED`] exists to prevent, arrived at from the other
+/// direction.
+///
+/// This is not hypothetical: it broke the v16.66.0 release. The
+/// `x86_64-unknown-linux-gnu` build of `veld-helper` carried the folded needle
+/// immediately before a `rustls` error string, so the binary held two
+/// well-formed records — its own version, and `EmptyTicketValue…` — and
+/// [`version_in_signed_bytes`] reads that as "no single answer", i.e. as
+/// unversioned, i.e. as a helper no privileged install may update onto. The same
+/// source built for `aarch64-apple-darwin` carried exactly one. Nothing about
+/// the source changed; the optimiser's mind did.
+///
+/// [`std::hint::black_box`] on the key is what stops the fold. The key stops
+/// being a value the optimiser may assume, so the XOR cannot be performed before
+/// the program runs, and the plaintext exists only in this function's stack
+/// frame — never in the file.
+///
+/// `black_box` is documented as best-effort, so this is a barrier and not a
+/// proof, and no test here can speak for it: the tests in this crate and in
+/// `crates/veld-helper/tests/version_record.rs` build the **host** arch in the
+/// **debug** profile, and the fold happened in release on another target. What
+/// makes that acceptable is the direction of the failure. If a future toolchain
+/// folds through the barrier anyway, `release.yml`'s `Package client binaries`
+/// step counts the records in the cross-compiled artifact and fails the release
+/// — before publishing, not after installing. Fail-closed, and the only check
+/// that can see it, which is why that step's tolerance must never be widened to
+/// silence a second record.
+fn version_record_magic_at_runtime() -> [u8; 16] {
+    let key = std::hint::black_box(VERSION_MAGIC_KEY);
+    let mut magic = [0u8; 16];
+    for (out, obfuscated) in magic.iter_mut().zip(VERSION_MAGIC_OBFUSCATED) {
+        *out = obfuscated ^ key;
+    }
+    magic
+}
+
 /// The version recorded inside `bytes`, or `None` when there isn't exactly one
 /// answer.
 ///
@@ -1123,7 +1167,7 @@ pub const fn version_record(version: &str) -> [u8; VERSION_RECORD_LEN] {
 /// and refusing that would wedge the updater on the very artifacts it exists to
 /// install. Requiring one *value* keeps the strictness where it belongs.
 pub fn version_in_signed_bytes(bytes: &[u8]) -> Option<String> {
-    let magic = version_record_magic();
+    let magic = version_record_magic_at_runtime();
     let mut found: Option<String> = None;
     for start in 0..bytes.len().saturating_sub(VERSION_RECORD_LEN - 1) {
         if bytes[start..start + 16] != magic {
@@ -1383,6 +1427,18 @@ mod tests {
         for (i, byte) in magic.iter().enumerate() {
             assert_eq!(*byte, VERSION_MAGIC_OBFUSCATED[i] ^ VERSION_MAGIC_KEY);
         }
+    }
+
+    /// The scanner's runtime magic and the record's compile-time magic are the
+    /// same 16 bytes.
+    ///
+    /// They are two functions because one must not be const-evaluable and the
+    /// other must be — see [`version_record_magic_at_runtime`]. Nothing in the
+    /// compiler ties them together, and if they ever drift the helper stops
+    /// finding its own record: no test of either half alone would notice.
+    #[test]
+    fn the_runtime_magic_matches_the_record_magic() {
+        assert_eq!(version_record_magic_at_runtime(), version_record_magic());
     }
 
     /// A FIFO where the signature should be is refused, not waited on.


### PR DESCRIPTION
## What broke

The v16.66.0 release failed in `release.yml` → **Package client binaries**
([run](https://github.com/prosperity-solutions/veld/actions/runs/33890099838/job/101079556055)):

```
dist/veld-helper carries 2 version record(s) resolving to
['16.66.0', 'EmptyTicketValuecccccccccccccccc']; expected exactly one version.
```

That step is not being fussy. Two disagreeing records make
`veld_core::signing::version_in_signed_bytes` return `None`, which the install
RPC reads as *unversioned*, which it refuses — so the artifact it blocked was a
helper **no privileged install could ever have updated onto**. The gate failed
the release instead of shipping a wedged updater, which is exactly its job.

## Root cause

`version_record_magic()` is a `const fn`. `version_in_signed_bytes` called it
from a non-const context, and that is **not** enough to keep the plaintext
needle out of the binary — LLVM const-folded it and emitted the 16 bytes into
the scanner's own `.rodata`, landing immediately before a `rustls` error-variant
string. That string is printable ASCII, so the 32 bytes behind the folded needle
parse as a perfectly well-formed version field, and the binary has two records.

The module's `VERSION_MAGIC_OBFUSCATED` doc already recorded two earlier ways
this exact invariant broke (a plaintext constant; two halves the linker laid
adjacent). This is the third, and the first one that depends on the *optimiser*
rather than on source or layout — which is why the same source built for
`aarch64-apple-darwin` carries exactly one record and every local test passed.

## The fix

`version_record_magic_at_runtime()` recovers the magic from a **volatile read**
of the XOR key, so the XOR cannot be performed before the program runs. The only
plaintext magic left in a shipped file is the one inside
`VELD_HELPER_VERSION_RECORD`, which is what the record is for.
`version_record()` keeps the `const` path.

**The barrier has to sit on the key, before the XOR** — review measured this
rather than assuming it. Four variants at `-O` on `aarch64-apple-darwin`:

| variant | plaintext magic in binary |
|---|---|
| `magic_const()` from a non-const fn (the bug) | 1 hit |
| `black_box(magic_const())` — barrier on the *result* | **1 hit** |
| `black_box(KEY)` then XOR | 0 hits |
| `read_volatile(&KEY_CELL)` then XOR (**shipped**) | 0 hits |

So the obvious simplification — fold the two magic functions back into one by
wrapping the const fn's result — silently reintroduces the bug and passes every
test in the repo. That trap is now written into the doc comment.

`black_box` measured identically to the volatile read and is the more idiomatic
spelling, but it is documented as **best-effort with no guarantee**. A volatile
load may not be elided or constant-folded, so the property becomes a language
rule instead of the optimiser's current mood. For an invariant whose only other
detector is a burnt release, that is worth three lines of `unsafe`.

A unit test ties the two magics together, because nothing in the compiler does
and a drift would silently stop the helper finding its own record.

## Test evidence

Built `veld-helper --release` inside a `linux/amd64` `rust:latest` container —
the target that actually failed, which a macOS host cannot speak for:

| | magic hits | fields |
|---|---|---|
| before | **2** | `EmptyTicketValueMissingExtension`, `16.65.0` |
| after | **1** | `16.65.0` |

(Re-run after review swapped the mechanism to the volatile read: still 1 hit.)

(CI's failure saw `EmptyTicketValuecccccccccccccccc` — same defect, different
rodata neighbour.) `aarch64-apple-darwin` release: 1 hit before and after.

Then ran **`release.yml`'s own `PYCHECK` script, extracted verbatim**, against
that fixed Linux artifact:

```
veld-helper version record: 16.65.0     # exit 0
```

Local pre-pass green: `rustup update stable` (rustc 1.98.1, unchanged) ·
`cargo fmt --all --check` · `cargo clippy --workspace --all-targets` exit 0 (6
pre-existing `veld-daemon` warnings, none in this diff) ·
`cargo test -p veld-core -p veld-helper` 939+13+1+105+2+3 passed, 0 failed ·
`just workflow-gates` ok · `just commit-subjects` ok.

## Adjacent fix, deliberately included

`release.yml`'s comment on the field-parsing tolerance argued that *"a
const-folded copy of the needle on some target"* was a false alarm the tolerance
exists to absorb, and that the runtime *"would read it perfectly"*. Both halves
are wrong, and this incident is the proof: the folded needle produced a
well-formed field, and the runtime would have returned `None` and refused the
install everywhere. Left as written, that comment is an argument for widening
the one gate that catches this. Corrected in place, with the incident named.

## Reviewer scope notes

- **Behaviour of the reader is unchanged.** The fix changes only what the
  compiler *emits*, not what the scanner *accepts*: the new test asserts
  `version_record_magic_at_runtime() == version_record_magic()`.
- **This is the fix that helps already-shipped helpers.** Field helpers (v16.59+)
  carry the old, unpatchable scanner and will scan future helper binaries. Only
  removing the second needle from the artifact helps them; tightening
  `parse_version_field` (e.g. requiring a leading digit) would not, which is why
  the parser is untouched — see *considered and rejected*.
- **`black_box` is best-effort, and that is knowingly accepted.** If a future
  toolchain folds through it, the failure is *fail-closed*: `release.yml`'s
  packaging step counts records in the cross-compiled artifact and fails the
  release before publishing. That reasoning is now in the doc comment rather
  than only here.

### Considered and rejected

- **Tighten `parse_version_field`** (a real version starts with a digit, so
  `EmptyTicketValue…` would stop being a record). Rejected: helpers already in
  the field run the old lenient parser and cannot be updated, so this protects
  nobody who is currently at risk, and it would fork the Rust reader from
  `release.yml`'s hand-copied mirror for no gain.
- **`static` + `read_volatile`** instead of `black_box` — a hard LLVM guarantee
  rather than a best-effort one, but it needs `unsafe` for a case where the CI
  gate is already the backstop. Worth revisiting if `black_box` ever proves
  insufficient here.
- **A release-profile, cross-target build test in `ci.yml`.** `ci.yml` runs five
  macOS legs, and macOS never folded — so the test that would have caught this
  is a Linux release build CI does not otherwise do. The existing packaging gate
  already covers it at the only place it matters.

## Known gap

Nothing in `cargo test` can catch a recurrence: both built-binary tests in
`crates/veld-helper/tests/version_record.rs` build the **host** arch in the
**debug** profile, and this bug lived in **release** on **x86_64-linux**. The
backstop stays `release.yml`'s packaging step. That gap is now written into the
code rather than left to be rediscovered.

---

## Review

Standard loop, Stage A (angles 1 counterfactual, 4 what-isn't-here, 7 threat
model), one round. **Reported late** — all three agents ran long past the point
I could keep the release fix waiting, so I ran the angles inline first, opened
this PR, and folded their reports in when they landed. Both passes are
represented below; the inline pass found the `release.yml` comment issue, and
the agent pass then corrected *my* correction of it.

**Fixed**

- 🟠 `signing.rs` — `black_box` stated as a guarantee when it is best-effort.
  Angle 1 built a four-variant probe proving `read_volatile` gets the identical
  result with a real language-level guarantee. Swapped, and the doc no longer
  overstates. Angle 7 independently flagged the same lines as overstated (🟢),
  which is the only corroboration signal a one-round loop has.
- 🟡 `signing.rs:1071` — `version_record_magic`'s doc still said it was "used at
  runtime by `version_in_signed_bytes` — one definition, both directions". The
  first commit made that false, and left standing it argues for reintroducing
  the bug. Rewritten (angle 7).
- 🟡 `signing.rs` — nothing documented that the barrier must sit on the *key*;
  `black_box(version_record_magic())` folds anyway and passes every test
  (angle 1, measured). Now stated explicitly.
- 🟡 test + fn docs — neither said that no test in this repo can catch a
  recurrence. Both now do, naming `release.yml` as the only gate (angles 1, 7).
- **I overcorrected `release.yml` and have backed it out.** My inline pass called
  the existing tolerance comment wrong. Angle 4 verified via
  `git log -S` that the clause was written deliberately in #342 and correctly
  describes the benign case: a const-folded needle *is* harmless while the bytes
  behind it do not parse as a field. The comment now keeps its original
  reasoning and adds the case it did not cover — that this is luck, not a rule —
  rather than contradicting it.

**Verified and not changed**

- Angle 7: the accepted set is unchanged, only codegen. Both non-test callers
  verify the signature before reading the version (`helper_store.rs:270-276`,
  `:425-427`), and disagreement returns `None`, never the max — no forged-version
  path. Old field helpers and new ones cannot disagree about a binary.
- Angle 7: fail-closed. Two records → `release.yml:239` `sys.exit` → `build`
  fails → `release` needs `build`, `publish` needs `release`. Nothing signs.
- Angle 4: no other runtime caller was left on the const fn; no `docs/` file
  mentions the record; no `[profile.release]` override, so the verification ran
  under the same profile that shipped and broke.
- Angle 1: leaving `parse_version_field` lenient is right — the scanner that
  matters during an update is the already-running *old* helper.

Verdict: **ship it** after the above. Angle 4 `ship it`; angle 7 no blocking;
angle 1's one 🟠 is fixed by taking its own recommendation.

---
🚢 Carried by the ship workflow (`docs/ship.md`).

| Setting | This run |
|---|---|
| Review depth | Standard — 3 spawns (2 opus, 1 sonnet), 1 round, Stage A. Agents reported late; inline pass ran first, both folded in. See Review above. |
| Merge policy | Bypass-merge on green CI |
| Hands-on checkpoints | None |
| Docs & tests | Internal — AGENTS.md docs checklist N/A; no `docs/`, website or `llms-full.txt` surface mentions the version record |
| Promotion | No — a release-pipeline bug fix, which the workflow says never to promote |
