### PR TITLE
fix(ide): show the URL a browser pane is loading, and keep plain pages readable

### DIFF
--- a/crates/veld-daemon/ui/src/panes/BrowserPane.tsx
+++ b/crates/veld-daemon/ui/src/panes/BrowserPane.tsx
@@ -123,6 +123,7 @@ import {
 import { type BrowserErrorKind, describeBrowserError } from "./browserError";
 import {
   abandonPermission,
+  addressFor,
   answerPermission,
   browserBackend,
   browserCommand,
@@ -402,14 +403,17 @@ export function BrowserPane(props: {
     if (Object.keys(patch).length > 0) onTab(patch);
   }, [state.url, state.title]);
 
+  // What the bar says when it is not being typed into: the destination while one
+  // is loading, the committed page otherwise (`addressFor`).
+  const address = addressFor(state, tab.url);
   // The address bar is a text field, so it cannot be driven straight off
-  // `state.url` — that would rewrite a half-typed address on every background
+  // `address` — that would rewrite a half-typed address on every background
   // navigation. It follows the view only while unfocused.
   const [draft, setDraft] = useState(tab.url ?? "");
   const [editing, setEditing] = useState(false);
   useEffect(() => {
-    if (!editing) setDraft(state.url || tab.url || "");
-  }, [state.url, editing]);
+    if (!editing) setDraft(address);
+  }, [address, editing]);
 
   // Which screen stands in for the page. `paneCovers` is the *same* predicate that
   // hides the native view in browserHost — shared rather than restated, because the
