### PR TITLE
refactor(ide): drag the rail with pointer events instead of HTML5 DnD

### DIFF
--- a/crates/veld-daemon/ui/src/App.tsx
+++ b/crates/veld-daemon/ui/src/App.tsx
@@ -67,6 +67,7 @@ import {
   detachedInSection,
   freshRunName,
   fuzzyMatch,
+  insertionTarget,
   laneDropTarget,
   liveRuns,
   moveLane,
@@ -100,6 +101,7 @@ import {
   type WorktreeStatus,
 } from "./model";
 import { startOriginLabel } from "./shared/startOrigin";
+import { usePointerDrag } from "./shared/pointerDrag";
 import { worktreeLabel } from "./shared/worktreeName";
 import { nodeRows, type NodeRow } from "./shared/NodeList";
 import { NodeActions } from "./shared/NodeActions";
@@ -7984,12 +7986,6 @@ function RailResizer(props: {
   );
 }
 
-/** Whether a drag is over the lower half of the row it is on. */
-function below(e: React.DragEvent): boolean {
-  const box = e.currentTarget.getBoundingClientRect();
-  return e.clientY > box.top + box.height / 2;
-}
-
 /**
  * The rail's insertion caret — the same 3px glowing bar the pane tab strip uses,
  * turned horizontal.
@@ -8050,8 +8046,9 @@ function ProjectCaret() {
  * Dragging a square rewrites the order for **every** window, because it is the
  * daemon's (`repos.sort_position`, schema v16) rather than this page's. That is not
  * incidental: ⌘1…⌘9 address a *position*, so a per-window order would make one chord
- * mean two projects. The drag mirrors the rail's own lane drag — same dataTransfer
- * discipline, same "drop on a row, land at its index" gesture.
+ * mean two projects. The drag mirrors the rail's own — same press-move-release
+ * substrate ([`usePointerDrag`]), same caret, same "the release point is the
+ * answer" resolution.
  */
 function ProjectColumn(props: {
   repos: Repo[];
@@ -8064,9 +8061,9 @@ function ProjectColumn(props: {
   onImport: () => void;
 }) {
   // Which square is being dragged, and where the caret is. Both are this
-  // component's alone — the rail's two drags are keyed on their own state for the
-  // reason its `onDragStart` explains, and a third one must not join that
-  // arrangement by sharing any of it.
+  // component's alone — the rail keeps its two drags on their own state for the
+  // reason recorded there, and a third one must not join that arrangement by
+  // sharing any of it.
   //
   // `dropAt` is a caret position (`0…length`, "insert before this index"), not the
   // index of a square — see `dropTargetIndex` for why the two are not the same
@@ -8074,42 +8071,64 @@ function ProjectColumn(props: {
   const [dragRoot, setDragRoot] = useState<string | null>(null);
   const [dropAt, setDropAt] = useState<number | null>(null);
   const roots = props.repos.map((r) => r.root);
+  const colRef = useRef<HTMLDivElement>(null);
   const endDrag = () => {
     setDragRoot(null);
     setDropAt(null);
   };
-  /** Commit whatever the caret is pointing at. Shared by every square's `onDrop`
-   *  and the column's own, so a release in the padding below the last square lands
-   *  the same way a release on a square does. */
-  const commitDrop = () => {
-    const from = roots.indexOf(dragRoot ?? "");
-    const at = dropAt;
-    endDrag();
-    if (from === -1 || at === null) return;
-    const to = dropTargetIndex(from, at);
-    if (to === null) return;
-    props.onReorder(from, to);
+  /**
+   * Where the caret goes for a pointer at (`x`, `y`), or `null` for a pointer
+   * that has left the column.
+   *
+   * Measured off the squares' own boxes rather than resolved from the element
+   * under the pointer, which is what makes the padding below the last square a
+   * target instead of a gap the drag falls through — the column used to need a
+   * drop zone of its own to cover exactly that, because the only other way to
+   * reach the last position was the bottom half of the final square. `null`
+   * outside the column is the other half of the same idea: a square carried off
+   * to the panes and released has nowhere to land, and says so by showing no
+   * caret before it is let go.
+   *
+   * `data-project-index` rather than the class, because the column's last child
+   * is a `.project-sq` too — the ＋ — and it is not a position.
+   */
+  const targetAt = (x: number, y: number): number | null => {
+    const col = colRef.current;
+    if (!col) return null;
+    const box = col.getBoundingClientRect();
+    if (x < box.left || x > box.right || y < box.top || y > box.bottom) {
+      return null;
+    }
+    const squares = [
+      ...col.querySelectorAll<HTMLElement>("[data-project-index]"),
+    ].map((el) => el.getBoundingClientRect());
+    return insertionTarget(squares, y);
   };
+  const drag = usePointerDrag<string>({
+    onBegin: setDragRoot,
+    onMove: (_root, x, y) => setDropAt(targetAt(x, y)),
+    onDrop: (root, x, y) => {
+      // Resolved again from the release point rather than read back out of
+      // `dropAt`: the caret and the commit then answer one question with one
+      // piece of code, so what lands is what was on screen.
+      const at = targetAt(x, y);
+      endDrag();
+      const from = roots.indexOf(root);
+      if (from === -1 || at === null) return;
+      const to = dropTargetIndex(from, at);
+      if (to === null) return;
+      props.onReorder(from, to);
+    },
+    onCancel: endDrag,
+    scroller: () => colRef.current,
+  });
   return (
     <div
       className="project-col"
       role="tablist"
       aria-label="Projects"
       aria-orientation="vertical"
-      // The column itself accepts the drop, so a release in the padding under the
-      // last square is a drop at the end rather than a cancelled drag. Without it
-      // the only way to reach the last position is to hit the bottom half of the
-      // final square exactly.
-      onDragOver={(e) => {
-        if (!dragRoot) return;
-        e.preventDefault();
-        e.dataTransfer.dropEffect = "move";
-      }}
-      onDrop={(e) => {
-        if (!dragRoot) return;
-        e.preventDefault();
-        commitDrop();
-      }}
+      ref={colRef}
     >
       {props.repos.map((r, index) => {
         const summary = inbox.groupState(projectWorktreeIds(r), props.showWorking);
@@ -8133,15 +8152,21 @@ function ProjectColumn(props: {
               position="right"
               withArrow
             >
-            {/* A div with role=tab, not a <button>, and the reason is the drag: a
-                native button consumes the mousedown for its own activation
-                behaviour, so `draggable` on one never starts a drag in Chromium.
-                The rail's own rows are divs for a related reason (nested controls)
-                — see the note there. `onKeyDown` restores the Enter/Space a real
+            {/* A div with role=tab, not a <button>. The original reason was the
+                drag — a native button consumes the mousedown for its own
+                activation behaviour, so `draggable` on one never started a drag
+                in Chromium — and that constraint is gone: a pointer drag needs
+                nothing from the mousedown a button eats. What is left is a free
+                choice this change deliberately does not spend, since converting
+                it back means re-deciding the button's default styling, its focus
+                ring and the `onKeyDown` below in one go. The rail's own rows are
+                divs for a reason that still stands on its own (nested controls) —
+                see the note there. `onKeyDown` restores the Enter/Space a real
                 button would have had. */}
             <div
               role="tab"
               tabIndex={0}
+              data-project-index={index}
               aria-selected={active}
               className={`project-sq${active ? " active" : ""}${
                 r.available ? "" : " unavailable"
@@ -8151,40 +8176,11 @@ function ProjectColumn(props: {
                 e.preventDefault();
                 props.onSelect(r.root);
               }}
-              draggable
-              onDragStart={(e) => {
-                setDragRoot(r.root);
-                e.dataTransfer.effectAllowed = "move";
-                // Firefox ignores a drag with no payload. Prefixed like the rail's
-                // lane drag, so anything outside this column that reads the plain
-                // text can tell what it is being offered.
-                e.dataTransfer.setData("text/plain", `project:${r.root}`);
-              }}
-              onDragOver={(e) => {
-                if (!dragRoot) return;
-                // Only for a drag this column started. Without the guard a worktree
-                // or a lane dragged out of the rail would paint a drop indicator on
-                // a target that cannot accept it.
-                e.preventDefault();
-                e.dataTransfer.dropEffect = "move";
-                // Above the midpoint inserts before this square, below it after —
-                // the gesture the rail already uses, and the reason the indicator
-                // is a caret between squares rather than a ring around one: a ring
-                // cannot say which side of the target you are about to land on.
-                const box = e.currentTarget.getBoundingClientRect();
-                setDropAt(e.clientY < box.top + box.height / 2 ? index : index + 1);
-              }}
-              onDrop={(e) => {
-                e.preventDefault();
-                // The column below also accepts drops (so a release in the padding
-                // lands at the end), and without this the event bubbled into it
-                // with the pre-`endDrag` closure still live — every drop on a square
-                // fired `commitDrop` twice, i.e. two identical POSTs and two polls
-                // per drag.
-                e.stopPropagation();
-                commitDrop();
-              }}
-              onDragEnd={endDrag}
+              // The press that moves a square is the press that selects it; which
+              // one it turns out to be is decided by how far it travels. The
+              // click is swallowed for a real drag, so this and `onClick` below
+              // cannot both fire.
+              onPointerDown={(e) => drag.start(e, r.root)}
               onClick={() => props.onSelect(r.root)}
               onContextMenu={(e) => props.onMenu(e, r)}
             >
@@ -8305,6 +8301,12 @@ function Rail(props: {
   // because the two drags have different drop targets and different feedback —
   // and a single "what is being dragged" value made every handler on both sides
   // ask what kind it was before doing anything.
+  //
+  // Exclusive with the row drag, and structurally so: one `pointerdown` reaches
+  // exactly one of the two `start` calls, since a row is not inside a header.
+  // Under native drag-and-drop this was a convention instead — each drag's start
+  // handler cleared the other's state by hand, because a `dragend` that never
+  // arrived could otherwise leave both live and both sets of zones armed.
   const [dragLane, setDragLane] = useState<string | null>(null);
   const [laneDropAt, setLaneDropAt] = useState<number | null>(null);
   // Whether the dock, rather than a section in the list, is the thing under the
@@ -8312,23 +8314,6 @@ function Rail(props: {
   // the bar can be seen, since the last lane's own bar is inside the scroller and
   // the dock is used precisely when that lane is scrolled out of view.
   const [onDock, setOnDock] = useState(false);
-  // `dragend` fires on the source node, so the rail's own `onDragEnd` only ever
-  // sees a drag whose source is still mounted. A lane renamed in ANOTHER window
-  // changes the section's key, React unmounts it, and the event then fires on a
-  // detached node and reaches nothing — leaving `dragLane` set for good. That is
-  // not cosmetic: the list keeps a live drop zone, so the next unrelated drag
-  // over the rail (a file from Finder) would be accepted and reorder a lane
-  // nobody grabbed. The window always hears it.
-  useEffect(() => {
-    if (dragLane === null) return;
-    const done = () => endDrag();
-    window.addEventListener("dragend", done);
-    window.addEventListener("drop", done);
-    return () => {
-      window.removeEventListener("dragend", done);
-      window.removeEventListener("drop", done);
-    };
-  }, [dragLane]);
   // Positions of the lane sections, by lane name.
   const laneIndex = new Map(props.lanes.map((l, i) => [l.name, i]));
   /**
@@ -8352,6 +8337,7 @@ function Rail(props: {
   const laneAtOf = (g: RailGroup) =>
     g.editable ? laneIndex.get(g.lane) : undefined;
   const listRef = useRef<HTMLDivElement>(null);
+  const dockRef = useRef<HTMLDivElement>(null);
 
   /**
    * The lane a pointer at `clientY` is aiming at, or `null` when the rail holds
@@ -8402,34 +8388,6 @@ function Rail(props: {
     setLaneDropAt(null);
     setOnDock(false);
   };
-  // A target's highlight follows the pointer *out* of it, not only into the next
-  // one. Nothing else retracted it: `dropAt` is written by whichever zone the
-  // pointer was last over and lasted until some other zone overwrote it, so
-  // dragging off a section and stopping anywhere that takes no drop — a pinned
-  // lane, the gap under the sections, the panes, outside the window — left it
-  // lit, still promising a landing it would no longer accept.
-  //
-  // `defaultPrevented` is what a claim looks like here. Accepting a drag *is*
-  // calling `preventDefault` — the browser gives no other way to say yes — so an
-  // event that reaches this listener unclaimed is proof that nothing under the
-  // pointer would take the drop. It is the same test `laneDrop` and the stray
-  // file-drop guard already read, rather than a second convention beside them.
-  // (Most row and section zones stop propagation as well and never arrive here
-  // at all, which is the same answer reached one step earlier.)
-  //
-  // On the window, because "over no target" has to include "not over the rail";
-  // mounted only while a drag of ours is in flight, so nothing listens at rest.
-  useEffect(() => {
-    if (dragPath === null && dragLane === null) return;
-    const clear = (e: DragEvent) => {
-      if (e.defaultPrevented) return;
-      setDropAt(null);
-      setLaneDropAt(null);
-      setOnDock(false);
-    };
-    window.addEventListener("dragover", clear);
-    return () => window.removeEventListener("dragover", clear);
-  }, [dragPath, dragLane]);
   // Dropping is disabled while the rail is collapsed. A 64px row shows only a
   // marker, so there is no way to see *where* a drop would land — and a reorder
   // whose result you cannot see is a reorder you did not mean.
@@ -8442,121 +8400,162 @@ function Rail(props: {
   const canDropOn = (group: RailGroup) => !group.pinned || group.key === TRASH_LANE;
 
   /**
-   * Drop handlers for a section, resolving to an insertion index.
+   * Which section a pointer at (`x`, `y`) is over and which slot in it, or
+   * `null` for a pointer that is over no section at all.
    *
-   * `half` splits a row into its top and bottom halves so the gap *below* the last
-   * row is reachable — without it, appending to a group was impossible: the row's
-   * own handler stops propagation before the section's `index = length` handler
-   * runs, and a flex column has no blank space under its last child to aim at.
+   * Two DOM reads and one pure choice, the same shape as [`laneTargetAt`]: the
+   * section is the one whose box contains the point, the slot is
+   * [`insertionTarget`] over that section's rows. What replacing per-element
+   * drop zones with this buys is the append. A row's zone had to stop
+   * propagation — otherwise the section's own zone fired too and the caret
+   * flickered between the two — so the section never saw a pointer that was over
+   * a row, and a flex column has no blank space under its last child to aim at;
+   * between them, the only way to append to a lane was the lower half of its
+   * final row, exactly. Resolved geometrically, the section's padding and
+   * everything below its last row mean "at the end", which is what they look
+   * like they mean.
    *
-   * The trash ignores the insertion index: dropping there is a bin, not a
-   * position.
+   * `null` is an ordinary answer rather than something inferred. Native
+   * drag-and-drop had no way to ask *would anything take this*, so the rail read
+   * `defaultPrevented` as a claim between its own handlers and mounted a window
+   * listener to retract a caret the pointer had left behind; here, "over
+   * nothing" is what the function returns.
+   *
+   * The trash resolves like any other section and then ignores the index:
+   * dropping there is a bin, not a position.
    */
-  const dropZone = (group: RailGroup, index: number, half = false) => ({
-    onDragOver: (e: React.DragEvent) => {
-      if (!dragPath || !canDropOn(group)) return;
-      // Both required: preventDefault marks the element a valid drop target, and
-      // without stopPropagation the enclosing section's own zone also fires and the
-      // indicator flickers between the two.
-      e.preventDefault();
-      e.stopPropagation();
-      setDropAt({ key: group.key, index: index + (half && below(e) ? 1 : 0) });
-    },
-    onDrop: (e: React.DragEvent) => {
-      if (!dragPath || !canDropOn(group)) return;
-      e.preventDefault();
-      e.stopPropagation();
-      if (group.key === TRASH_LANE) {
-        props.onTrashDrop(dragPath);
-      } else {
-        props.onMove(dragPath, group.key, index + (half && below(e) ? 1 : 0));
+  const rowTargetAt = (
+    x: number,
+    y: number,
+  ): { key: string; index: number } | null => {
+    // The two containers are tested separately, and only while the point is
+    // inside one of them. `getBoundingClientRect` is layout, not clipping: a
+    // section scrolled out of the list still reports a box, and without this a
+    // pointer over the dock could be answered by whichever section happens to
+    // overhang it. Clipping each section to its container is the same guard one
+    // level down, for a section that is only half in view.
+    for (const container of [listRef.current, dockRef.current]) {
+      if (!container) continue;
+      const outer = container.getBoundingClientRect();
+      if (x < outer.left || x > outer.right) continue;
+      if (y < outer.top || y > outer.bottom) continue;
+      for (const el of container.querySelectorAll<HTMLElement>("[data-group-key]")) {
+        const box = el.getBoundingClientRect();
+        if (y < Math.max(box.top, outer.top)) continue;
+        if (y > Math.min(box.bottom, outer.bottom)) continue;
+        const group = groups.find((g) => g.key === el.dataset.groupKey);
+        // A section that takes no drop is not a miss to look past — it is the
+        // answer, and the answer is "nowhere".
+        if (!group || !canDropOn(group)) return null;
+        const rows = [...el.querySelectorAll<HTMLElement>("[data-row]")].map(
+          (row) => row.getBoundingClientRect(),
+        );
+        return { key: group.key, index: insertionTarget(rows, y) };
       }
-      endDrag();
+    }
+    return null;
+  };
+
+  /**
+   * Where a carried lane would land for a pointer at (`x`, `y`): a lane index,
+   * plus whether the **dock** is the thing under the pointer.
+   *
+   * Inside the scroller the answer is the list's geometry, resolved once for the
+   * whole column rather than per section — a dragged lane always has somewhere
+   * to land, which per-section targets could not promise. Dropping a lane means
+   * displacement, it takes the target lane's place, so there is no midpoint to
+   * consult: a lane is a block, and unlike a row it has no "above me" and "below
+   * me" halves. Which side the bar is drawn on is a rendering question, answered
+   * from the travel direction in `renderGroup`.
+   *
+   * The dock is answered first and answered flatly: **always the last lane,
+   * never the geometry**. It sits *outside* the scroller, and
+   * `getBoundingClientRect` is layout rather than clipping — a section below the
+   * fold has a bottom below the dock's own Y, so running the dock's pointer
+   * through `laneTargetAt` picks whichever section happens to overhang instead
+   * of the last lane. That is wrong exactly when the dock target is useful: a
+   * rail long enough to scroll, scrolled up, with the last lane off-screen. The
+   * dock means "the bottom", so it says so directly — its whole area, the Trash
+   * header included, because a dock that answered differently depending on which
+   * of its two sections you were over would be a distinction nothing on screen
+   * makes. `dock` is also what makes it draw its own bar, since the last lane's
+   * own bar lives inside the scroller and is out of sight in that very case.
+   *
+   * `null` for a pointer outside both, and for a rail holding no lanes: nothing
+   * to draw, nothing to commit.
+   */
+  const laneTargetAtPoint = (
+    x: number,
+    y: number,
+  ): { index: number; dock: boolean } | null => {
+    const inside = (el: HTMLElement | null) => {
+      if (!el) return false;
+      const box = el.getBoundingClientRect();
+      return x >= box.left && x <= box.right && y >= box.top && y <= box.bottom;
+    };
+    if (props.lanes.length === 0) return null;
+    if (inside(dockRef.current)) {
+      return { index: props.lanes.length - 1, dock: true };
+    }
+    if (!inside(listRef.current)) return null;
+    const to = laneTargetAt(y);
+    return to === null ? null : { index: to, dock: false };
+  };
+
+  /**
+   * The two rail drags, on the shared press-move-release substrate.
+   *
+   * Each is a resolver and four callbacks, and the resolver runs twice: once per
+   * move to draw the target, once more on release to commit it. That repetition
+   * is the point — the caret and the write answer the same question with the
+   * same code, so the rail cannot commit a drop it was not showing.
+   *
+   * `endDrag` before the write in both, because both writes re-render the rail
+   * and the feedback for a gesture that is over should not survive into it.
+   */
+  const rowDrag = usePointerDrag<string>({
+    onBegin: setDragPath,
+    // Only when the answer changed. `pointermove` fires far more often than the
+    // caret can move, and the rail is a big subtree to re-render for a target
+    // that is still the same row's top half; returning the previous object makes
+    // React bail out of the render entirely.
+    onMove: (_path, x, y) => {
+      const at = rowTargetAt(x, y);
+      setDropAt((prev) =>
+        prev?.key === at?.key && prev?.index === at?.index ? prev : at,
+      );
     },
+    onDrop: (path, x, y) => {
+      const at = rowTargetAt(x, y);
+      endDrag();
+      if (at === null) return;
+      // The trash is a destination, not a position — the index is thrown away.
+      if (at.key === TRASH_LANE) props.onTrashDrop(path);
+      else props.onMove(path, at.key, at.index);
+    },
+    onCancel: endDrag,
+    scroller: () => listRef.current,
   });
 
-  /**
-   * The dock's own lane drop: always the last lane, never the geometry.
-   *
-   * The dock sits *outside* the scroller, and `getBoundingClientRect` is layout,
-   * not clipping — a section below the fold has a bottom below the dock's own Y,
-   * so running the dock's pointer through `laneTargetAt` picks whichever section
-   * happens to overhang rather than the last lane. That is wrong exactly when the
-   * dock target is useful: a rail long enough to scroll, scrolled up, where the
-   * last lane is off-screen. The dock means "the bottom", so it says so directly
-   * — its whole area, the Trash header included, because a dock that answered
-   * differently depending on which of its two sections you were over would be a
-   * distinction nothing on screen makes.
-   *
-   * It draws its own bar, too (`onDock`): the last lane's bar lives inside the
-   * scroller, so in the very case this exists for it is scrolled out of sight and
-   * the dock would accept a drop while showing nothing.
-   */
-  const laneDockDrop = (() => {
-    const last = props.lanes.at(-1);
-    if (dragLane === null || !last) return null;
-    const take = (e: React.DragEvent) => {
-      if (e.defaultPrevented) return false;
-      e.preventDefault();
-      return true;
-    };
-    return {
-      onDragOver: (e: React.DragEvent) => {
-        if (!take(e)) return;
-        setLaneDropAt(props.lanes.length - 1);
-        setOnDock(true);
-      },
-      onDrop: (e: React.DragEvent) => {
-        if (!take(e)) return;
-        props.onMoveLane(dragLane, last.name);
-        endDrag();
-      },
-    };
-  })();
-
-  /**
-   * The lane drag's drop zone inside the scroller: the list as a whole, not the
-   * sections.
-   *
-   * One owner within the column. Every section and row bails out of its own
-   * handlers while a lane is in flight (each drop zone answers only to its own
-   * drag), so the event reaches here from anywhere in the list and
-   * [`laneTargetAt`] decides what it means. A dragged lane always has somewhere
-   * to land, which is what per-section targets could not promise; below the
-   * scroller, `laneDockDrop` above owns the same gesture.
-   *
-   * Dropping a lane means displacement — it takes the target lane's place — so
-   * there is no midpoint to consult: a lane is a block, and unlike a row it has
-   * no "above me" and "below me" halves. Which side the bar is drawn on is a
-   * rendering question, answered from the travel direction in `renderGroup`.
-   */
-  const laneDrop = dragLane === null
-    ? null
-    : {
-        onDragOver: (e: React.DragEvent) => {
-          if (e.defaultPrevented) return;
-          const to = laneTargetAt(e.clientY);
-          if (to === null) return;
-          e.preventDefault();
-          setLaneDropAt(to);
-          setOnDock(false);
-        },
-        onDrop: (e: React.DragEvent) => {
-          // A nested handler that already claimed this drop wins, and says so
-          // by having called `preventDefault`. Without this the container is a
-          // second, invisible consumer of the same event: a future "drop a lane
-          // on the trash" would delete the lane *and* reorder one, because
-          // `stopPropagation` is the only other way to stop this and nothing
-          // here would remind its author to call it.
-          if (e.defaultPrevented) return;
-          const to = laneTargetAt(e.clientY);
-          const onto = to === null ? undefined : props.lanes[to];
-          if (!onto) return;
-          e.preventDefault();
-          props.onMoveLane(dragLane, onto.name);
-          endDrag();
-        },
-      };
+  const laneDrag = usePointerDrag<string>({
+    onBegin: setDragLane,
+    onMove: (_lane, x, y) => {
+      const at = laneTargetAtPoint(x, y);
+      setLaneDropAt(at?.index ?? null);
+      setOnDock(at?.dock ?? false);
+    },
+    onDrop: (lane, x, y) => {
+      const at = laneTargetAtPoint(x, y);
+      endDrag();
+      const onto = at === null ? undefined : props.lanes[at.index];
+      if (!onto) return;
+      // `moveLane` returns null for a lane dropped on itself, so a no-op drop
+      // costs nothing here and needs no guard of its own.
+      props.onMoveLane(lane, onto.name);
+    },
+    onCancel: endDrag,
+    scroller: () => listRef.current,
+  });
 
   /**
    * Render one rail section — a lane, a user lane, or one of the two
@@ -8696,15 +8695,12 @@ function Rail(props: {
               // outline saying the same thing in the same colour.
               dropInto && group.key !== TRASH_LANE ? " drop-in" : ""
             }${group.editable && dragLane === group.lane ? " lane-dragging" : ""}${laneDropSide === "before" ? " lane-drop-before" : ""}${laneDropSide === "after" ? " lane-drop-after" : ""}`}
-            // The section itself is the fallback target, and it resolves to its
-            // FIRST position rather than its last. What actually reaches this
-            // handler is the header and the padding above it — the rows stop
-            // propagation — and both sit at the *top* of the section, so
-            // appending here contradicted where the pointer was: dragging down
-            // into a lane crossed its header and the caret jumped to the bottom.
-            // Appending is still reachable, and unambiguously so: it is the lower
-            // half of the last row.
-            {...dropZone(group, 0)}
+            /* What `rowTargetAt` measures a row drop against: the box is the
+               section, and the rows inside it are the slots. Every section
+               carries one, droppable or not — a pinned lane the drag cannot
+               enter has to be able to say so, and a section that carried no key
+               would instead be looked straight through. */
+            data-group-key={group.key}
             /* What `laneTargetAt` measures. Only a real lane carries one, so the
                ungrouped section and the pinned lanes are not lane targets — a
                pointer over them resolves to the nearest lane instead. */
@@ -8723,23 +8719,13 @@ function Rail(props: {
 
                    Only a real lane, and only expanded: the ungrouped section and
                    the trash hold no place in the lane order, and a collapsed rail
-                   renders no headers at all. */
-                draggable={group.editable && canDrag}
-                onDragStart={(e) => {
-                  setDragLane(group.lane);
-                  // The two drags are exclusive, and this is what makes that
-                  // true rather than conventional: every drop zone answers only
-                  // to its own drag, so a `dragend` that never arrived (the
-                  // source unmounted by the 5s poll, say) would otherwise leave
-                  // both live and both sets of handlers armed at once.
-                  setDragPath(null);
-                  setDropAt(null);
-                  e.dataTransfer.effectAllowed = "move";
-                  // Firefox ignores a drag with no payload. Prefixed because a
-                  // worktree drag puts a bare path here and something outside the
-                  // rail may yet read it — the rail itself keys off the state.
-                  e.dataTransfer.setData("text/plain", `lane:${group.lane}`);
-                }}
+                   renders no headers at all — so a header with no handler is how
+                   "this one does not move" is said. */
+                onPointerDown={
+                  group.editable && canDrag
+                    ? (e) => laneDrag.start(e, group.lane)
+                    : undefined
+                }
                 onContextMenu={
                   hasMenu ? (e) => props.onLaneMenu(e, group.lane) : undefined
                 }
@@ -8784,10 +8770,13 @@ function Rail(props: {
                    already exists, which is the one shape where a click target
                    that cannot be focused is honest rather than a hole.
 
-                   A drag of this same bar does not also fold it: Chromium
-                   emits no `click` after a completed drag, so the release that
-                   drops a lane in its new place is not a second gesture here.
-                   Measured, not assumed. */
+                   A drag of this same bar does not also fold it — and that is
+                   now something the drag arranges rather than something the
+                   browser does. A native drag ended without a `click`; a pointer
+                   drag ends in an ordinary `pointerup` and would produce one, so
+                   `usePointerDrag` swallows exactly one click in the capture
+                   phase at the end of every drag. Without it, every lane reorder
+                   would also fold the lane it had just moved. */
                 onClick={(e) => {
                   if (
                     (e.target as Element).closest(
@@ -9153,19 +9142,19 @@ function Rail(props: {
                             ? `${worktreeLabel(w)} — ${w.branch}${stateNote} (${awayNote(holder)})`
                             : `${worktreeLabel(w)} — ${w.branch}${stateNote}`
                   }
-                  draggable={rowDraggable}
-                  onDragStart={(e) => {
-                    setDragPath(w.path);
-                    // Exclusive with the lane drag — see the lane header's own
-                    // `onDragStart`.
-                    setDragLane(null);
-                    setLaneDropAt(null);
-                    e.dataTransfer.effectAllowed = "move";
-                    // Firefox ignores a drag with no payload, and the path is the
-                    // key everything downstream uses anyway.
-                    e.dataTransfer.setData("text/plain", w.path);
-                  }}
-                  {...dropZone(group, index, true)}
+                  /* What `rowTargetAt` counts as a slot. Valueless: the index is
+                     the element's position among its section's rows, which the
+                     query already gives, and duplicating it here would be a
+                     second copy of the order to keep in step. */
+                  data-row=""
+                  /* The press that moves a row is the press that selects it;
+                     which one it turns out to be is decided by how far it
+                     travels, and the click is swallowed for a real drag so this
+                     and `onClick` below cannot both fire. A row that cannot be
+                     dragged simply has no handler. */
+                  onPointerDown={
+                    rowDraggable ? (e) => rowDrag.start(e, w.path) : undefined
+                  }
                   /* A pending removal is not selectable: selecting it would open
                      panes, terminals and a browser rooted at a directory that is
                      about to stop existing. The restore control and the context
@@ -9406,8 +9395,11 @@ function Rail(props: {
                 deletion would make people avoid a gesture that is safe.
 
                 `aria-hidden`, and `pointer-events: none` in the CSS: it is a
-                picture of a drop, and the section underneath is the real target —
-                the drag events have to reach it. */}
+                picture of a drop, and the section underneath is the real target.
+                Nothing now depends on events passing *through* it — the drop is
+                resolved from the pointer's position against the section's box —
+                but an overlay that is only a picture should not be hit-testable
+                either, and it outlives its drag by a frame. */}
             {group.key === TRASH_LANE && dragPath !== null && (
               <div
                 className={`trash-drop${dropInto ? " over" : ""}`}
@@ -9486,19 +9478,15 @@ function Rail(props: {
           </Tooltip>
         )}
       </div>
-      <div
-        className="rail-list"
-        ref={listRef}
-        onDragEnd={endDrag}
-        {...(laneDrop ?? {})}
-      >
+      <div className="rail-list" ref={listRef}>
         {scroll.map((group) => renderGroup(group))}
       </div>
       {/* The dock takes a lane drop too, though it holds no lane. It is the
           natural overshoot for "pull this lane to the bottom", and it is the
           strip immediately under the edge you have to reach to get there —
           refusing there made the last position the one place the gesture could
-          miss. Its own handler, not the list's: see `laneDockDrop`. */}
+          miss. It resolves differently from the list, too — see
+          `laneTargetAtPoint`. */}
       {dockVisible && (
         <div
           className={`rail-dock${
@@ -9509,8 +9497,7 @@ function Rail(props: {
               ? " lane-drop-into"
               : ""
           }`}
-          onDragEnd={endDrag}
-          {...(laneDockDrop ?? {})}
+          ref={dockRef}
         >
           {docked.map((group) => renderGroup(group))}
         </div>

--- a/crates/veld-daemon/ui/src/model.test.ts
+++ b/crates/veld-daemon/ui/src/model.test.ts
@@ -10,6 +10,7 @@ import {
   diagnosticsRun,
   freshRunName,
   fuzzyMatch,
+  insertionTarget,
   laneDropTarget,
   liveRuns,
   MAIN_LANE,
@@ -1387,6 +1388,47 @@ describe("laneDropTarget", () => {
       laneDropTarget([{ index: Number.NaN, bottom: 50 }, ...sections], 30),
     ).toBe(0);
     expect(laneDropTarget([{ index: Number.NaN, bottom: 50 }], 30)).toBeNull();
+  });
+});
+
+describe("insertionTarget", () => {
+  // Three rows stacked with a 2px gap, as the rail's list renders them:
+  // 0 spans 10-40, 1 spans 42-72, 2 spans 74-104. Midpoints 25, 57, 89.
+  const rows = [
+    { top: 10, bottom: 40 },
+    { top: 42, bottom: 72 },
+    { top: 74, bottom: 104 },
+  ];
+
+  it("splits each row at its own midpoint", () => {
+    expect(insertionTarget(rows, 20)).toBe(0);
+    expect(insertionTarget(rows, 30)).toBe(1);
+    expect(insertionTarget(rows, 50)).toBe(1);
+    expect(insertionTarget(rows, 60)).toBe(2);
+  });
+
+  it("gives the gap to the row below it", () => {
+    // 41 is between two rows and belongs to neither element. It reads as
+    // "before row 1", which is the same place "after row 0" names.
+    expect(insertionTarget(rows, 41)).toBe(1);
+  });
+
+  it("puts everything above the first midpoint at the very top", () => {
+    // The list's padding is up here, and a drop on it has to mean the top of
+    // the lane rather than nothing at all.
+    expect(insertionTarget(rows, 10)).toBe(0);
+    expect(insertionTarget(rows, -400)).toBe(0);
+  });
+
+  it("puts everything below the last midpoint at the very end", () => {
+    expect(insertionTarget(rows, 104)).toBe(3);
+    expect(insertionTarget(rows, 5000)).toBe(3);
+  });
+
+  it("aims at the only slot an empty column has", () => {
+    // A lane with no rows still takes drops — that is how the first worktree
+    // gets into a lane someone just made.
+    expect(insertionTarget([], 42)).toBe(0);
   });
 });
 

--- a/crates/veld-daemon/ui/src/model.ts
+++ b/crates/veld-daemon/ui/src/model.ts
@@ -920,6 +920,35 @@ export function laneDropTarget(
 }
 
 /**
+ * Where an item dropped at `clientY` belongs in a vertical column, as an
+ * insertion index into `boxes`.
+ *
+ * The sibling of [`laneDropTarget`] for the two columns whose items *are* the
+ * order: the rail's worktree rows and the project switcher's squares. Same
+ * discipline — the answer comes from the pointer's Y against the items' boxes,
+ * not from whatever element happens to be under it — but a different question,
+ * because these drops land *between* items rather than *on* one. The boundary is
+ * each box's own midpoint, so the top half of a row means "before it" and the
+ * bottom half "after it", and the gaps between rows, the list's padding and
+ * everything below the last row resolve like the nearest half they adjoin
+ * instead of belonging to nothing.
+ *
+ * `boxes` must be in rendered order. Returns `boxes.length` for a drop past the
+ * final midpoint, and `0` for an empty column — an insertion point is always in
+ * range, which is what lets a caller drop into a lane holding no rows at all.
+ */
+export function insertionTarget(
+  boxes: Array<{ top: number; bottom: number }>,
+  clientY: number,
+): number {
+  for (let i = 0; i < boxes.length; i++) {
+    const b = boxes[i];
+    if (clientY < b.top + (b.bottom - b.top) / 2) return i;
+  }
+  return boxes.length;
+}
+
+/**
  * The lane order after moving the lane `name` onto the place currently held by
  * the lane `onto`.
  *

--- a/crates/veld-daemon/ui/src/shared/pointerDrag.test.ts
+++ b/crates/veld-daemon/ui/src/shared/pointerDrag.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AUTOSCROLL_BAND,
+  AUTOSCROLL_MAX,
+  autoScrollVelocity,
+  beyondThreshold,
+  seeThrough,
+} from "./pointerDrag";
+
+describe("beyondThreshold", () => {
+  it("lets a press wobble without becoming a drag", () => {
+    // A rail row is both selected and moved by the same press, so a hand that
+    // shifts a pixel between down and up has to still count as a click.
+    expect(beyondThreshold(0, 0)).toBe(false);
+    expect(beyondThreshold(3, 0)).toBe(false);
+    expect(beyondThreshold(0, -3)).toBe(false);
+  });
+
+  it("counts travel, not either axis on its own", () => {
+    // 3px right and 3px down is 4.2px of movement. Testing the axes separately
+    // would call this a click on both counts and no diagonal drag would start.
+    expect(beyondThreshold(3, 3)).toBe(true);
+    expect(beyondThreshold(-3, 3)).toBe(true);
+  });
+
+  it("starts at the threshold rather than past it", () => {
+    expect(beyondThreshold(4, 0)).toBe(true);
+    expect(beyondThreshold(0, 4)).toBe(true);
+  });
+});
+
+describe("autoScrollVelocity", () => {
+  // A container taller than two bands, so the two do not overlap.
+  const top = 100;
+  const bottom = 500;
+
+  it("leaves the middle alone", () => {
+    expect(autoScrollVelocity(top, bottom, 300)).toBe(0);
+    expect(autoScrollVelocity(top, bottom, top + AUTOSCROLL_BAND)).toBe(0);
+    expect(autoScrollVelocity(top, bottom, bottom - AUTOSCROLL_BAND)).toBe(0);
+  });
+
+  it("scrolls up near the top and down near the bottom", () => {
+    expect(autoScrollVelocity(top, bottom, top + 1)).toBeLessThan(0);
+    expect(autoScrollVelocity(top, bottom, bottom - 1)).toBeGreaterThan(0);
+  });
+
+  it("has no dead rim at the edge of the band", () => {
+    // One pixel inside the band rounds to zero without the floor, so the moment
+    // a drag enters the band would be the moment autoscroll looks broken.
+    expect(autoScrollVelocity(top, bottom, top + AUTOSCROLL_BAND - 1)).toBe(-1);
+    expect(autoScrollVelocity(top, bottom, bottom - AUTOSCROLL_BAND + 1)).toBe(1);
+  });
+
+  it("ramps with depth and tops out at the edge", () => {
+    const shallow = autoScrollVelocity(top, bottom, top + 20);
+    const deep = autoScrollVelocity(top, bottom, top + 4);
+    expect(Math.abs(deep)).toBeGreaterThan(Math.abs(shallow));
+    expect(autoScrollVelocity(top, bottom, top)).toBe(-AUTOSCROLL_MAX);
+    expect(autoScrollVelocity(top, bottom, bottom)).toBe(AUTOSCROLL_MAX);
+  });
+
+  it("clamps past the container instead of accelerating forever", () => {
+    // A pointer far above the list is still "scroll up", not "scroll up 400px
+    // a frame" — the speed it gets is the one the edge already gives.
+    expect(autoScrollVelocity(top, bottom, top - 300)).toBe(-AUTOSCROLL_MAX);
+    expect(autoScrollVelocity(top, bottom, bottom + 300)).toBe(AUTOSCROLL_MAX);
+  });
+
+  it("gives a short container both directions", () => {
+    // Shorter than two bands, so every point sits in both. The deeper side
+    // wins; taking the first match would make a short list only ever scroll up.
+    const shortBottom = AUTOSCROLL_BAND;
+    expect(autoScrollVelocity(0, shortBottom, 2)).toBeLessThan(0);
+    expect(autoScrollVelocity(0, shortBottom, AUTOSCROLL_BAND - 2)).toBeGreaterThan(0);
+  });
+});
+
+describe("seeThrough", () => {
+  // What decides whether the flying copy of a row gets handed the rail's
+  // surface to carry. Get it wrong in the permissive direction and every ghost
+  // is a card that should have been the square's own colour; get it wrong the
+  // other way and a row dragged over a terminal is dark text on a dark page.
+  it("treats a fully transparent background as see-through", () => {
+    // What Chromium answers for `background: transparent`, which is what
+    // `.wt-row` and `.lane-head` both declare.
+    expect(seeThrough("rgba(0, 0, 0, 0)")).toBe(true);
+    expect(seeThrough("transparent")).toBe(true);
+  });
+
+  it("treats an unset background as see-through", () => {
+    // `surfaceUnder` walks past `<html>` and returns "", and an element with no
+    // computed value at all is likewise nothing to see the page through.
+    expect(seeThrough("")).toBe(true);
+  });
+
+  it("does not read an opaque colour's blue channel as an alpha", () => {
+    // The three-argument form has no alpha, and a regex loose enough to match
+    // it would take 247 for one — which reads every opaque light colour as
+    // see-through and backs the project squares for no reason.
+    expect(seeThrough("rgb(245, 246, 247)")).toBe(false);
+    expect(seeThrough("rgb(0, 0, 0)")).toBe(false);
+  });
+
+  it("backs a partly transparent colour too", () => {
+    // A half-alpha row over a terminal is still a row you cannot read.
+    expect(seeThrough("rgba(255, 255, 255, 0.5)")).toBe(true);
+    expect(seeThrough("rgba(255, 255, 255, 1)")).toBe(false);
+  });
+
+  it("reads the alpha out of the modern colour forms too", () => {
+    // Not hypothetical: `.rail-group.drop-in` is a `color-mix(in oklab, …)`
+    // and Chromium hands that back as `oklab(L a b / A)`, not as `rgba()`.
+    // The first two are the exact strings measured off the running app.
+    expect(seeThrough("oklab(0.186986 -0.00893791 -0.0236999 / 0.09)")).toBe(
+      true,
+    );
+    expect(
+      seeThrough("color(srgb 0.0392157 0.0784314 0.117647 / 0.88)"),
+    ).toBe(true);
+    expect(seeThrough("hsl(210 40% 96% / 50%)")).toBe(true);
+  });
+
+  it("does not invent an alpha for an opaque modern colour", () => {
+    // No slash, no alpha. The channels must not be mistaken for one — the
+    // whole point of anchoring the match to the closing paren.
+    expect(seeThrough("oklab(0.186986 -0.00893791 -0.0236999)")).toBe(false);
+    expect(seeThrough("color(srgb 0.0392157 0.0784314 0.117647)")).toBe(false);
+    expect(seeThrough("oklch(0.7 0.1 240 / 1)")).toBe(false);
+    expect(seeThrough("hsl(210 40% 96% / 100%)")).toBe(false);
+  });
+});

--- a/crates/veld-daemon/ui/src/shared/pointerDrag.ts
+++ b/crates/veld-daemon/ui/src/shared/pointerDrag.ts
@@ -1,0 +1,531 @@
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * The rail's drag substrate: press, move, release — not HTML5 drag-and-drop.
+ *
+ * # Why not `draggable`
+ *
+ * The rail carried three native drags (worktree rows, lane headers, project
+ * squares) and paid for each of them in workarounds that are all the same
+ * complaint: **HTML5 drag-and-drop hides the pointer from the page**. What it
+ * offers instead is a per-element `dragover` protocol, and every question the
+ * rail actually had to answer was a question about a *point*.
+ *
+ * Three costs, each of which was a comment in `App.tsx` before this existed:
+ *
+ * - **`dragend` fires on the source node.** A source unmounted mid-drag — the
+ *   5s poll, a lane renamed in another window — took the only event that ends
+ *   the gesture with it, stranding the drag state and leaving the rail with a
+ *   live drop zone nobody was aiming at. The rail carried a window-level
+ *   `dragend`/`drop` listener purely to survive that. A pointer drag cannot
+ *   reach the same state: `pointerup` is delivered to the window whatever
+ *   happened to the element it started on.
+ * - **There is no way to ask "would anything here take this".** `preventDefault`
+ *   is the only way to accept a drop, so the rail adopted *defaultPrevented as a
+ *   claim* between its own handlers and mounted a second window listener to
+ *   retract a highlight the pointer had left. Resolving from a point makes "over
+ *   nothing" the ordinary answer instead of an event that has to be inferred.
+ * - **No payload, no drag.** Firefox ignores a native drag that sets no
+ *   `dataTransfer` data, so three `setData` calls existed to satisfy a browser
+ *   rather than to carry anything: nothing in the app ever read them back.
+ *
+ * # What this owes the thing it replaces
+ *
+ * Three behaviours came free with a native drag and are re-implemented here,
+ * because losing them silently is how a rewrite regresses:
+ *
+ * - **Autoscroll.** A native drag scrolls a scrollable container when the
+ *   pointer nears its edge. Nothing does that for a pointer drag, and the rail
+ *   is a list long enough to scroll — see `scroller`.
+ * - **No click after a drag.** Chromium emits no `click` following a native
+ *   drop, and the rail's lane header leans on it: the bar that reorders lanes is
+ *   also the bar that folds the section. A pointer drag ends in an ordinary
+ *   `pointerup` and therefore an ordinary `click`, so this swallows exactly one
+ *   — centrally, in the capture phase, rather than asking every handler on three
+ *   surfaces to remember a guard it cannot be compiled into remembering.
+ * - **A drag image.** The caret and the wash say where the thing will *land*,
+ *   which is a different question from what is in your hand — and a drag with no
+ *   answer to the second one is a cursor travelling across an unchanged page. So
+ *   the source element is cloned and flown under the cursor, at its own size,
+ *   which is what the native drag image was. See `mountGhost`.
+ *
+ * # Native views, and why nothing is done about them
+ *
+ * Pointer capture does not survive an embedded browser pane. A `WebContentsView`
+ * is an OS-level child window rather than a DOM node, so once the cursor is over
+ * one it takes the mouse: the renderer stops seeing `pointermove`, the ghost is
+ * painted over, and the release goes to the pane instead of here. The drag
+ * therefore ends the moment a pane takes focus — `blur` reaches `onAbort`, and
+ * the gesture cancels. Which is what a release outside a drop area is supposed
+ * to do anyway: every drop target the rail has is *in* the rail, so a pointer
+ * out over a pane was never going to commit anything.
+ *
+ * The alternative was tried and taken back out rather than missed. `PaneArea`'s
+ * splitter hides the views for its duration (`pushBrowserSuspend`), and a rail
+ * drag can do the same; it keeps the ghost visible out over the panes. It also
+ * freezes every browser pane in the window to a still on every row, lane and
+ * square drag — a very common gesture — to buy feedback on a path with no
+ * destination. Not worth it. If the ghost vanishing at the rail's edge ever
+ * reads as broken, that is the lever to pull.
+ */
+
+/**
+ * How far the pointer must travel before a press counts as a drag.
+ *
+ * A press that never crosses it is a click and nothing here is told about it —
+ * which is what lets a row be *selected* by the same gesture that moves it. Four
+ * pixels is the usual figure and it is deliberately small: the rail's rows are
+ * 28px, so a threshold generous enough to be felt would be a threshold that eats
+ * the first third of a short drag.
+ */
+export const DRAG_THRESHOLD = 4;
+
+/** The band at a scroller's top and bottom edge where a drag scrolls it. */
+export const AUTOSCROLL_BAND = 28;
+
+/** Pixels per frame at the very edge of the band — roughly 840px/s at 60fps. */
+export const AUTOSCROLL_MAX = 14;
+
+/** Whether a press that started at the origin has travelled far enough to be a
+ *  drag. Distance, not per-axis: a diagonal 3px+3px move is 4.2px of travel and
+ *  reads as deliberate, which axis-wise tests would both miss. */
+export function beyondThreshold(dx: number, dy: number): boolean {
+  return Math.hypot(dx, dy) >= DRAG_THRESHOLD;
+}
+
+/**
+ * How far to scroll a container this frame, for a drag whose pointer is at
+ * `clientY`. Negative scrolls up, positive down, `0` leaves it alone.
+ *
+ * Ramped rather than constant: the speed rises with how far into the band the
+ * pointer is, so the edge of the list nudges and the edge of the *screen* moves
+ * properly. Past the container entirely the depth clamps, so dragging far above
+ * a list scrolls at the top speed rather than at an ever-increasing one.
+ *
+ * The rounding floor of 1 matters: without it the outermost pixels of the band
+ * round to zero and the band has a dead rim exactly where a drag first enters
+ * it, which reads as autoscroll being broken rather than as it being gentle.
+ *
+ * A container shorter than two bands has them overlap; the deeper side wins,
+ * which keeps a short list scrollable in both directions instead of always up.
+ */
+export function autoScrollVelocity(
+  top: number,
+  bottom: number,
+  clientY: number,
+): number {
+  const up = top + AUTOSCROLL_BAND - clientY;
+  const down = clientY - (bottom - AUTOSCROLL_BAND);
+  if (up <= 0 && down <= 0) return 0;
+  const depth = Math.min(Math.max(up, down), AUTOSCROLL_BAND);
+  const speed = Math.max(1, Math.round((AUTOSCROLL_MAX * depth) / AUTOSCROLL_BAND));
+  return up > down ? -speed : speed;
+}
+
+/**
+ * Properties the ghost has to be handed, because it hangs off `<body>` and the
+ * cascade that dressed the original does not reach it there.
+ *
+ * Short on purpose. Everything that makes a row look like a row is matched by a
+ * plain class selector (`.wt-row`, `.lane-head`, `.project-sq` — none of them
+ * scoped to an ancestor), so those follow the clone wherever it goes. The colour
+ * tokens do not, quite: the light theme redefines them on `body[data-theme]`
+ * rather than on `:root`, so they reach the clone because it is parented to
+ * `<body>` — one more reason `mountGhost` puts it exactly there. What does not
+ * follow either way is the *inherited* text properties, which the original gets
+ * from somewhere up inside the rail. Setting those on the clone's root covers
+ * its whole subtree — that is what inheritance means.
+ */
+const GHOST_INHERITED = [
+  "color",
+  "font-family",
+  "font-size",
+  "font-style",
+  "font-weight",
+  "letter-spacing",
+  "line-height",
+  "text-align",
+  "text-transform",
+] as const;
+
+/**
+ * Whether a computed `background-color` lets what is behind it show through.
+ *
+ * The alpha is the whole question, and it is asked twice because Chromium has
+ * two ways of writing one. A legacy colour serialises as `rgb(r, g, b)` when it
+ * is opaque and `rgba(r, g, b, a)` when it is not — comma-separated, alpha last.
+ * Anything that went through `color-mix()` or a modern colour space does not:
+ * measured, `color-mix(in oklab, … , transparent)` computes to
+ * `oklab(L a b / 0.09)` and the `in srgb` form to `color(srgb r g b / 0.88)`,
+ * both of which omit the slash entirely when opaque.
+ *
+ * Reading only the first form was the bug this replaces: the stylesheet already
+ * uses `color-mix` on a rail selector, and an `oklab(… / 0.09)` matched nothing,
+ * so a 9%-alpha background was read as fully opaque — which is the one answer
+ * that makes the ghost unreadable rather than merely wrong.
+ */
+export function seeThrough(color: string): boolean {
+  if (color === "transparent" || color === "") return true;
+  const legacy =
+    /^rgba\(\s*[\d.]+\s*,\s*[\d.]+\s*,\s*[\d.]+\s*,\s*([\d.]+)\s*\)$/.exec(
+      color,
+    );
+  if (legacy) return Number(legacy[1]) < 1;
+  // `oklab(… / a)`, `oklch`, `lab`, `lch`, `color(srgb … / a)`, `hsl(… / a)` —
+  // every modern form puts the alpha after a slash, as a number or a percentage.
+  const slash = /\/\s*([\d.]+)(%?)\s*\)$/.exec(color);
+  if (slash) return Number(slash[1]) < (slash[2] ? 100 : 1);
+  return false;
+}
+
+/**
+ * The colour of the surface `el` is sitting on: the nearest ancestor that
+ * actually paints something.
+ *
+ * A rail row's own background is transparent — it borrows the rail's — and the
+ * clone leaves the rail behind. Flying over a terminal that is the one thing the
+ * native drag image never was: dark text on a dark page. So the ghost is handed
+ * the surface it was lifted off, and carries it like a card.
+ */
+function surfaceUnder(el: HTMLElement): string {
+  for (let n = el.parentElement; n; n = n.parentElement) {
+    const bg = getComputedStyle(n).backgroundColor;
+    if (!seeThrough(bg)) return bg;
+  }
+  return "";
+}
+
+/**
+ * The copy of the dragged element that flies under the cursor.
+ *
+ * A clone rather than a rendering the caller describes: three surfaces would each
+ * need a second version of themselves kept in step with the first, and this way
+ * there is nothing to keep in step — a photograph cannot drift from its subject.
+ * It is taken before `onBegin`, so it catches the source *un*faded; the fade is a
+ * React class that only lands on the following render.
+ *
+ * Parked on `<body>` because `position: fixed` is fixed to the viewport only
+ * while no ancestor carries a `transform`, `filter` or `will-change`, and a
+ * clone left inside the rail would be one refactor away from being positioned
+ * against a box that moves. Mounting is this function's job rather than the
+ * caller's, because the last decision it makes has to be read back off the live
+ * element — see the backing colour below.
+ */
+function mountGhost(el: HTMLElement, rect: DOMRect): HTMLElement {
+  const ghost = el.cloneNode(true) as HTMLElement;
+  ghost.classList.add("drag-ghost");
+  // Duplicated ids would quietly steal every `aria-labelledby` and `for=` aimed
+  // at the original, and there is nothing here for a screen reader to read
+  // anyway: the row it was copied from is still in the tree, still labelled.
+  ghost.removeAttribute("id");
+  ghost.querySelectorAll("[id]").forEach((n) => n.removeAttribute("id"));
+  ghost.setAttribute("aria-hidden", "true");
+  const cs = getComputedStyle(el);
+  for (const prop of GHOST_INHERITED) {
+    ghost.style.setProperty(prop, cs.getPropertyValue(prop));
+  }
+  // Inline rather than in `.drag-ghost`: these have to beat whatever the
+  // element's own rules say about where it sits and how big it is, and the class
+  // is a single one competing with selectors that may carry more.
+  ghost.style.position = "fixed";
+  ghost.style.left = "0";
+  ghost.style.top = "0";
+  ghost.style.margin = "0";
+  ghost.style.boxSizing = "border-box";
+  ghost.style.width = `${rect.width}px`;
+  ghost.style.height = `${rect.height}px`;
+  document.body.appendChild(ghost);
+  // Asked of the clone and not of the original, and only once it is mounted,
+  // because they do not agree: the source is under the pointer and therefore
+  // `:hover`, which paints it. The copy is not hovered by anything and never
+  // will be, so this is the only way to learn what it will actually render as.
+  if (seeThrough(getComputedStyle(ghost).backgroundColor)) {
+    ghost.style.backgroundColor = surfaceUnder(el);
+  }
+  return ghost;
+}
+
+/**
+ * Move the ghost so its top-left is at `x`,`y`.
+ *
+ * `transform` and not `left`/`top`: this runs on every `pointermove` and the
+ * transform is composited, so the ghost moves without laying the page out again.
+ * Rounded because a row is mostly text and a half-pixel offset renders it blurry.
+ */
+function placeGhost(ghost: HTMLElement, x: number, y: number): void {
+  ghost.style.transform = `translate3d(${Math.round(x)}px, ${Math.round(y)}px, 0)`;
+}
+
+/**
+ * Capture phase for the drag's Escape listener, and window's capture phase runs
+ * before anything else in the document. Measured: a project square carries a
+ * Mantine `Tooltip`, the tooltip is open exactly when you are dragging the
+ * square, and Floating UI's dismiss-on-Escape swallows the keydown at capture —
+ * so a bubble-phase listener here never saw it, and Escape silently committed
+ * the drag instead of cancelling it. Whatever else wants Escape, a drag in
+ * flight wants it more.
+ */
+const KEY_OPTS = { capture: true } as const;
+
+/** What the caller is told about the drag it asked for. */
+export type PointerDragSpec<S> = {
+  /** The press became a drag. Fires once, when the threshold is crossed. */
+  onBegin: (source: S) => void;
+  /** The pointer moved while dragging — or the autoscroll moved the content
+   *  under a pointer that did not. */
+  onMove: (source: S, x: number, y: number) => void;
+  /** Released. The target is the caller's to resolve from the coordinates, the
+   *  same way `onMove` did, so what is committed is what was last shown. */
+  onDrop: (source: S, x: number, y: number) => void;
+  /** Escape, a cancelled pointer, or the window losing focus. Never fires for a
+   *  press that stayed under the threshold. */
+  onCancel: () => void;
+  /** The element to scroll while the pointer sits near its top or bottom edge,
+   *  if any — and only while the pointer is horizontally inside it. */
+  scroller?: () => HTMLElement | null;
+};
+
+type Session<S> = {
+  pointerId: number;
+  source: S;
+  startX: number;
+  startY: number;
+  /** The element the press landed on, and the one that takes pointer capture
+   *  once this is a drag. Held rather than read back off the event: React
+   *  clears `currentTarget` as soon as the handler returns. */
+  el: HTMLElement;
+  /** Whether the threshold has been crossed. Until it has, this is still a
+   *  click and the caller has been told nothing. */
+  active: boolean;
+  /** Where the pointer was last seen, for the autoscroll frame loop. */
+  x: number;
+  y: number;
+  frame: number | null;
+  /** The flying copy of `el`, once this is a drag. */
+  ghost: HTMLElement | null;
+  /** Where inside `el` the press landed, so the ghost keeps the grab point: the
+   *  cursor stays on the part of the row it took hold of, and the copy lifts off
+   *  the original instead of jumping to meet the pointer. */
+  offX: number;
+  offY: number;
+};
+
+/**
+ * A press-move-release drag on any number of elements.
+ *
+ * `start` goes on the source's `onPointerDown` along with what is being carried;
+ * everything after that is on the window, so the drag survives the pointer
+ * leaving the element, the element unmounting, and the list reflowing under it.
+ *
+ * Capture is taken **at the threshold, not at the press**. That ordering is what
+ * lets a row full of nested buttons be draggable at all: capture retargets the
+ * `pointerup` and with it the `click`, so capturing on `pointerdown` would break
+ * every ▶ and ⋮ inside the things being dragged. By the time capture is taken
+ * the click is being swallowed anyway.
+ */
+export function usePointerDrag<S>(spec: PointerDragSpec<S>): {
+  start: (e: React.PointerEvent, source: S) => void;
+} {
+  // Read through a ref, so a drag in flight sees this render's handlers — they
+  // close over `groups`, `props.lanes` and the rest, which change under it.
+  const specRef = useRef(spec);
+  specRef.current = spec;
+  const session = useRef<Session<S> | null>(null);
+  // Forward reference: the listeners below end the drag, and `end` removes the
+  // listeners. Every function here is built once (`useCallback` with no
+  // dependencies) and reads its moving parts out of refs — which is required
+  // rather than tidy, because `removeEventListener` has to be handed the same
+  // function object `addEventListener` was.
+  const endRef = useRef<(commit: boolean, stillDown?: boolean) => void>(
+    () => {},
+  );
+
+  const frameStep = useCallback(() => {
+    const s = session.current;
+    if (!s || !s.active) return;
+    const scroller = specRef.current.scroller?.();
+    if (scroller) {
+      const box = scroller.getBoundingClientRect();
+      // Horizontally inside, or not at all. Vertically the velocity deliberately
+      // survives overshooting the edge — that is how you keep scrolling once the
+      // pointer has run past the last row — but a drag carried sideways out of
+      // the column entirely is not asking it to scroll, and a list that ran to
+      // its end while the pointer was somewhere else would have moved every
+      // target out from under the gesture that came back.
+      const v =
+        s.x < box.left || s.x > box.right
+          ? 0
+          : autoScrollVelocity(box.top, box.bottom, s.y);
+      if (v !== 0) {
+        const before = scroller.scrollTop;
+        scroller.scrollTop = before + v;
+        // Only when the content actually moved. At either end of the scroll
+        // range the velocity is still non-zero, and re-resolving there would be
+        // a target recomputed sixty times a second for a list that is not
+        // moving.
+        if (scroller.scrollTop !== before) {
+          specRef.current.onMove(s.source, s.x, s.y);
+        }
+      }
+    }
+    s.frame = requestAnimationFrame(frameStep);
+  }, []);
+
+  const onMove = useCallback(
+    (e: PointerEvent) => {
+      const s = session.current;
+      if (!s || e.pointerId !== s.pointerId) return;
+      s.x = e.clientX;
+      s.y = e.clientY;
+      if (!s.active) {
+        if (!beyondThreshold(e.clientX - s.startX, e.clientY - s.startY)) return;
+        s.active = true;
+        // Capture keeps the stream coming once the pointer leaves the source,
+        // which it does immediately — the whole gesture is about aiming
+        // somewhere else. Guarded on `isConnected` because a refresh between
+        // the press and the first move can have unmounted the row already, and
+        // capturing on a detached element throws.
+        if (s.el.isConnected) s.el.setPointerCapture(s.pointerId);
+        // Photograph before `onBegin` fades the source: the ghost is what the
+        // row looked like when it was picked up, not what it looks like now that
+        // it is a hole in the list.
+        const rect = s.el.getBoundingClientRect();
+        s.offX = s.startX - rect.left;
+        s.offY = s.startY - rect.top;
+        s.ghost = mountGhost(s.el, rect);
+        document.body.classList.add("pointer-dragging");
+        specRef.current.onBegin(s.source);
+        s.frame = requestAnimationFrame(frameStep);
+      }
+      // Placed here rather than at creation so there is one line that does it.
+      // The ghost is appended untranslated a few statements above, which is
+      // invisible: nothing can paint between there and here.
+      if (s.ghost) placeGhost(s.ghost, e.clientX - s.offX, e.clientY - s.offY);
+      specRef.current.onMove(s.source, e.clientX, e.clientY);
+    },
+    [frameStep],
+  );
+
+  const onUp = useCallback((e: PointerEvent) => {
+    const s = session.current;
+    if (!s || e.pointerId !== s.pointerId) return;
+    s.x = e.clientX;
+    s.y = e.clientY;
+    endRef.current(true);
+  }, []);
+
+  const onAbort = useCallback(() => endRef.current(false), []);
+
+  const onKey = useCallback((e: KeyboardEvent) => {
+    if (e.key !== "Escape") return;
+    // Only once this is a drag. Below the threshold there is nothing to cancel,
+    // and Escape belongs to whatever else is listening for it.
+    if (!session.current?.active) return;
+    e.preventDefault();
+    e.stopPropagation();
+    // The button is still held — Escape is a key, not a release — which is what
+    // the second argument is for. See the click swallower in `end`.
+    endRef.current(false, true);
+  }, []);
+
+  const end = useCallback(
+    (commit: boolean, stillDown = false) => {
+      const s = session.current;
+      if (!s) return;
+      session.current = null;
+      if (s.frame !== null) cancelAnimationFrame(s.frame);
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onAbort);
+      window.removeEventListener("keydown", onKey, KEY_OPTS);
+      window.removeEventListener("blur", onAbort);
+      // A press that never crossed the threshold was a click. Nothing was told
+      // a drag existed, so nothing is told it ended.
+      if (!s.active) return;
+      document.body.classList.remove("pointer-dragging");
+      s.ghost?.remove();
+      if (s.el.hasPointerCapture(s.pointerId)) {
+        s.el.releasePointerCapture(s.pointerId);
+      }
+      // The click this release produces belongs to the drag, not to whatever is
+      // under the pointer — a lane header is also its section's fold toggle, and
+      // a row is its own selection. Capture phase, so it never reaches a
+      // handler, and one-shot, because a drag released over nothing clickable
+      // produces no click at all and the listener must not outlive the gesture.
+      const swallow = (ev: MouseEvent) => {
+        ev.stopPropagation();
+        ev.preventDefault();
+        disarm();
+      };
+      const disarm = () => {
+        window.removeEventListener("click", swallow, true);
+        window.removeEventListener("pointerup", released, true);
+        window.removeEventListener("pointercancel", disarm, true);
+      };
+      // `pointerup` runs before `click`, so the disarm waits a turn — otherwise
+      // it removes the swallower just in time for the click to get through.
+      const released = () => setTimeout(disarm, 0);
+      window.addEventListener("click", swallow, true);
+      if (stillDown) {
+        // Escape, with the button still held. The click that must not happen has
+        // not been produced yet: it arrives whenever the user lets go, which is
+        // arbitrarily later than a timer would have fired. Measured — Escape and
+        // then a release over the source row selected that worktree and folded
+        // its lane, which is exactly what cancelling was supposed to prevent.
+        window.addEventListener("pointerup", released, true);
+        // A release is not guaranteed even so: the pointer can be cancelled, or
+        // the window can take the gesture away. Either way no click follows, and
+        // a swallower left armed would eat an unrelated one later.
+        window.addEventListener("pointercancel", disarm, true);
+      } else {
+        // The release already happened — on a drop it is what got us here, and
+        // on a `blur` or a cancelled pointer it went somewhere this window will
+        // never hear about. Either way the click, if there is one, is the very
+        // next thing to run.
+        released();
+      }
+      if (commit) specRef.current.onDrop(s.source, s.x, s.y);
+      else specRef.current.onCancel();
+    },
+    [onMove, onUp, onAbort, onKey],
+  );
+  endRef.current = end;
+
+  // A component unmounted mid-drag would otherwise leave the window listeners,
+  // the frame loop and the body class behind.
+  useEffect(() => () => endRef.current(false), []);
+
+  const start = useCallback(
+    (e: React.PointerEvent, source: S) => {
+      // Primary button only. The secondary one opens the context menu the rail's
+      // sections and rows already have, and a drag armed underneath it would be
+      // in flight while the user reads the menu.
+      if (e.button !== 0 || session.current) return;
+      session.current = {
+        pointerId: e.pointerId,
+        source,
+        startX: e.clientX,
+        startY: e.clientY,
+        el: e.currentTarget as HTMLElement,
+        active: false,
+        x: e.clientX,
+        y: e.clientY,
+        frame: null,
+        ghost: null,
+        offX: 0,
+        offY: 0,
+      };
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onUp);
+      window.addEventListener("pointercancel", onAbort);
+      window.addEventListener("keydown", onKey, KEY_OPTS);
+      // A window that loses focus mid-drag stops being told where the pointer
+      // is, so the honest end is here rather than on a target the user can no
+      // longer see themselves aiming at.
+      window.addEventListener("blur", onAbort);
+    },
+    [onMove, onUp, onAbort, onKey],
+  );
+
+  return { start };
+}

--- a/crates/veld-daemon/ui/src/styles.css
+++ b/crates/veld-daemon/ui/src/styles.css
@@ -885,8 +885,10 @@ button.lane-empty {
  * pointer would move the whole list above it as well.
  *
  * `.rail-group` is the positioning context (it already is one, for the lane
- * bars). `pointer-events: none` because the section underneath is the actual
- * drop target and the drag events must reach it. */
+ * bars). `pointer-events: none` because this is a picture of a drop and the
+ * section underneath is the actual target: the drop no longer resolves through
+ * hit testing at all, but the overlay outlives its drag by a frame and must not
+ * be something the next press can land on. */
 .trash-drop {
   position: absolute;
   inset: 0;
@@ -940,12 +942,17 @@ button.lane-empty {
    the secondary gesture at the expense of the primary one: what you do to a
    section is fold it and click the rows inside, while dragging a lane into a new
    order is the rare, deliberate act. Pressing is the moment the two stop
-   competing, so that is where the hand belongs — and it is the last moment a
-   page can draw one at all, because a native drag hands the cursor to the OS the
-   instant it starts.
+   competing, so that is where the hand belongs.
+
+   This covers the press only. Once the press becomes a drag the pointer is off
+   the header and `body.pointer-dragging` takes over — which it can, now that the
+   drag is the page's rather than the OS's: a native drag took the cursor away at
+   the instant it started, and this rule was the last moment anything could draw
+   one.
 
    Only on a real lane in the expanded rail — the class carries that decision (it
-   is the same expression that sets `draggable`), the cursor only reports it. */
+   is the same expression that gates `onPointerDown`), the cursor only reports
+   it. */
 .lane-head.draggable:active {
   cursor: grabbing;
 }
@@ -1125,12 +1132,12 @@ button.lane-empty {
    hover overrode that with the secondary gesture and made every row read as
    something to move rather than something to open. Dragging is real but rarer,
    and it does not need advertising to be found — pressing and holding is the
-   gesture people already try, and it is the only window in which a page can draw
-   a hand at all, since a native drag gives the cursor to the OS.
+   gesture people already try. Past the press, `body.pointer-dragging` carries
+   the cursor for the rest of the drag.
 
-   The class carries the decision (it is the same expression that sets
-   `draggable`, so the cursor cannot claim a row is movable when it is not); the
-   cursor only reports it.
+   The class carries the decision (it is the same expression that gates
+   `onPointerDown`, so the cursor cannot claim a row is movable when it is not);
+   the cursor only reports it.
 
    The nested controls need no override here: `.wt-edit`, `.wt-run` and
    `.wt-alert` each declare `cursor: pointer` on themselves, and a cursor
@@ -1144,6 +1151,62 @@ button.lane-empty {
    under the pointer makes the drop target move as you aim at it. */
 .wt-row.dragging {
   opacity: 0.4;
+}
+
+/* Set on `<body>` for the length of any rail drag — rows, lane headers, project
+   squares — by `usePointerDrag`.
+
+   A pointer drag is an ordinary press, so without this the page carries on
+   behaving like one: the cursor becomes whatever it is passing over (a row's
+   `pointer`, a terminal's `text`, a resizer's `col-resize`), and a move with a
+   button held selects text the whole way. A native drag handed both problems to
+   the OS; this is the half of that which had to come back.
+
+   `!important` on a descendant selector, which this stylesheet otherwise spends
+   sparingly, because it is competing with a `cursor` declared on the element
+   under the pointer — and specificity cannot win that, since the whole point is
+   that we do not know what is under the pointer. It applies only while a drag is
+   in flight, and a drag always ends: `end()` removes the class on release,
+   cancel, Escape, lost focus and unmount alike. */
+body.pointer-dragging,
+body.pointer-dragging * {
+  cursor: grabbing !important;
+  user-select: none !important;
+}
+
+/* The thing you are holding: a clone of the dragged element, made and flown by
+   `usePointerDrag` (see `mountGhost`). The caret says where the drop lands; this
+   says what is in your hand, and a drag across the window without it is a cursor
+   moving over a page that never acknowledged the press.
+
+   Deliberately thin. Everything that makes the copy look like a row still comes
+   from `.wt-row`, `.lane-head` and `.project-sq` — none of them scoped to an
+   ancestor, so they keep applying to a node parked on `<body>`. Position, size
+   and the backing colour are set inline instead, because they have to beat the
+   element's own rules; `mountGhost` explains why the backing exists at all. */
+.drag-ghost {
+  /* The drag resolves its target geometrically, from `getBoundingClientRect` on
+     the rail's own nodes, so a ghost under the cursor could not confuse it even
+     if it were hittable. This is for the cursor and for a stray `:hover`. */
+  pointer-events: none;
+  /* Above everything. Nothing modal can be open mid-drag, but the ghost has to
+     clear the rail, the topbar and a Mantine portal alike, and a number chosen
+     to lose to one of them would only ever be discovered by dragging over it.
+     Every z-index this stylesheet sets is single-digit. */
+  z-index: 300;
+  /* Not opaque: the ghost starts exactly over the row it was copied from, and a
+     solid copy would read as the row having failed to fade. Not faint either —
+     `.wt-row.dragging` is already at 0.4, and the point of the pair is that what
+     you are carrying is the more present of the two. */
+  opacity: 0.85;
+  /* Lifted off the page, which is the whole claim the ghost is making. */
+  box-shadow: var(--shadow);
+  /* It moves every frame and nothing else on the page does. */
+  will-change: transform;
+  /* A transition inherited from the original would apply to the transform this
+     is moved with, and the ghost would trail the cursor by its duration — which
+     reads as the drag lagging rather than as the ghost easing. */
+  transition: none;
 }
 /* The insertion caret — the same 3px glowing bar the pane tab strip uses, turned
  * horizontal.
@@ -1274,6 +1337,12 @@ button.lane-empty {
   max-width: 100%;
   overflow: hidden;
   cursor: pointer;
+  /* A row is a control, not prose. It reads as text you could select, and while
+     the row was `draggable` the browser suppressed that for free; a pointer
+     drag does not, and a press that selects an alias before it crosses the
+     threshold leaves Chromium dragging the selected text instead of the row.
+     `.lane-head` and `.project-sq` have said this for the same reason. */
+  user-select: none;
   /* Fixed so collapsing the rail doesn't reflow the list: expanded rows are
      as tall as their 17px controls, collapsed ones only as tall as the
      emoji. Must clear the tallest expanded child plus vertical padding. */


### PR DESCRIPTION
The rail's three drags — worktree rows, lane headers, project squares — no
longer use HTML5 drag-and-drop. `shared/pointerDrag.ts` is a `pointerdown` →
threshold → `setPointerCapture` → `pointermove` → `pointerup` gesture, with the
drop target resolved from a point instead of from a per-element `dragover`
protocol.

## Why

HTML5 DnD hides the pointer from the page, and every question the rail actually
had to answer was a question about a *point*. Each of the three costs below was
a comment in `App.tsx` before this PR:

| Native DnD | What the rail did about it |
|---|---|
| `dragend` fires on the **source node**, so a row unmounted mid-drag (the 5s poll, a rename in another window) takes the only event that ends the gesture | A window-level `dragend`/`drop` listener existed purely to un-strand the drag state |
| No way to ask *"would anything here take this?"* — `preventDefault` is the only way to accept a drop | `defaultPrevented` was adopted as a claim between the rail's own handlers, plus a second window listener to retract a highlight the pointer had left |
| Firefox ignores a drag that sets no `dataTransfer` data | Three `setData` calls that nothing in the app ever read back |

A pointer drag cannot reach the first state at all: `pointerup` is delivered to
the window whatever happened to the element it started on. "Over nothing"
becomes the ordinary answer rather than an event that has to be inferred.

## What was owed back

Three things came free with a native drag. Losing them silently is how a
rewrite regresses, so they are re-implemented:

- **Edge autoscroll** (`autoScrollVelocity`) — ramped, not constant, with a
  rounding floor of 1 so the band has no dead rim where a drag first enters it.
- **No click after a drop.** Chromium emits no `click` after a native drop, and
  the lane header leans on that: the bar that reorders lanes is also the bar
  that folds the section. This swallows exactly one click, centrally, in the
  capture phase.
- **A drag image.** The caret and the wash say where the thing will *land*,
  which is a different question from what is in your hand. The source element
  is cloned and flown under the cursor at its own size (`mountGhost`).

The ghost hangs off `<body>`, which is deliberate — the light theme redefines
the colour tokens on `body[data-theme]`, so they reach the clone there — and it
is handed the surface it was lifted off. `.wt-row` is transparent and only
looks white when `:hover`ed; a clone is never hovered, so without that a row
dragged over a terminal pane is dark text on a dark page.

## Rejected alternative: suspending the browser panes

Pointer capture does not survive a `WebContentsView`. Once the cursor is over
an embedded browser pane the renderer stops seeing `pointermove`, the pane
takes focus, `blur` reaches `onAbort`, and the drag cancels.

`PaneArea`'s splitter already hides the views for its duration
(`pushBrowserSuspend`), and a rail drag can do the same — it was implemented,
demonstrated, and taken back out. It freezes **every** browser pane in the
window to a still on **every** row, lane and square drag, to buy feedback on a
path that has no destination: every drop target the rail has is *in* the rail.
Cancelling on a release outside a drop area is the intended behaviour
(maintainer's call at the checkpoint), so nothing is done about native views
and the reasoning is recorded in the module docstring.

## Review

**No multi-angle review ran — single-agent inline review only.** `AGENTS.md`
mandates the multi-angle loop; this run could not spawn subagents, so
[`docs/agentic-review.md`](docs/agentic-review.md) §11's angles 4 (*what isn't
here*) and 5 (*self-consistency*) were run inline over the diff, once. §4's
blindness and §8.1's dedupe-by-location did not happen — two angles landing on
the same `path:line` is the only corroboration signal the loop has, and a
single reader cannot be independent of itself. Weigh the findings below
accordingly.

Three findings, all verified against the running app rather than asserted, all
fixed in this PR:

1. 🔴 **Escape cancelled the drag, then the release still landed a click.**
   Press a row, drag, press Escape (button still down), let go: measured over
   CDP, that selected a worktree (`row selection before=main after=pr-129`) and
   folded a lane (`lane fold before=true after=false`). Escape said *forget it*
   and the gesture acted anyway, one release later. The click swallower
   disarmed on a `setTimeout(…, 0)` — right for a drop, where the release
   already happened and the click is one turn away; wrong for Escape, where the
   click does not exist yet and arrives whenever the user lets go. `end()` now
   takes `stillDown` and waits for the real `pointerup`, and disarms on
   `pointercancel` so a swallower is never left armed to eat an unrelated
   click. Both probes now read `PASS no click`. Note this is a bug on its own
   terms; HTML5 DnD owns the gesture after `dragstart` and emits no `click` on
   release, but that side of the comparison was not re-measured on `main` —
   what was measured is the broken behaviour and the fix, both on this branch.

   *Not* to be confused with releasing outside a drop area, which cancels and
   always did: there the release **is** the `pointerup`, so the swallower is
   armed and the click that follows lands in it.
2. 🟠 **`seeThrough` misread the modern colour serializations.** Measured:
   `color-mix(in oklab, X 9%, transparent)` computes to `oklab(0.186986
   -0.00893791 -0.0236999 / 0.09)` and the `in srgb` form to `color(srgb
   0.0392157 0.0784314 0.117647 / 0.88)`. Only `rgba()` was parsed, so a
   9%-alpha background read as fully opaque — the one answer that makes the
   ghost unreadable. `.rail-group.drop-in` is already a `color-mix(in oklab,
   …)`. Not reachable today (that class lands after the ghost is measured), but
   the failure mode is silent. Generalised, with unit tests.
3. 🟡 **A false claim in a comment.** `GHOST_INHERITED` said the colour tokens
   live on `:root`; the light theme redefines them on `body[data-theme="light"]`
   and they reach the clone only because it is parented to `<body>`. Corrected.

## Verification

`crates/veld-daemon/ui` has no jsdom/RTL, so behaviour is verified two ways:
pure functions extracted and unit-tested, and the running app driven over CDP.

- `npm run lint` · `npm run typecheck` · `npm run test` — all green, 1203 tests
  in 44 files (20 new: `pointerDrag.test.ts` ×15, `insertionTarget` ×5).
- `just favicon`, `just topbar-height`, `just shellcheck` — green. The rest of
  `just lint`/`just test` is Rust and untouched by this diff.
- CDP against a live `/ide`: ghost geometry, styling, parentage, id-stripping
  and `aria-hidden` (**21/21**); row moves between lanes and back; lane reorder,
  lane-onto-dock, row-to-trash and restore; project-square reorder; Escape
  mid-drag on all three; a 2px press producing no ghost; drop outside a target
  committing nothing; clicks still selecting after a drag. No console errors, no
  leaked `.drag-ghost`, no leaked `pointer-dragging` class.

## Docs

Purely internal by the `AGENTS.md` checklist's own test — no config field, no
CLI flag, no new keyboard shortcut, and no user-visible capability that the
README does not already describe ("squares are **dragged to reorder**" is still
true). The mechanism changed; the surface did not. Nothing added to the
shortcuts registry: Escape-to-cancel is contextual, not a chord.

**Promotion: no.** This is a mechanism swap with a legibility fix on the drag
image. Nobody's day changes, and a promotion interrupts every user once.

## Settings

Recorded at kickoff in `.veld-ship.json`:

| | |
|---|---|
| Review depth | `standard` |
| Merge policy | `bypass-on-green` |
| Checkpoints | `one-before-review` |
| Docs scope | `user-visible-ui` (revised to *internal* — see Docs) |

Checkpoint one was presented twice. The first pass returned two items; both are
resolved above — the browser-pane workaround was withdrawn on the maintainer's
instruction, and the drag ghost was approved as-is.

## Behaviour-visible review fixes worth re-driving

One checkpoint was chosen, so this is named here rather than in a second
hand-over: **finding 1 changed drag-cancel behaviour after the checkpoint.**
Press a row or a lane header, drag, press Escape, and let go — over the source
and away from it. Nothing should be selected and no lane should fold.
