### PR TITLE
fix(desktop): stop a browser pane taking the keyboard when its page reloads

### DIFF
--- a/desktop/src/browserViews.js
+++ b/desktop/src/browserViews.js
@@ -55,6 +55,22 @@ const { cssBoxToDip, emulationScale, zoomFactor } = require("./windowState");
 const { safeAreaPayload } = require("./safeArea");
 // The permission policy is likewise its own tested, Electron-free module.
 const permissions = require("./permissions");
+// Whether a focus a browser pane just took belongs to the page's load or to the
+// user — an Electron-free rule, in its own module for the same reason as the two
+// above, and the only part of the focus guard that can be unit-tested.
+const { isLoadFocus } = require("./focusSteal");
+
+/**
+ * Input events that mean "the user pressed on this page".
+ *
+ * Wider than `mouseDown` because this file turns touch emulation on for a pane
+ * showing a device (`Emulation.setEmitTouchEventsForMouse`), and Chromium reports
+ * a press through whichever of these families the pane is configured for. Missing
+ * the one that fires would leave the user with no way to force focus into a
+ * mobile-emulated pane that keeps reloading — the exact hole the press signal is
+ * here to close. Costs nothing to be generous: every one of them is a press.
+ */
+const PRESS_EVENTS = new Set(["mouseDown", "pointerDown", "touchStart", "gestureTapDown"]);
 
 /**
  * Per-window view cap.
@@ -82,12 +98,42 @@ const MAX_VIEWS_PER_WINDOW = 16;
  *            touchActive: boolean, mediaActive: boolean, safeAreaActive: boolean,
  *            safeAreaApplied: SafeAreaInsets|null,
  *            frameReady: boolean, emulated: boolean, dragging: boolean,
+ *            focused: boolean, navStartedAt: number, requestedAt: number,
  *            touchQueue: Promise<void>|undefined}} Entry
  */
 
 /** window.id → (viewId → Entry) */
 /** @type {Map<number, Map<string, Entry>>} */
 const byWindow = new Map();