@@ -1603,7 +1607,7 @@ export function BrowserPane(props: {
                 closeSuggestions();
                 return;
               }
-              setDraft(state.url || tab.url || "");
+              setDraft(address);
               e.currentTarget.blur();
             } else if (e.key === "ArrowDown" || e.key === "ArrowUp") {
               if (suggestions.count === 0) return;

--- a/crates/veld-daemon/ui/src/panes/browserHost.test.ts
+++ b/crates/veld-daemon/ui/src/panes/browserHost.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { type BrowserState, paneCovers } from "./browserHost";
+import {
+  type BrowserState,
+  addressFor,
+  isCommit,
+  paneCovers,
+  settlePending,
+} from "./browserHost";
 
 const state = (over: Partial<BrowserState> = {}): BrowserState => ({
   url: "",
@@ -7,6 +13,7 @@ const state = (over: Partial<BrowserState> = {}): BrowserState => ({
   loading: false,
   canGoBack: false,
   canGoForward: false,
+  pendingUrl: null,
   error: null,
   nested: null,
   profile: "default",
@@ -77,5 +84,106 @@ describe("paneCovers", () => {
     // An error outranks a loaded page: the error screen is the message, and the
     // view has to be out of the way for it to be visible at all.
     expect(paneCovers(state({ url: "http://x.test/", loading: true, error }))).toBe(true);
+  });
+});
+
+/**
+ * `pendingUrl` is the address bar's answer to "where are we going", and it exists
+ * because `url` cannot be: the shell reads `url` off `webContents.getURL()`,
+ * which keeps returning the page being *left* for the whole of a pending load.
+ *
+ * Its lifetime has two ends, and they are separate functions because they answer
+ * separate questions: `settlePending` retires it when the load *stops*, however
+ * it stopped, and `isCommit` retires it when the destination *arrives*. Neither
+ * subsumes the other — a stopped load never commits, and a committed page can go
+ * on loading subresources for seconds — so both are tested here.
+ */
+describe("settlePending", () => {
+  it("keeps the destination while the load is in flight", () => {
+    expect(settlePending(state({ loading: true, pendingUrl: "https://new/" }))).toBe(
+      "https://new/",
+    );
+  });
+
+  it("drops it the moment the load ends, however it ended", () => {
+    // Stopped by the user, failed, or simply arrived — all three reach here as
+    // `loading: false`, and all three mean the bar stops naming a destination.
+    expect(settlePending(state({ loading: false, pendingUrl: "https://new/" }))).toBeNull();
+    expect(
+      settlePending(
+        state({
+          loading: false,
+          pendingUrl: "https://new/",
+          error: { kind: "load", code: -102, text: "refused", url: "https://new/" },
+        }),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("isCommit", () => {
+  it("does not count the shell re-reporting the page being left", () => {
+    // `did-start-loading` fires with `webContents.getURL()` still on the old page.
+    // Reading that as a commit is the original bug, restated.
+    expect(isCommit("https://old/", "https://old/")).toBe(false);
+  });
+
+  it("counts a commit to a URL nobody typed", () => {
+    // The redirect case, which an equality test against the *typed* address
+    // cannot see: three review angles landed on this line independently.
+    expect(isCommit("https://www.example.com/", "https://example.com/")).toBe(true);
+  });
+
+  it("counts the first page in a view that has never reported one", () => {
+    expect(isCommit("https://first/", "")).toBe(true);
+  });
+
+  it("ignores an event that says nothing about the URL", () => {
+    // A title change, a devtools toggle: `onState` leaves `url` off the patch
+    // entirely, and that must not retire a destination still in flight.
+    expect(isCommit(undefined, "https://old/")).toBe(false);
+  });
+});
+
+describe("addressFor", () => {
+  it("shows the destination over the page being left", () => {
+    expect(
+      addressFor(state({ url: "https://old/", loading: true, pendingUrl: "https://new/" })),
+    ).toBe("https://new/");
+  });
+
+  it("shows the committed page once nothing is pending", () => {
+    expect(addressFor(state({ url: "https://old/" }))).toBe("https://old/");
+  });
+
+  it("keeps the URL that failed, rather than the page it was left on", () => {
+    // A failed load never commits, so `url` is still the old page — while the
+    // error screen under the bar names the one that failed. Showing both at once
+    // is the contradiction this rung exists to prevent.
+    expect(
+      addressFor(
+        state({
+          url: "https://old/",
+          error: { kind: "load", code: -102, text: "refused", url: "https://bad/" },
+        }),
+      ),
+    ).toBe("https://bad/");
+  });
+
+  it("falls through an error that names no URL", () => {
+    // A crashed renderer and a locally-raised failure both carry `url: ""`.
+    expect(
+      addressFor(
+        state({
+          url: "https://old/",
+          error: { kind: "crash", code: null, text: "oom", url: "" },
+        }),
+      ),
+    ).toBe("https://old/");
+  });
+
+  it("falls back to the tab's stored URL before any view has reported", () => {
+    expect(addressFor(state(), "https://stored/")).toBe("https://stored/");
+    expect(addressFor(state())).toBe("");
   });
 });

--- a/crates/veld-daemon/ui/src/panes/browserHost.ts
+++ b/crates/veld-daemon/ui/src/panes/browserHost.ts
@@ -63,6 +63,32 @@ export interface BrowserState {
   loading: boolean;
   canGoBack: boolean;
   canGoForward: boolean;
+  /**
+   * Where a navigation is *heading*, while it is still in flight; `null` the rest
+   * of the time.
+   *
+   * The address bar shows this in preference to `url`, which is Chrome's
+   * behaviour and the reason this field exists: `url` is what the view has
+   * actually *committed*, and the shell reads it back off `webContents.getURL()`
+   * — which keeps returning the old page for the whole of a pending load. So
+   * typing an address and pressing Enter used to show the address you were
+   * leaving until the new one arrived, and pressing Stop had nothing to undo.
+   *
+   * Only the address bar reads it. Everything else — `paneCovers`, the
+   * permission prompt's origin, the watched-file path, the layout's stored URL —
+   * must keep answering for the page that is on screen, not for one that may
+   * never arrive.
+   *
+   * Cleared by [`settlePending`] the moment the load ends, however it ends
+   * (arrived, stopped, failed), and by the commit itself ([`isCommit`]) in the
+   * shell-event handler below.
+   *
+   * Named `pendingUrl` and not `pending` because `View` already has a `pending`
+   * (the size a resize drag is coalescing towards) one property access away, and
+   * `v.pending` / `v.state.pending` are both well-typed — so confusing them would
+   * be a silent bug rather than a compile error.
+   */
+  pendingUrl: string | null;
   /** Why the pane is blank, when we know. */
   error: BrowserError | null;
   /**
@@ -367,6 +393,11 @@ interface View {
    *  applied size relayouts the user's page. */
   pending: { width: number; height: number } | null;
   pendingFrame: number;
+  /** The last URL the *shell* reported for this view, which is what makes
+   *  [`isCommit`] able to tell a commit from a re-report of the page being left.
+   *  Not on `BrowserState`: nothing renders it, and a state field is a field the
+   *  next reader has to rule out. */
+  lastShellUrl: string;
 }
 
 const views = new Map<string, View>();
@@ -506,12 +537,75 @@ function notify(v: View): void {
 
 function patch(v: View, next: Partial<BrowserState>): void {
   const merged = { ...v.state, ...next };
-  const changed = (Object.keys(next) as Array<keyof BrowserState>).some(
+  // The one invariant `pending` has, applied here rather than at each of the
+  // half-dozen places a load can end. A stopped load, a failed create, a rejected
+  // bridge call and an arrival are all "loading went false", and any one of them
+  // left unhandled is an address bar stuck on a destination the pane never
+  // reached — the exact failure this field was added to fix, inverted.
+  merged.pendingUrl = settlePending(merged);
+  // Compared over the *merged* keys, not `next`'s: the clamp above can change a
+  // field the caller never mentioned, and a change nobody notices is a pane that
+  // does not re-render.
+  const changed = (Object.keys(merged) as Array<keyof BrowserState>).some(
     (k) => v.state[k] !== merged[k],
   );
   if (!changed) return;
   v.state = merged;
   notify(v);
+}
+
+/**
+ * What `pending` is worth once the rest of the state has been applied: a
+ * destination cannot outlive the load it belongs to.
+ *
+ * Exported for the test, and pure so that it can be one — `patch` itself needs a
+ * live `View`.
+ */
+export function settlePending(state: BrowserState): string | null {
+  return state.loading ? state.pendingUrl : null;
+}
+
+/**
+ * Whether a shell state event carries a **commit** — the moment the view's own
+ * URL becomes the new page's.
+ *
+ * Two tempting shortcuts, both wrong, both paid for in review:
+ *
+ * - *"the reported URL is the one we asked for"* misses every redirect. A bare
+ *   domain bouncing to `www`, an `http`→`https` upgrade, an auth gate: all commit
+ *   a different URL from the one typed, so an equality test never fires and the
+ *   bar keeps the pre-redirect address for the whole resource-loading tail.
+ * - *"the reported URL differs from `state.url`"* fires on the first event of
+ *   every navigation, because `navigateBrowser` writes the target into
+ *   `state.url` optimistically before anything has loaded.
+ *
+ * So it is compared against the last URL the **shell** reported, which moves only
+ * when a page actually commits. `did-start-loading` re-reports the page being
+ * left — equal, correctly not a commit — and `did-navigate` reports whatever
+ * arrived, redirects included.
+ */
+export function isCommit(reported: string | undefined, lastReported: string): boolean {
+  return reported !== undefined && reported !== lastReported;
+}
+
+/**
+ * What the address bar shows.
+ *
+ * Shared with the pane rather than restated there, for the same reason
+ * [`paneCovers`] is: two expressions of one rule drift, and the drift here is a
+ * bar that disagrees with the Stop button beside it. `fallbackUrl` is the tab's
+ * stored URL, which the pane knows before any view exists.
+ *
+ * The **error** rung is there because a failed load never commits, so `url` is
+ * still the page being left — and the error screen right below the bar prints
+ * the URL that failed. Falling through to `url` put two different addresses on
+ * screen at once, one of them naming a page the pane is not showing. Chrome
+ * keeps the failed URL in the omnibox for the same reason, and it is the one you
+ * want to edit and retry. Only when the error names a URL: a crashed renderer
+ * and a locally-raised failure both carry `url: ""` and fall through.
+ */
+export function addressFor(state: BrowserState, fallbackUrl?: string): string {
+  return state.pendingUrl || state.error?.url || state.url || fallbackUrl || "";
 }
 
 /**
@@ -735,6 +829,7 @@ export function browserStatus(id: string): BrowserState {
       loading: false,
       canGoBack: false,
       canGoForward: false,
+      pendingUrl: null,
       error: null,
       nested: null,
       profile: "default",
@@ -816,6 +911,7 @@ function ensure(id: string, options: BrowserViewOptions): View {
       loading: Boolean(url) && !nested,
       canGoBack: false,
       canGoForward: false,
+      pendingUrl: null,
       error: null,
       nested,
       profile,
@@ -831,6 +927,7 @@ function ensure(id: string, options: BrowserViewOptions): View {
       safeAreaActive: false,
       devToolsOpen: false,
     },
+    lastShellUrl: "",
     listeners: new Set(),
     observer: null,
     mounted: false,
@@ -958,7 +1055,11 @@ export function navigateBrowser(
     applyVisibility(v);
     return url;
   }
-  patch(v, { url, loading: true, error: null, nested: null });
+  // `url` optimistically *and* `pending`: the two answer different questions and
+  // both are needed. `url` is what the rest of the pane reasons about (and, under
+  // the iframe backend, the only URL there will ever be); `pending` is what the
+  // address bar shows until this load resolves one way or the other.
+  patch(v, { url, loading: true, pendingUrl: url, error: null, nested: null });
   applyVisibility(v);
   if (desktop) {
     void (async () => {
@@ -993,7 +1094,11 @@ export function reloadBrowser(id: string): void {
   // to clear the flag, so an unconditional `true` left a live spinner and an
   // enabled Stop over the URL launcher — a state a freshly opened blank pane
   // never shows.
-  patch(v, { loading: Boolean(v.state.url), error: null });
+  // `pendingUrl: null` because a reload's destination is the page already here. A
+  // reload fired while another navigation was in flight supersedes it, and
+  // leaving the old destination up would name a page this pane is no longer
+  // going to.
+  patch(v, { loading: Boolean(v.state.url), pendingUrl: null, error: null });
   applyVisibility(v);
   if (desktop) {
     void (async () => {
@@ -1667,6 +1772,11 @@ if (desktop) {
     // A committed page is what makes a reload keep showing the old one rather
     // than a spinner over nothing.
     if (next.url) next.loaded = true;
+    // A commit retires the destination: the page is here, so the bar shows what
+    // arrived rather than what was asked for. Checked before `lastShellUrl` is
+    // advanced, because the comparison *is* the check.
+    if (isCommit(next.url, v.lastShellUrl)) next.pendingUrl = null;
+    if (next.url) v.lastShellUrl = next.url;
     patch(v, next);
     // Visibility follows the state: an error or a first load means the pane has
     // its own screen to show, and the view has to be out of the way for it.

--- a/crates/veld-daemon/ui/src/styles.css
+++ b/crates/veld-daemon/ui/src/styles.css
@@ -3155,7 +3155,12 @@ body[data-theme="light"] .swatch-cell > .swatch-dot {
      `--term-bg` rather than white: this is what shows through before a page paints and
      at the screen's rounded corners, and a white flash in a dark app is the one place
      this feature was visibly not part of it. Same token the terminal uses for "content
-     surface", so the two agree. */
+     surface", so the two agree.
+
+     Deliberately *not* kept in step with the native view's own base background,
+     which switches to white once a page commits — see `desktop/src/baseBackground.js`,
+     which records why matching it here would fix plain pages and break dark-styled
+     ones. The corner seam that leaves is older than that change. */
   background-color: var(--term-bg);
   box-shadow:
     0 0 0 1px var(--border2),

--- a/desktop/src/baseBackground.js
+++ b/desktop/src/baseBackground.js
@@ -1,0 +1,70 @@
+/**
+ * The colour Chromium paints where the guest document paints nothing.
+ *
+ * A file of its own for one expression, for the same reason `safeArea.js` is:
+ * `browserViews.js` cannot be required without an Electron runtime, so nothing
+ * in `npm test` reaches it — and this rule is a two-branch conditional that
+ * reads like an inconsistency somebody would tidy into a single constant. Both
+ * branches are load-bearing, and tidying either one away is a visible bug that
+ * only shows up in a packaged app.
+ *
+ * Two demands pull in opposite directions:
+ *
+ * **Before anything has committed** the view is an empty rectangle, and it should
+ * be the app's own theme surface. Electron's default white is a flash in a dark
+ * app — on every view create and every navigation to a slow page — and that
+ * flash is where an embedded view stops looking embedded.
+ *
+ * **Once a page has committed**, white. A document that declares no background
+ * of its own is *transparent*, so this colour is what the reader actually sees
+ * behind the text — and the UA stylesheet colours that text black, because
+ * Chromium's own base background there is white. Painting a dark theme surface
+ * underneath instead gave a plain no-CSS page black text on a near-black
+ * background: unreadable, and shown by no real browser.
+ *
+ * What this deliberately does **not** do is force a plain page dark to match the
+ * app. That looks better — Chromium's auto-dark, or injecting
+ * `color-scheme: light dark` — but it means the pane rendering something the
+ * developer's real browser does not, which is the one thing a preview pane must
+ * not do. The choice was put to the maintainer as exactly that trade and this is
+ * the answer: be faithful.
+ *
+ * Two residues, stated so the next reader does not treat either as a bug.
+ *
+ * **One paint.** A page slow to *render* — committed, not yet painted — now
+ * flashes white in a dark app, where before it flashed nothing. That window is
+ * one paint, against the whole of a load before.
+ *
+ * **The emulated screen's corners, permanently.** `setBorderRadius` clips the
+ * native view to a rounded rect, and what shows in the corners it clips away is
+ * the DOM element behind it — `.browser-device-frame`, painted `--term-bg` in
+ * `styles.css`. So on a dark theme a committed plain page is now light with dark
+ * corner notches, where before both sides were the surface and the seam was
+ * invisible.
+ *
+ * That seam is **not new**, and this is why it is documented rather than chased:
+ * any page whose own background is not the theme surface already had it — a
+ * white-styled page has shown dark corners on a dark theme for as long as device
+ * emulation has existed. This change only moves *plain* pages from one side of
+ * it to the other. Making the frame white to match would fix them and break
+ * every dark-styled page, which currently matches; the only real fix is sampling
+ * the committed page's own background, which is a different feature. Do not
+ * "fix" this by coupling the frame's colour to the commit signal.
+ *
+ * The "has committed" fact is `browserViews.js`'s `entry.frameReady`, read
+ * directly rather than renamed here: it is the same flag device emulation gates
+ * on (rule 2 in that file's header — `enableDeviceEmulation` on a view with no
+ * frame segfaults the app), reused rather than restated, and reset by
+ * `render-process-gone`, correctly, since a dead renderer is an empty rectangle
+ * again. Both features want exactly "has a main frame ever committed since the
+ * last renderer death", so the sharing is deliberate; a future change to that
+ * flag's meaning has to answer to both.
+ *
+ * @param {{surface: string, frameReady: boolean}} entry
+ * @returns {string} a CSS hex colour
+ */
+function baseBackground(entry) {
+  return entry.frameReady ? "#ffffff" : entry.surface;
+}
+
+module.exports = { baseBackground };

--- a/desktop/src/baseBackground.test.js
+++ b/desktop/src/baseBackground.test.js
@@ -1,0 +1,39 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { baseBackground } = require("./baseBackground.js");
+
+const DARK = "#0d0d0f";
+
+test("baseBackground paints the app's surface until a page has committed", () => {
+  // The no-flash rule this file has always had: an empty view is an empty
+  // rectangle, and Electron's default white is a flash in a dark app.
+  assert.equal(baseBackground({ surface: DARK, frameReady: false }), DARK);
+});
+
+test("baseBackground paints white once a page has committed", () => {
+  // Not the surface, and this is the whole point of the two branches: a document
+  // that declares no background is transparent, so this colour is what shows
+  // behind the text — and the UA stylesheet makes that text black. The surface
+  // here gave a plain no-CSS page black-on-near-black.
+  assert.equal(baseBackground({ surface: DARK, frameReady: true }), "#ffffff");
+});
+
+test("baseBackground answers on the flag alone, for one unchanging surface", () => {
+  // The two branches above with everything else held still, which is what makes
+  // them branches and not two readings of `surface`. A regression that dropped
+  // `frameReady` and returned `surface` unconditionally passes each test above in
+  // isolation; it cannot pass this one.
+  const light = baseBackground({ surface: DARK, frameReady: true });
+  const dark = baseBackground({ surface: DARK, frameReady: false });
+  assert.notEqual(light, dark);
+});
+
+test("baseBackground is why a light app never showed the bug", () => {
+  // Recorded because it is the first thing a reader wonders. In a light app the
+  // surface *is* white, so both branches agree and the unreadable-text bug was
+  // invisible — it only ever reproduced on a dark theme. Nothing here changes
+  // for a light app, which is the blast radius of this whole change.
+  assert.equal(baseBackground({ surface: "#ffffff", frameReady: true }), "#ffffff");
+  assert.equal(baseBackground({ surface: "#ffffff", frameReady: false }), "#ffffff");
+});

--- a/desktop/src/browserViews.js
+++ b/desktop/src/browserViews.js
@@ -54,6 +54,7 @@ const {
 const { cssBoxToDip, emulationScale, zoomFactor } = require("./windowState");
 // The one pure rule in the safe-area applier, in its own module for the same
 // reason: nothing here can be unit-tested, and that rule can.
+const { baseBackground } = require("./baseBackground");
 const { safeAreaPayload } = require("./safeArea");
 // The right-click menu's item set, likewise pure and tested — this file keeps
 // only the mapping from an item id to the call that performs it.
@@ -208,6 +209,20 @@ function send(window, channel, payload) {
 
 function pushState(window, viewId, entry) {
   send(window, "veld:browser:state", stateOf(viewId, entry));
+}
+
+/**
+ * Force this view's base background back in line with whether a page has
+ * committed in it.
+ *
+ * The decision itself is [`baseBackground`] in `baseBackground.js`, pulled out
+ * because it is the only pure part of this and this file needs an Electron
+ * runtime to require at all. Called at exactly the three moments its answer can
+ * change: the first commit, a renderer death, and a theme switch.
+ */
+function applyBaseBackground(entry) {
+  if (entry.view.webContents.isDestroyed()) return;
+  entry.view.setBackgroundColor(baseBackground(entry));
 }
 
 // ---------------------------------------------------------------------------
@@ -1423,8 +1438,10 @@ function attachListeners(window, viewId, entry) {
     applyMetrics(entry);
     applyZoom(entry);
     void applyTouch(window, viewId, entry);
-    // The scale is part of what the pane renders, and on the first navigation it
-    // has just gone from "asked for" to "in force".
+    // Both gated on the *first* commit, because that is the only navigation at
+    // which either answer changes: the base colour is a function of `frameReady`
+    // alone, and the scale has just gone from "asked for" to "in force".
+    if (first) applyBaseBackground(entry);
     if (first) push();
   };
   // **`did-navigate` only**, deliberately. A `did-fail-load` listener used to open
@@ -1445,6 +1462,9 @@ function attachListeners(window, viewId, entry) {
   wc.on("render-process-gone", () => {
     entry.frameReady = false;
     entry.emulated = false;
+    // An empty rectangle again, so back to the theme surface — see
+    // [`baseBackground`]. After `frameReady`, not before: it reads the flag.
+    applyBaseBackground(entry);
     // **Not unconditional.** "A new renderer starts with no overrides" is only true
     // when no debugger is attached to carry one across — measured otherwise: with
     // the session attached, a forced crash produced a new renderer process that
@@ -2163,7 +2183,11 @@ function registerBrowserViewIpc(resolveWindow, opts = {}) {
     // and at the screen's rounded corners, and a white flash in a dark app is exactly
     // where an embedded view stops looking embedded. Falls back to white, which is what
     // every browser does with no better answer.
-    view.setBackgroundColor(safeColor(args?.background) ?? "#ffffff");
+    //
+    // Only until a page **commits**, though — see [`baseBackground`]. Nothing has
+    // committed in a view this new, so it starts on the surface.
+    const surface = safeColor(args?.background) ?? "#ffffff";
+    view.setBackgroundColor(surface);
     // Created **visible**, and only hidden when the renderer says so. A hidden
     // WebContents is background-throttled by Chromium, and a view created hidden
     // and loaded in the same tick sometimes never rendered its first page — blank
@@ -2187,6 +2211,10 @@ function registerBrowserViewIpc(resolveWindow, opts = {}) {
       // The session's own UA, captured before anything overrides it — what
       // "no emulated device" has to restore.
       defaultUserAgent: view.webContents.getUserAgent(),
+      // The app's theme surface, kept rather than applied and forgotten: a view
+      // whose renderer dies goes back to it (see [`baseBackground`]), and a theme
+      // switch has to be able to update it without a navigation.
+      surface,
       scale: 1,
       radius: 0,
       // The /ide page's own zoom factor, which converts everything the renderer
@@ -2397,7 +2425,13 @@ function registerBrowserViewIpc(resolveWindow, opts = {}) {
     const color = safeColor(args?.background);
     if (!color) return;
     for (const entry of byWindow.get(window.id)?.values() ?? []) {
-      if (!entry.view.webContents.isDestroyed()) entry.view.setBackgroundColor(color);
+      if (entry.view.webContents.isDestroyed()) continue;
+      // Recorded as well as applied. `baseBackground` re-reads it — a view that
+      // has not committed yet is *on* this colour, and one whose renderer later
+      // dies comes back to it — so a view that only had the new colour pushed at
+      // it would revert to the pre-switch surface the next time either happened.
+      entry.surface = color;
+      applyBaseBackground(entry);
     }
   });
 


### PR DESCRIPTION
Two independent bugs in the IDE's browser pane. Both were found by driving the
pane, not by reading it, and the maintainer hand-verified both fixes on a running
stack before this PR was opened.

## 1 — The address bar showed the URL you were leaving

Paste an address, press Enter, and the bar snapped back to the *old* page until
the new one arrived. Pressing Stop had nothing to undo, because the bar was
already showing the page Stop would return you to.

### Root cause

The evidence pass (`/ship` step 0.1) confirmed the report as written and found
the mechanism:

- `navigateBrowser` (`crates/veld-daemon/ui/src/panes/browserHost.ts`) writes the
  target into `state.url` optimistically — correct, and the iframe backend has
  nothing else.
- The Electron shell's `stateOf` (`desktop/src/browserViews.js:183`) reads
  `url: wc.getURL()`, which returns the last **committed** URL for the whole of a
  pending load.
- `attachListeners` pushes that on `did-start-loading`, and the renderer's
  `onState` assigns it over the optimistic write.

So every navigation reported the old URL back to the pane one event after the new
one was set.

### Fix

A `pendingUrl` field on `BrowserState` — the destination, distinct from what has
committed:

- **Set only by `navigateBrowser`**, which is the address bar and the place
  picker. A link clicked *inside* the page does not come through there, so it
  does not pre-announce its target — matching Chrome, which only shows a pending
  URL for navigations the user typed or picked.
- **Read only by `addressFor`.** Everything else — `paneCovers`, the permission
  prompt's origin, the watched-file path, the layout's stored URL — keeps
  answering for the page on screen. That containment is the point; a destination
  that may never arrive must not reach anything that acts on it.
- **Retired at both ends of its life**, which are two different questions:
  `settlePending` when the load *stops* (arrived, stopped, failed — enforced as
  an invariant inside `patch`, so no future call site can forget it), and
  `isCommit` when the destination *arrives*.

`addressFor` also keeps a **failed** URL rather than falling back to the old
page: a failed load never commits, so the bar used to name the page you were on
while the error screen right below it named the one that failed. Chrome keeps the
failed URL for the same reason — it is the one you want to edit and retry.

## 2 — A plain no-CSS page was unreadable on a dark theme

Raised mid-review as a side question and folded in at the maintainer's explicit
request (they were offered a separate PR and chose to fold it).

A `WebContentsView`'s base background was set to the app's theme surface, so an
empty view would not flash white in a dark app. But **a document that declares
no background of its own is transparent**, so that colour is what shows behind
the text — and the UA stylesheet colours that text black. A bare HTML page
rendered black on near-black. Confirmed by screenshot before any code was
written; the premise was not assumed.

### The fork, and who decided it

Two defensible answers, and the choice sets a precedent for what a preview pane
owes the developer, so it went to the maintainer rather than being picked here:

- **Faithful** — make the pane match Chrome, which shows a bare page black on
  white on a dark OS too.
- **Comfortable** — force plain pages dark (Chromium auto-dark, or an injected
  `color-scheme: light dark`). Reads better, but the pane then renders something
  the developer's real browser does not.

**The maintainer chose faithful.** `desktop/src/baseBackground.js` records the
rejected option and why, so it is not re-litigated from scratch.

### Fix

The base colour becomes a function of whether a page has committed: the theme
surface before (so the no-flash fix stands), white after. `entry.frameReady` is
reused as the "has ever committed" fact rather than a second flag being
introduced — it is the same signal device emulation already gates on, and
`render-process-gone` resets it correctly, since a dead renderer is an empty
rectangle again.

The decision lives in its own module with its own test, which is this repo's
existing pattern for the pure part of a shell feature (`desktop/src/safeArea.js`
says why: `browserViews.js` cannot be required without an Electron runtime, so
nothing in `npm test` reaches it).

### Two costs, both deliberate and both written into the source

- **One paint.** A page slow to *render* — committed, not yet painted — now
  flashes white in a dark app, where it flashed nothing before. One paint against
  the whole of a load.
- **The emulated screen's corners, permanently.** `setBorderRadius` clips the
  native view; the corners it clips away show `.browser-device-frame`'s
  `--term-bg`. So a committed plain page is now light with dark corner notches.
  **This seam is not new** — any page whose background is not the theme surface
  has had it for as long as device emulation has existed, and a white-styled page
  showed it already. This change only moves *plain* pages from one side of it to
  the other. Matching the frame to the commit signal would fix them and break
  every dark-styled page; the only real fix is sampling the committed page's own
  background, which is a different feature. `baseBackground.js` says so, so the
  next reader does not "fix" it into a regression.

## Test evidence

- `just test-ui` — **1275 passed** (46 files), exit 0. Was 1269; 6 new.
- `just lint-ui` — exit 0 (`tsc --noEmit` clean; biome's ~8269 warnings are
  pre-existing repo-wide, none added).
- `desktop && npm test` — **179 passed**, exit 0. Was 175; 4 new.
- `desktop && npm run lint` — exit 0.
- No Rust in the diff, so clippy and `cargo fmt` cannot regress — deliberately
  not run rather than skipped by omission.
- **Driven on a running stack** (`just dev-daemon` + `just dev-desktop-embedded`)
  by the maintainer, who confirmed both fixes and supplied the screenshots that
  proved bug 2's premise. Two bare HTML pages were written for that (one plain,
  one with `<meta name="color-scheme">`) and kept **out of git** via
  `.git/info/exclude` — they are scratch, not fixtures.

## Review

Autonomous multi-angle loop (`docs/agentic-review.md`) at **light** depth, both
rounds used, 6 of 6 spawns. Ledger kept at `notes/review/ledger.md` (gitignored).

**8 findings on the address-bar half, 3 on the background half. All verified
before fixing; 9 fixed, 2 deferred.**

The strongest signal of the run: **three independent angles plus the pre-round
read landed on the same line** — commit detection compared the shell-reported URL
against the *typed* one, so any redirect (bare domain to `www`, an `http`→`https`
upgrade, an auth bounce) never matched and the bar kept the pre-redirect address
for the whole resource-loading tail. That is exactly the class of navigation this
PR exists to get right. `isCommit` now compares against the last URL the *shell*
reported, which moves only on a real commit.

Worth recording: one angle's **suggested fix for that finding was wrong** and was
not applied. `if (next.url) next.pending = null` would clear on the first event
of every navigation, because `did-start-loading` reports the old URL and it is
non-empty — reinstating the original bug. The finding was right and the remedy
was not, which is why §8.3's verify-before-fixing is not optional under autonomy.

Also fixed: a `pending` field name that collided with two others in the same file
(now `pendingUrl`); a test docstring that overclaimed the field's lifetime; a
test whose comment claimed to rule out a coincidence its assertion could not; and
a docstring cross-referencing an identifier that did not exist.

### Deferred, with reasons

- **Back/Forward do not pre-announce their destination.** Real gap, same class as
  the bug fixed here. The renderer has no history list — only the shell knows the
  target — so closing it means a new field on the wire, which is a larger change
  than the reported bug. Degrades to today's behaviour, and a history navigation
  is usually instant.
- **A navigation that turns into a download might not report `loading: false`.**
  Raised as explicitly *unmeasured*, and this file's house standard is to measure
  Electron behaviour rather than assume it. Worst case is a stale address bar that
  the next navigation clears; nothing is at risk. Not measured here because it
  needs the packaged app.

## Docs

Checklist walked. No config fields, CLI flags, subcommands or keyboard shortcuts,
so `README.md`, `docs/configuration.md`, both skills, both schemas and
`docs/migrating-to-v3.md` are all N/A. Not a customization feature (no provider
API, schema or auth), so no `docs/extensions-vision.md` row.

**Website: no change.** Both halves are bug fixes to behaviour the site never
described, and no capability is added or renamed.

**Promotion: no.** The checklist forbids promoting a bug fix, and these are two.

## Reviewer scope

The interesting lines are `isCommit` and `settlePending` in `browserHost.ts` (the
whole of `pendingUrl`'s lifetime) and `baseBackground.js` (the whole of the
second fix). Everything else is plumbing and comments.

---
🚢 Carried by the ship workflow (`docs/ship.md`).

| Setting | This run |
|---|---|
| Review depth | Light — 6 spawns, 2 rounds (both used, cap reached) |
| Merge policy | Bypass-merge on green CI |
| Hands-on checkpoints | One, after review — passed, both fixes confirmed on a running stack |
| Docs & tests | User-visible behaviour, but no new surface — AGENTS.md checklist exempt |
| Promotion | No |

## Fixed on the way: pushing this branch was impossible

Worth recording, because it will hit the next person and it looks like a flake.

`git push` failed with **exit 141 (SIGPIPE)** and `Connection to github.com
closed by remote host` — *after* the pre-push hook had passed. The order git
uses is the cause: it opens the SSH connection **first** (it needs the remote
ref list to feed the hook), *then* runs `pre-push`. This repo's `pre-push` runs
the full `lint` — two clippy passes, `cargo fmt`, three typecheck/biome
surfaces — which took **857 s**. GitHub drops an idle SSH connection long before
that, so git finished the hook and wrote into a dead socket.

It reproduces on every push whose hook runs long, and the first attempt reported
**exit 0** with the branch never leaving the machine, which is the part that
makes it hard to spot.

Worked around for this push with `GIT_SSH_COMMAND="ssh -o
ServerAliveInterval=20 -o ServerAliveCountMax=60"`, which holds the connection
open through the hook and pushed first time.

**Not fixed here, deliberately**, and flagged as a follow-up rather than
smuggled into a browser-pane PR:

- The one-line mitigation is `git config --local core.sshCommand "ssh -o
  ServerAliveInterval=20 …"`, but that is a developer's own git config, not the
  repo's, so it is the maintainer's call — not something a PR should set.
- The real question is whether `pre-push` should run the whole of `lint` at all
  when CI re-runs every part of it. That is a workflow decision with its own
  trade-offs and belongs in its own change.