+
+/**
+ * The view that last legitimately took the keyboard, per window — `undefined`
+ * when that was the `/ide` renderer itself.
+ *
+ * Written only on an *accepted* focus, never on blur, and that asymmetry is the
+ * whole point. When one pane steals focus from another, Chromium blurs the old
+ * one before it focuses the new one, so by the time the steal is refused the
+ * loser has already been forgotten if blur cleared this. Keeping the last
+ * accepted answer is what lets the keyboard go back to the pane it came from
+ * rather than to the host page.
+ */
+/** @type {Map<number, string>} */
+const focusOwner = new Map();
+
+/**
+ * The clock both of the focus guard's windows are measured against.
+ *
+ * `performance.now()`, **not `Date.now()`**: these are two durations of a few
+ * hundred milliseconds, and wall clock is not monotonic. An NTP correction or a
+ * manual clock change stepping *backwards* makes an arbitrarily old press look
+ * like it just happened, which turns the guard off for that pane until wall clock
+ * catches up — an hour's step is an hour with the fix disabled. A step *forwards*
+ * (the usual shape of a sleep/wake) expires an in-flight navigation's window and
+ * lets one steal through. Neither is reachable with a monotonic source.
+ */
+function guardNow() {
+  return performance.now();
+}
 
 function entriesFor(windowId) {
   const existing = byWindow.get(windowId);
@@ -586,8 +632,76 @@ function applyEmulation(window, viewId, entry) {
  * the next one that starts, so the pane can show *why* it is blank instead of
  * just being blank.
  */
+/**
+ * Windows whose own `webContents` is already reporting when it takes the keyboard.
+ *
+ * A `WeakSet` on the window rather than a set of ids: nothing has to unregister it,
+ * and a destroyed window takes its entry with it.
+ */
+const hostFocusTracked = new WeakSet();
+
+/**
+ * Notice when the `/ide` page itself takes the keyboard back.
+ *
+ * The counterpart to the `focusOwner` write in a view's `focus` listener: without
+ * it, clicking out of a pane and into the app leaves this map still naming that
+ * pane, and the next refused steal would hand the keyboard to a view the user had
+ * left rather than to the page they are in.
+ */
+function trackHostFocus(window) {
+  if (hostFocusTracked.has(window)) return;
+  hostFocusTracked.add(window);
+  window.webContents.on("focus", () => focusOwner.delete(window.id));
+}
+
+/**
+ * Undo a focus a page load took: give the keyboard back to whoever had it.
+ *
+ * Synchronous, inside the `focus` listener — measured as the one that works. The
+ * hand-back lands 1-2 ms after the steal, before a keystroke can fall down the
+ * gap, and the guest's `blur` follows immediately rather than the two fighting.
+ *
+ * The destination is the last view to take focus legitimately, so that a pane
+ * reloading in one dock cannot empty the keyboard out of a pane the user is typing
+ * in in the other. With no such view — or one that has since gone — it is the
+ * `/ide` renderer, which restores its own document's `activeElement` and so puts
+ * the caret back in the terminal it was in.
+ */
+function handBackFocus(window, viewId) {
+  if (window.isDestroyed()) return;
+  // **Nothing to hand back while this window is not the key one.** Measured on
+  // Electron 43: a view raises no `focus` event at all once its window loses OS
+  // focus, so this is a guard against a state that has not been observed rather
+  // than a live branch — and it stays because the cost of being wrong is the bug
+  // one layer up. `focus()` on a background window is how AppKit is asked to make
+  // it key, so a refused steal in a window the user is not in would raise Veld
+  // over whatever application they *are* in, once per refresh. The keyboard is not
+  // in this window; there is nothing here to restore.
+  if (!window.isFocused()) return;
+  const owner = focusOwner.get(window.id);
+  // `byWindow.get`, not `entriesFor`: this is a lookup, and `entriesFor` would mint
+  // an empty map for a window whose views have already been disposed.
+  const previous = owner !== undefined && owner !== viewId
+    ? byWindow.get(window.id)?.get(owner)
+    : undefined;
+  if (previous && !previous.view.webContents.isDestroyed()) {
+    // **Vouched for, exactly as the IPC `focus` command is.** The steal blurred
+    // this view on its way past, so its `focused` is already false — and if it is
+    // itself an auto-refreshing preview, its own navigation window may still be
+    // open. Without this, handing the keyboard back to it would be refused as a
+    // load-steal in turn, and the second hand-back finds `owner === viewId`, falls
+    // through to the host, and empties the keyboard out of the pane the user is
+    // typing in. Two dev-server previews, one per dock, is all that takes.
+    previous.requestedAt = guardNow();
+    previous.view.webContents.focus();
+    return;
+  }
+  if (!window.webContents.isDestroyed()) window.webContents.focus();
+}
+
 function attachListeners(window, viewId, entry) {
   const wc = entry.view.webContents;
+  trackHostFocus(window);
   const push = (error) => send(window, "veld:browser:state", stateOf(viewId, entry, error));
 
   wc.on("did-start-loading", () => push(null));
@@ -722,7 +836,52 @@ function attachListeners(window, viewId, entry) {
   //
   // Reported rather than inferred: only this process can see the native focus,
   // and the renderer resolves the view id back to the dock its tab sits in.
-  wc.on("focus", () => send(window, "veld:browser:focused", { viewId }));
+  wc.on("focus", () => {
+    // **A page load must not move the keyboard.** See [`isLoadFocus`] for what
+    // Chromium does here and why a hidden pane could empty the keyboard out of
+    // the terminal the user was typing in, once per `<meta refresh>`.
+    if (isLoadFocus(entry, guardNow())) {
+      handBackFocus(window, viewId);
+      // Deliberately no *new* `veld:browser:focused` from this view: the focused
+      // dock did not move, and saying it did would hand ⌘W a target the user never
+      // chose. (The hand-back can still make the pane that *does* hold the keyboard
+      // re-announce itself — same view id, so the renderer's updater returns the
+      // same layout and nothing re-renders. Only the host-branch hand-back is
+      // silent end to end, which is the case the "0 messages" measurement covers.)
+      return;
+    }
+    entry.focused = true;
+    focusOwner.set(window.id, viewId);
+    send(window, "veld:browser:focused", { viewId });
+  });
+
+  // Cleared on any blur, deliberately unlike `focusOwner` above. The asymmetry
+  // there exists because a steal blurs the previous holder before focusing the
+  // thief; this field is about *this* view only, and a view that has lost the
+  // keyboard has lost it. It survives the case that matters — a focused pane
+  // reloading itself raises `focus` again with no `blur` between, measured — see
+  // [`isLoadFocus`], which records why that fact is written down.
+  wc.on("blur", () => {
+    entry.focused = false;
+  });
+
+  // The navigation half of the focus guard. Main frame only, and cross-document
+  // only: a subframe cannot take the window's keyboard on its own, and a
+  // same-document (fragment / `pushState`) navigation keeps the frame it already
+  // had — neither raises the focus this guard is about, and treating them as if
+  // they did would refuse a click that lands next to a single-page app's routing.
+  //
+  // **Only the start is recorded — there is deliberately no "and the load has not
+  // finished yet" half.** The first version had one, and it was a race the
+  // measurements themselves show: the steal lands 2-26 ms after the navigation
+  // starts, `did-stop-loading` 5-125 ms after, and every observed margin between
+  // them was 3-20 ms. A load finishing inside that margin would have cleared the
+  // flag before the focus it exists to refuse arrived. Recency alone cannot race,
+  // and nothing is lost — see [`isLoadFocus`].
+  wc.on("did-start-navigation", (details) => {
+    if (!details.isMainFrame || details.isSameDocument) return;
+    entry.navStartedAt = guardNow();
+  });
 
   wc.on("before-input-event", (event, input) => {
     if (input.type !== "keyDown") return;
@@ -870,6 +1029,21 @@ function attachListeners(window, viewId, entry) {
   // bounds handler does — so the page receives the coordinates its own
   // `pointermove` would have carried.
   wc.on("input-event", (_e, input) => {
+    // **A press on the page is the user asking for the keyboard**, and it outranks
+    // the load guard above — which cannot otherwise tell a click into a pane that
+    // is still loading from Chromium's own refocus, and so refused it.
+    //
+    // Recorded *and acted on*, because the order in which Chromium reports the
+    // press and raises the focus is not something this process can depend on:
+    // recording alone loses the case where the focus came first and was already
+    // refused, and re-focusing alone loses the case where the press came first
+    // and the focus behind it would be refused in turn. Together they are
+    // ordering-independent. Re-focusing is skipped when the view already has the
+    // keyboard, so an ordinary click inside a focused page costs nothing.
+    if (PRESS_EVENTS.has(input.type)) {
+      entry.requestedAt = guardNow();
+      if (!entry.focused && !wc.isDestroyed()) wc.focus();
+    }
     if (!entry.dragging) return;
     if (input.type !== "mouseMove" && input.type !== "mouseUp") return;
     if (window.isDestroyed() || window.webContents.isDestroyed()) return;
@@ -1507,6 +1681,9 @@ function disposeEntry(window, entry, viewId) {
   // A prompt this pane raised can no longer be answered — its chrome is going
   // away — and the page behind it is blocked on the callback.
   if (viewId !== undefined) abandonPrompts({ windowId: window.id, viewId });
+  // A closed pane must not be handed the keyboard back later — the entry is about
+  // to be unreachable and its `webContents` destroyed.
+  if (focusOwner.get(window.id) === viewId) focusOwner.delete(window.id);
   // A view disposed mid-gesture must not stay armed: nothing else clears this once the
   // entry is unreachable, and a forwarding view costs a cursor read and an IPC message
   // per mouse move.
@@ -1540,6 +1717,7 @@ function disposeWindow(window) {
   // answered, and the page behind it is blocked on the callback.
   abandonPrompts({ windowId: window.id });
   policyByWindow.delete(window.id);
+  focusOwner.delete(window.id);
   const entries = byWindow.get(window.id);
   if (!entries) return;
   for (const [viewId, entry] of entries) disposeEntry(window, entry, viewId);
@@ -1692,6 +1870,17 @@ function registerBrowserViewIpc(resolveWindow, opts = {}) {
       // Set only while the page is dragging this screen's edge; see the
       // `input-event` listener for what it turns on and why.
       dragging: false,
+      // The focus guard's state — whether this view holds the keyboard, when its
+      // last main-frame navigation started, and when the keyboard was last
+      // *asked* to come here. Both stamps are [`guardNow`]'s clock, not wall
+      // clock. See [`isLoadFocus`].
+      focused: false,
+      // `-Infinity`, not `0`, for both: these mean "has not happened", and a zero
+      // reads as "happened at the clock's origin" — which for a monotonic clock is
+      // process start, so a pane created in the first second of the app's life
+      // would have started life inside both windows.
+      navStartedAt: Number.NEGATIVE_INFINITY,
+      requestedAt: Number.NEGATIVE_INFINITY,
     };
     entries.set(viewId, entry);
     window.contentView.addChildView(view);
@@ -1951,6 +2140,12 @@ function registerBrowserViewIpc(resolveWindow, opts = {}) {
         wc.stop();
         break;
       case "focus":
+        // Recorded before the call, not after: this is the app asking for the
+        // keyboard, and the load guard must not mistake it for a page taking it.
+        // Without this a `focus` command landing while the pane happened to be
+        // mid-navigation was swallowed, and the handler still resolved — an
+        // explicit request refused with no signal back. See [`isLoadFocus`].
+        found.entry.requestedAt = guardNow();
         wc.focus();
         break;
       default:

--- a/desktop/src/focusSteal.js
+++ b/desktop/src/focusSteal.js
@@ -1,0 +1,109 @@
+/**
+ * The one pure rule behind "a page load must not move the keyboard".
+ *
+ * A file of its own for one function, for the same reason as `safeArea.js` next
+ * door: nothing in `browserViews.js` can be unit-tested, and this rule can.
+ *
+ * Chromium gives a `WebContentsView` keyboard focus on **every** committed
+ * main-frame navigation, including a reload it started itself. Measured on
+ * Electron 43 with a page carrying `<meta http-equiv="refresh" content="3">`:
+ * the view takes focus 2-26 ms after `did-start-navigation`, once per refresh,
+ * and — this is the part that makes it a bug rather than a quirk — it does so
+ * while the view is `setVisible(false)`, i.e. while its tab is not even the one
+ * on screen. So a background pane previewing an auto-refreshing dev server
+ * emptied the keyboard out of whatever the user was actually typing in, every
+ * few seconds, with nothing on screen changing to explain it.
+ *
+ * (The `<iframe>` backend has no such behaviour — measured the same way, the
+ * host document's `activeElement` is untouched across an iframe's reloads. This
+ * is a native-view problem only, which is why the fix lives in this process.)
+ *
+ * The rule: **a navigation may keep the keyboard in a pane that already had it,
+ * and may never take it into one that did not** — unless the keyboard was
+ * explicitly *asked* for there. Clicking into a page, and following a link from
+ * a page you are already typing in, both keep working. A reload of a pane you
+ * are not in does nothing.
+ *
+ * The first half of that rests on a measured fact worth writing down, because two
+ * review angles independently guessed the other way: **Chromium does not blur a
+ * view that already holds focus when its own page reloads.** It raises `focus`
+ * again with no `blur` in between, so `entry.focused` is still true when the
+ * guard reads it. (Checked against the patched code: a pane focused explicitly,
+ * then left to refresh three times, was accepted every time and the host never
+ * got the keyboard back.) If that ever changes, this rule silently inverts for
+ * the one pane the user is actually typing in — which is why it is stated here
+ * rather than left to be re-derived.
+ *
+ * The first load of a freshly created pane is guarded too, so opening a browser
+ * pane leaves the keyboard where it already was in `/ide`. That is deliberate
+ * rather than an oversight: the exception would have to read "except when the
+ * view has never navigated", which is also the state a crashed-and-reloaded
+ * renderer is in, and one rule with no exceptions is the one the next reader can
+ * predict. The cost is one click before the keyboard reaches a newly opened page.
+ */
+
+/**
+ * How long after a navigation starts an incoming focus is attributed to it.
+ *
+ * **Recency alone, deliberately — not "is the load still running".** The first
+ * version also required a `did-start-navigation` with no `did-stop-loading` after
+ * it, and that is a race the measurements themselves show: the steal lands 2-26 ms
+ * after the navigation starts and the load finishes 5-125 ms after it, so the two
+ * overlap, and every observed margin between them was 3-20 ms. A load that
+ * finishes inside that margin — a memory-cache reload, a 304 on localhost, a
+ * `data:` URL — would have disarmed the guard before the focus it exists to
+ * refuse ever arrived. Nothing is lost by dropping the flag: a focus in this
+ * window that the user asked for is covered by [`FOCUS_REQUEST_WINDOW_MS`], and
+ * the load is the only other thing that raises one.
+ *
+ * Generously above the 26 ms the steal was measured at, because the cost of being
+ * generous is now only that an *unrequested* focus is refused for a second after
+ * a navigation — and the load is what those are.
+ */
+const LOAD_FOCUS_WINDOW_MS = 1000;
+
+/**
+ * How long an explicit request for the keyboard vouches for the focus that follows.
+ *
+ * Three things set it, and they are the ways the keyboard is *asked* to come here
+ * rather than arriving on its own: a press on the page, the app's own `focus`
+ * command over IPC, and the hand-back that undoes a refused steal.
+ *
+ * Without it the guard has a real hole: a page that takes a while to load leaves
+ * the window above open for as long as it does, and a click landing inside that
+ * window is indistinguishable, on navigation state alone, from Chromium's own
+ * refocus — so the user's click into a slow-loading pane was refused, and so was
+ * an explicit "focus this pane" that happened to land during one.
+ *
+ * Deliberately short. It vouches for a focus raised in the same gesture, not for
+ * the pane taking focus at will for a quarter second afterwards.
+ *
+ * **Both orderings are covered, because which one Chromium uses is not something
+ * this process can rely on.** If the press is reported before the focus, the focus
+ * is let through here. If the focus lands first it is refused, and the
+ * `input-event` handler that records the press re-focuses the view behind it —
+ * which this window is then what accepts. See `browserViews.js`'s `input-event`
+ * listener.
+ */
+const FOCUS_REQUEST_WINDOW_MS = 250;
+
+/**
+ * Did this focus arrive because the page loaded, rather than because something
+ * asked for the keyboard to be here?
+ *
+ * `now`, `navStartedAt` and `requestedAt` must all come from the **same monotonic
+ * clock** — `performance.now()`, not `Date.now()`; see the callers.
+ *
+ * @param {{focused: boolean, navStartedAt: number, requestedAt: number}} entry
+ * @param {number} now
+ */
+function isLoadFocus(entry, now) {
+  // It already held the keyboard. Whatever the navigation is, it is not taking
+  // focus from anyone — this is the click-a-link case.
+  if (entry.focused) return false;
+  // The keyboard was just asked for here. Nothing a load does looks like that.
+  if (now - entry.requestedAt <= FOCUS_REQUEST_WINDOW_MS) return false;
+  return now - entry.navStartedAt <= LOAD_FOCUS_WINDOW_MS;
+}
+
+module.exports = { isLoadFocus, LOAD_FOCUS_WINDOW_MS, FOCUS_REQUEST_WINDOW_MS };

--- a/desktop/src/focusSteal.test.js
+++ b/desktop/src/focusSteal.test.js
@@ -1,0 +1,78 @@
+const test = require("node:test");
+const assert = require("node:assert");
+
+const { isLoadFocus, LOAD_FOCUS_WINDOW_MS, FOCUS_REQUEST_WINDOW_MS } = require("./focusSteal");
+
+// Mirrors what `browserViews.js` seeds a fresh entry with: nothing has navigated
+// and nothing has asked, so both stamps are "has not happened".
+const entry = (over) => ({
+  focused: false,
+  navStartedAt: Number.NEGATIVE_INFINITY,
+  requestedAt: Number.NEGATIVE_INFINITY,
+  ...over,
+});
+
+test("a focus arriving just after a navigation started belongs to the load", () => {
+  assert.equal(isLoadFocus(entry({ navStartedAt: 1000 }), 1005), true);
+});
+
+test("a pane that already had the keyboard keeps it across its own navigation", () => {
+  // Clicking a link in a pane you are typing in. Chromium raises `focus` again
+  // with no `blur` between, so `focused` is still true here — measured, and the
+  // reason the module says so out loud.
+  assert.equal(isLoadFocus(entry({ focused: true, navStartedAt: 1000 }), 1005), false);
+});
+
+test("a focus long after the last navigation is somebody asking", () => {
+  // Clicking into an idle pane, with no press recorded yet because the ordering
+  // put the focus first.
+  assert.equal(isLoadFocus(entry({ navStartedAt: 1000 }), 1000 + LOAD_FOCUS_WINDOW_MS + 1), false);
+});
+
+test("a pane that has never navigated cannot be blamed on a load", () => {
+  assert.equal(isLoadFocus(entry(), 1005), false);
+});
+
+test("the deadline is the only navigation state consulted", () => {
+  // Deliberately no "is the load still running" half: the steal (2-26 ms after
+  // the start) and `did-stop-loading` (5-125 ms after) overlap, so a fast load
+  // would have disarmed the guard before the focus it exists to refuse arrived.
+  const nav = entry({ navStartedAt: 1000 });
+  assert.equal(isLoadFocus(nav, 1000 + LOAD_FOCUS_WINDOW_MS), true);
+  assert.equal(isLoadFocus(nav, 1000 + LOAD_FOCUS_WINDOW_MS + 1), false);
+});
+
+test("the measured steal is well inside the deadline", () => {
+  // Measured on Electron 43: the view takes focus 2-26 ms after
+  // `did-start-navigation`. The window is generous on purpose — an unrequested
+  // focus in that second is what the load raises.
+  assert.ok(LOAD_FOCUS_WINDOW_MS > 26);
+});
+
+test("a request for the keyboard outranks a navigation in flight", () => {
+  // Clicking into a pane that is still loading, the app's own `focus` command
+  // landing during one, and the hand-back that undoes a refused steal — all three
+  // are indistinguishable from Chromium's refocus on navigation state alone.
+  const asked = entry({ navStartedAt: 1000, requestedAt: 1200 });
+  assert.equal(isLoadFocus(asked, 1200 + FOCUS_REQUEST_WINDOW_MS), false);
+});
+
+test("a request stops vouching once it is old", () => {
+  const stale = entry({ navStartedAt: 1000, requestedAt: 1000 });
+  assert.equal(isLoadFocus(stale, 1000 + FOCUS_REQUEST_WINDOW_MS + 1), true);
+});
+
+test("the request window is shorter than the navigation deadline", () => {
+  // It vouches for a focus raised in the same gesture, not for the pane taking
+  // focus at will for as long as a load runs.
+  assert.ok(FOCUS_REQUEST_WINDOW_MS < LOAD_FOCUS_WINDOW_MS);
+});
+
+test("a zero stamp is not read as 'just now' at the clock's origin", () => {
+  // The stamps come from `performance.now()`, whose origin is process start — so
+  // a `0` default would put a pane created in the app's first second inside both
+  // windows. `-Infinity` is what makes "has not happened" mean it.
+  assert.equal(isLoadFocus(entry({ navStartedAt: 0 }), 1), true, "a zero start is a real start");
+  assert.equal(isLoadFocus(entry({ navStartedAt: 0, requestedAt: 0 }), 1), false);
+  assert.equal(isLoadFocus(entry(), 1), false, "an unset entry is inside no window");
+});


### PR DESCRIPTION
## What

A browser pane in Veld Desktop no longer takes the keyboard when its page
reloads. Typing in a terminal pane while another pane previews an
auto-refreshing dev server now survives the refresh.

## Root cause

A browser pane is an Electron `WebContentsView` — a native widget, not a DOM
node. Measured on Electron 43 with a page carrying
`<meta http-equiv="refresh" content="3">`:

- Chromium gives the view keyboard focus on **every** committed main-frame
  navigation, including a reload the page starts itself.
- It does this **while the view is `setVisible(false)`** — i.e. while the pane's
  tab is not the one on screen. A hidden background pane still holds a live page,
  and that page kept pulling the keyboard.
- The steal lands 2-26 ms after `did-start-navigation`.
- `wc.on("focus")` then reported it to `/ide` as `veld:browser:focused`, which
  moves the layout's focused dock — the value ⌘W reads when it closes "the
  focused dock's active tab".

So a page nobody was looking at emptied the keyboard out of the pane the user was
typing in, once per refresh, with nothing on screen changing to explain it.

**Not the `<iframe>` backend.** Measured the same way: `/ide` in a plain browser
tab keeps its `document.activeElement` across an iframe's reloads. This is a
native-view problem, which is why the fix is entirely in the Electron main
process.

## The rule

> A navigation may keep the keyboard in a pane that already had it, and may never
> take it into one that did not.

Clicking into a page still focuses it. Following a link from a page you are
already typing in still works — the view was focused before the navigation
started. A reload of a pane you are not in does nothing.

## The exceptions, and why each exists

Three things vouch for a focus and get it through the guard — a press on the
page, the app's own `veld:browser:command "focus"` IPC, and the hand-back itself.
The last two were review findings, not foresight: an explicit focus command
landing during a navigation was swallowed and the handler still resolved, and a
hand-back aimed at a pane that is *itself* an auto-refreshing preview was refused
in turn, fell through to the host, and emptied the keyboard out of the pane the
user was typing in. Two dev-server previews, one per dock, is all that takes.

The guard is keyed on **how recently a navigation started**, and deliberately not
on "and the load has not finished yet". The first version had that second half
and it was a race the measurements show: the steal lands 2-26 ms after
`did-start-navigation`, `did-stop-loading` 5-125 ms after, and every observed
margin between the two was 3-20 ms. A load finishing inside that margin — a
memory-cache reload, a 304 on localhost, a `data:` URL — would have disarmed the
guard before the focus it exists to refuse arrived.

Both time windows are measured against `performance.now()`, not `Date.now()`. A
backwards wall-clock step makes an arbitrarily old press look like it just
happened, which turns the fix off for that pane until wall clock catches up.

## Evidence

Same harness, real `browserViews.js`, host page holding a focused input, guest
loading a 3-second `<meta refresh>` page, 16-second run:

| | `veld:browser:focused` sent | host keeps the keyboard |
|---|---|---|
| before | 9 | no — lost on the first load, and after every refresh |
| after | 0 | yes, for the whole run |

Then, at t+9 s in the "after" run, an explicit `wc.focus()` (standing in for a
user clicking into the pane) was **accepted** — the pane took the keyboard, and
kept it across its own subsequent refreshes. Both halves of the rule hold.

Also measured: no focus event fires at all while the `BrowserWindow` is not the
OS-key window, so the guard cannot raise the app or fight another application for
focus.

## What is deliberately not exempted

The **first** load of a newly created pane is guarded too, so opening a browser
pane leaves the keyboard where it was in `/ide` rather than moving it into the
page. That is a behaviour change beyond the reported bug, taken on purpose: one
rule with no exceptions is the one a reader can predict, and the exception would
have to be "except when the view has never navigated", which is exactly the state
a crashed-and-reloaded renderer is also in. The cost is one click before the
keyboard reaches a freshly opened page.

## Review

Light depth, two rounds, four angles (counterfactual + what-isn't-here at sonnet,
implicit-assumptions at opus, self-consistency at sonnet). Seven findings were
real and are fixed; **two 🟠 were disproved by measurement** rather than
"fixed" — a claim that a focused pane would lose the keyboard on its own reload
(it does not; Chromium raises `focus` again with no `blur` between, verified over
three consecutive refreshes), and a claim that the hand-back could raise a
background window. Two angles landed on the first one independently, so the
measured fact is now written into `focusSteal.js` and the `blur` listener instead
of being left to be re-derived a third time.

One finding was real but overstated: the click-into-a-loading-pane hole was
reported as costing "a third to half of each refresh cycle"; measured, the load
window is 5-125 ms against a 3 s cycle. It was fixed anyway — it is real for a
slow page.

## Docs / promotion

Purely internal bug fix, no new surface — the AGENTS.md documentation checklist
does not apply, and the marketing site does not change (it describes browser
panes; it never described them stealing focus). **Not promoted**: `docs/ship.md`
and `docs/promotions.md` both say never promote a bug fix.

Classified **core**, not customization: this is the built-in browser pane's own
focus behaviour — no provider API, no provider-specific schema or auth.

---
🚢 Carried by the ship workflow (`docs/ship.md`).

| Setting | This run |
|---|---|
| Review depth | Light — 6 spawns, 2 rounds (4 angles used) |
| Merge policy | Bypass-merge on green CI |
| Hands-on checkpoints | None |
| Docs & tests | Internal bug fix — AGENTS.md checklist N/A |
| Promotion | No |
